### PR TITLE
fix: buffer limit, config lock safety, merge depth guard, S3 backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "serde",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "axum",
  "md-5",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2412,11 +2412,11 @@ dependencies = [
 
 [[package]]
 name = "rs-ts-normalize"
-version = "0.3.2"
+version = "0.3.4"
 
 [[package]]
 name = "rs-youtube"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-api/src/handlers.rs
+++ b/crates/rs-api/src/handlers.rs
@@ -279,8 +279,14 @@ pub async fn patch_config(
         tracing::info!("Config saved to {}", path.display());
     }
 
-    if let Ok(mut live) = state.config_live.write() {
-        *live = std::sync::Arc::new(new_config.clone());
+    match state.config_live.write() {
+        Ok(mut live) => {
+            *live = std::sync::Arc::new(new_config.clone());
+        }
+        Err(e) => {
+            error!("Config lock poisoned, runtime config diverges from saved file: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
     }
 
     new_config.s3.access_key_id = REDACTED.to_string();
@@ -291,13 +297,27 @@ pub async fn patch_config(
     Ok(Json(new_config))
 }
 
-/// Recursively merge a JSON patch into a base object.
+/// Maximum recursion depth for JSON merge to prevent stack overflow from malicious input.
+const MAX_MERGE_DEPTH: usize = 10;
+
+/// Recursively merge a JSON patch into a base object with depth limit.
 fn merge_json(base: serde_json::Value, patch: serde_json::Value) -> serde_json::Value {
+    merge_json_inner(base, patch, 0)
+}
+
+fn merge_json_inner(
+    base: serde_json::Value,
+    patch: serde_json::Value,
+    depth: usize,
+) -> serde_json::Value {
+    if depth >= MAX_MERGE_DEPTH {
+        return patch;
+    }
     match (base, patch) {
         (serde_json::Value::Object(mut base_map), serde_json::Value::Object(patch_map)) => {
             for (key, value) in patch_map {
                 let existing = base_map.remove(&key).unwrap_or(serde_json::Value::Null);
-                base_map.insert(key, merge_json(existing, value));
+                base_map.insert(key, merge_json_inner(existing, value, depth + 1));
             }
             serde_json::Value::Object(base_map)
         }
@@ -850,3 +870,58 @@ pub async fn list_delivery_instances(
 }
 
 // Stream control handlers (start_stream, stop_stream, update_event) are in stream_handlers.rs
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_json_simple_override() {
+        let base = serde_json::json!({"a": 1, "b": 2});
+        let patch = serde_json::json!({"b": 3});
+        let result = merge_json(base, patch);
+        assert_eq!(result, serde_json::json!({"a": 1, "b": 3}));
+    }
+
+    #[test]
+    fn merge_json_nested() {
+        let base = serde_json::json!({"s3": {"bucket": "old", "region": "us"}});
+        let patch = serde_json::json!({"s3": {"bucket": "new"}});
+        let result = merge_json(base, patch);
+        assert_eq!(
+            result,
+            serde_json::json!({"s3": {"bucket": "new", "region": "us"}})
+        );
+    }
+
+    #[test]
+    fn merge_json_depth_limit_stops_recursion() {
+        // Build a deeply nested JSON object exceeding MAX_MERGE_DEPTH
+        let mut base = serde_json::json!("base_leaf");
+        let mut patch = serde_json::json!("patch_leaf");
+        for _ in 0..(MAX_MERGE_DEPTH + 5) {
+            base = serde_json::json!({"nested": base});
+            patch = serde_json::json!({"nested": patch});
+        }
+        // Should not stack overflow — at depth limit, patch replaces base wholesale
+        let result = merge_json(base, patch.clone());
+        // The result should be valid JSON (no stack overflow)
+        assert!(result.is_object());
+    }
+
+    #[test]
+    fn merge_json_adds_new_keys() {
+        let base = serde_json::json!({"a": 1});
+        let patch = serde_json::json!({"b": 2});
+        let result = merge_json(base, patch);
+        assert_eq!(result, serde_json::json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn merge_json_scalar_replaces_object() {
+        let base = serde_json::json!({"a": {"nested": 1}});
+        let patch = serde_json::json!({"a": "flat"});
+        let result = merge_json(base, patch);
+        assert_eq!(result, serde_json::json!({"a": "flat"}));
+    }
+}

--- a/crates/rs-endpoint/src/uploader.rs
+++ b/crates/rs-endpoint/src/uploader.rs
@@ -14,8 +14,10 @@ use crate::s3::S3Client;
 /// Maximum retry attempts per batch cycle for transient S3 failures.
 /// Failed chunks are automatically retried in subsequent batch cycles.
 const MAX_RETRIES: u32 = 10;
-/// Delay between retries (flat 3-second interval per spec).
-const RETRY_DELAY: Duration = Duration::from_secs(3);
+/// Base delay for exponential backoff between retries.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+/// Maximum delay cap for exponential backoff.
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
 
 /// Watches for unsent chunks and uploads them to S3.
 /// No manager notification needed — delivery VPS probes S3 directly.
@@ -134,11 +136,14 @@ impl ChunkUploader {
                         }
                         Err(e) => {
                             if attempt + 1 < MAX_RETRIES {
+                                let delay = RETRY_BASE_DELAY
+                                    .saturating_mul(1 << attempt.min(5))
+                                    .min(RETRY_MAX_DELAY);
                                 warn!(
-                                    "S3 upload failed for chunk {} (attempt {}/{}): {e}, retrying in {}s",
-                                    chunk.id, attempt + 1, MAX_RETRIES, RETRY_DELAY.as_secs()
+                                    "S3 upload failed for chunk {} (attempt {}/{}): {e}, retrying in {:.0}s",
+                                    chunk.id, attempt + 1, MAX_RETRIES, delay.as_secs_f64()
                                 );
-                                tokio::time::sleep(RETRY_DELAY).await;
+                                tokio::time::sleep(delay).await;
                             } else {
                                 warn!(
                                     "S3 upload failed for chunk {} after {MAX_RETRIES} attempts: {e}",
@@ -259,6 +264,18 @@ mod tests {
     #[test]
     fn retry_constants_are_valid() {
         assert!(MAX_RETRIES > 0);
-        assert!(RETRY_DELAY.as_secs() > 0);
+        assert!(RETRY_BASE_DELAY.as_secs() > 0);
+        assert!(RETRY_MAX_DELAY >= RETRY_BASE_DELAY);
+    }
+
+    #[test]
+    fn exponential_backoff_delays_are_bounded() {
+        for attempt in 0..MAX_RETRIES {
+            let delay = RETRY_BASE_DELAY
+                .saturating_mul(1 << attempt.min(5))
+                .min(RETRY_MAX_DELAY);
+            assert!(delay >= RETRY_BASE_DELAY);
+            assert!(delay <= RETRY_MAX_DELAY);
+        }
     }
 }

--- a/crates/rs-inpoint/src/chunker.rs
+++ b/crates/rs-inpoint/src/chunker.rs
@@ -4,6 +4,10 @@ use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::{Mutex, broadcast};
 use tracing::info;
 
+/// Maximum buffer size before a forced flush (50 MB).
+/// Prevents unbounded memory growth if chunk duration is long or streaming stalls.
+const MAX_BUFFER_SIZE: usize = 50 * 1024 * 1024;
+
 /// Receives pre-muxed MPEG-TS data and produces time-based chunk files.
 ///
 /// Chunks are accumulated for `chunk_duration` and then flushed to disk
@@ -95,13 +99,22 @@ impl ChunkSink {
             // Buffer the pre-muxed MPEG-TS data directly
             inner.buffer.extend_from_slice(data);
 
-            // Check if chunk duration has elapsed
-            if let Some(start) = inner.chunk_start {
-                if start.elapsed() >= inner.chunk_duration {
-                    Self::extract_chunk(&mut inner)
-                } else {
-                    None
-                }
+            // Force-flush if buffer exceeds max size to prevent memory exhaustion
+            let duration_elapsed = inner
+                .chunk_start
+                .map(|s| s.elapsed() >= inner.chunk_duration)
+                .unwrap_or(false);
+            let buffer_exceeded = inner.buffer.len() >= MAX_BUFFER_SIZE;
+
+            if buffer_exceeded {
+                tracing::warn!(
+                    "Chunk buffer exceeded {}MB limit, force-flushing",
+                    MAX_BUFFER_SIZE / (1024 * 1024)
+                );
+            }
+
+            if duration_elapsed || buffer_exceeded {
+                Self::extract_chunk(&mut inner)
             } else {
                 None
             }
@@ -327,5 +340,13 @@ mod tests {
         let file_data = std::fs::read(&chunk.path).unwrap();
         assert_eq!(file_data[0], 0x47);
         assert_eq!(file_data[188], 0x47);
+    }
+
+    #[test]
+    fn max_buffer_size_constant_is_reasonable() {
+        // 50 MB — large enough for normal chunks, small enough to prevent OOM
+        assert_eq!(MAX_BUFFER_SIZE, 50 * 1024 * 1024);
+        assert!(MAX_BUFFER_SIZE > 1024 * 1024); // at least 1MB
+        assert!(MAX_BUFFER_SIZE <= 100 * 1024 * 1024); // at most 100MB
     }
 }

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 

--- a/leptos-ui/src/ws.rs
+++ b/leptos-ui/src/ws.rs
@@ -167,10 +167,8 @@ fn dispatch_event(store: DashboardStore, event: WsEvent) {
             ..
         } => {
             store.inpoint_connected.set(rtmp_connected);
-            // Update chunk stats with live received data
             store.chunk_stats.update(|stats| {
-                // received_bytes comes from the total on the event
-                let _ = received_bytes;
+                stats.total_bytes = received_bytes as i64;
                 stats.total_chunks = chunk_count as i64;
             });
         }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -306,7 +306,8 @@ fn derive_tray_state(status: &TrayStatus, inpoint_connected: bool) -> TrayState 
                     TrayState::Receiving
                 }
             } else {
-                TrayState::Ready
+                // RTMP disconnected while event expects receiving — show idle, not ready
+                TrayState::Idle
             }
         }
         "Paused" => TrayState::Ready,
@@ -477,12 +478,12 @@ mod tests {
     }
 
     #[test]
-    fn derive_state_receiving_not_connected_is_ready() {
+    fn derive_state_receiving_not_connected_is_idle() {
         let status = TrayStatus {
             inpoint: "Receiving".to_string(),
             ..TrayStatus::default()
         };
-        assert_eq!(derive_tray_state(&status, false), TrayState::Ready);
+        assert_eq!(derive_tray_state(&status, false), TrayState::Idle);
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Add 50MB max buffer size to `ChunkSink` to prevent memory exhaustion on long-running streams (force-flush when exceeded)
- Return HTTP 500 when config `RwLock` is poisoned instead of silently diverging runtime config from saved file
- Use `received_bytes` from WebSocket `InpointStatus` to update dashboard `total_bytes` (was explicitly ignored as dead code)
- Add max recursion depth (10) to `merge_json` to prevent stack overflow from deeply nested API payloads
- Replace flat 3s S3 upload retry with exponential backoff (1s base, 30s cap)
- Fix tray state machine: Receiving + RTMP disconnected maps to `Idle` instead of `Ready`

## Findings addressed
| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | HIGH | Unbounded chunk buffer growth | 50MB `MAX_BUFFER_SIZE` with force-flush |
| 2 | HIGH | Silent config write-lock failure | Return 500 on poisoned lock |
| 4 | HIGH | `received_bytes` dead code | Wire to `stats.total_bytes` |
| 5 | HIGH | `merge_json` no recursion limit | `MAX_MERGE_DEPTH = 10` |
| 7 | MEDIUM | Flat S3 retry strategy | Exponential backoff 1s→30s |
| 8 | MEDIUM | Tray state inconsistency | Receiving+disconnected → Idle |

## Test plan
- [ ] CI passes all workspace tests including new `merge_json` tests
- [ ] CI passes `test-integrity` job (no ignored tests)
- [ ] E2E tests pass on stream.lan deployment
- [ ] Verify exponential backoff constants are bounded in new test
- [ ] Verify buffer size constant test validates 50MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)