### PR TITLE
fix(ci): scope Hetzner pre-flight cleanup by client_uuid (#137) + preserve extra_ssh_key_names (#132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,20 @@ jobs:
             exit 1
           fi
           echo "OK: No trivial assertions found."
+      - name: Scan for unscoped Hetzner label_selector
+        run: |
+          # Assemble the regex in pieces so this step's own source does NOT
+          # match (otherwise the check would fail on itself). The real usages
+          # in workflow code always have the full literal on one line.
+          PREFIX='label_selector=app='
+          SUFFIX='restreamer(?!,client_uuid=)'
+          BAD=$(grep -Prn "${PREFIX}${SUFFIX}" .github/workflows/ || true)
+          if [ -n "$BAD" ]; then
+            echo "ERROR: Hetzner label_selector must include ,client_uuid=<uuid> scope to protect other installations:"
+            echo "$BAD"
+            exit 1
+          fi
+          echo "OK: All Hetzner label_selector usages are client_uuid-scoped."
       - name: Verify zero ignored tests in cargo test output
         run: |
           # Run tests and capture output
@@ -1587,20 +1601,21 @@ jobs:
           if (-not $env:HETZNER_API_TOKEN) {
             throw "HETZNER_API_TOKEN secret not set"
           }
-          # Write Hetzner token directly into config file and restart service
+          # Merge Hetzner secrets into existing hetzner config section.
+          # Preserves operator-set fields like `extra_ssh_key_names` that
+          # aren't secret-managed here (was getting wiped on every deploy).
           $configPath = "C:\ProgramData\Restreamer\config.json"
           $config = Get-Content $configPath -Raw | ConvertFrom-Json
           if (-not $config.hetzner) {
-            $config | Add-Member -NotePropertyName "hetzner" -NotePropertyValue @{}
+            $config | Add-Member -NotePropertyName "hetzner" -NotePropertyValue ([pscustomobject]@{})
           }
-          $config.hetzner = @{
-            api_token = $env:HETZNER_API_TOKEN
-            location = "nbg1"
-            default_server_type = "cpx22"
-            snapshot_label = "rs-delivery"
-            ssh_key_name = "restreamer-ci"
-          }
-          $json = $config | ConvertTo-Json -Depth 5
+          # Overwrite CI-owned fields only — do not touch the rest.
+          $config.hetzner | Add-Member -NotePropertyName "api_token" -NotePropertyValue $env:HETZNER_API_TOKEN -Force
+          $config.hetzner | Add-Member -NotePropertyName "location" -NotePropertyValue "nbg1" -Force
+          $config.hetzner | Add-Member -NotePropertyName "default_server_type" -NotePropertyValue "cpx22" -Force
+          $config.hetzner | Add-Member -NotePropertyName "snapshot_label" -NotePropertyValue "rs-delivery" -Force
+          $config.hetzner | Add-Member -NotePropertyName "ssh_key_name" -NotePropertyValue "restreamer-ci" -Force
+          $json = $config | ConvertTo-Json -Depth 10
           [System.IO.File]::WriteAllText($configPath, $json)
           Write-Host "Config file updated with Hetzner settings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,21 @@ jobs:
             exit 1
           fi
           echo "OK: All Hetzner label_selector usages are client_uuid-scoped."
+      - name: Scan for destructive Hetzner config overwrite
+        run: |
+          # CI must use Add-Member -Force per-field to preserve operator-set
+          # fields such as extra_ssh_key_names (fixes #132). The destructive
+          # pattern is a whole-object assignment opening a multi-line hashtable.
+          # Assembled from PREFIX+SUFFIX so this step's own source does not match.
+          PREFIX='\$config\.hetzner\s*='
+          SUFFIX='\s*@\{\s*$'
+          BAD=$(grep -Prn "${PREFIX}${SUFFIX}" .github/workflows/ || true)
+          if [ -n "$BAD" ]; then
+            echo "ERROR: Hetzner config must use Add-Member -Force per-field to preserve operator fields (e.g. extra_ssh_key_names). Full-overwrite detected:"
+            echo "$BAD"
+            exit 1
+          fi
+          echo "OK: No destructive Hetzner config overwrites found."
       - name: Verify zero ignored tests in cargo test output
         run: |
           # Run tests and capture output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2334,17 +2334,32 @@ jobs:
             Write-Host "Could not check delivery instances via API: $_"
           }
 
-          # Step 2: Clean up orphaned Hetzner VPS directly (survives Restreamer restarts)
-          # This catches VPS instances left behind by cancelled CI runs.
+          # Step 2: Clean up orphaned Hetzner VPS directly (scoped to this installation).
+          # Filters by client_uuid so a CI run on one Restreamer install can never
+          # delete another install's VPS sharing the same Hetzner account (fixes #137).
           if ($env:HETZNER_API_TOKEN) {
-            Write-Host "Checking Hetzner API for orphaned rs-delivery VPS instances..."
+            $clientUuid = $null
+            try {
+              $cfg = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/config" -TimeoutSec 10
+              $clientUuid = $cfg.client_uuid
+            } catch {
+              Write-Host "  Could not read local client_uuid: $_"
+            }
+
+            if (-not $clientUuid) {
+              Write-Host "ERROR: client_uuid not available - refusing to run Hetzner cleanup (fail-closed to protect other installations)"
+              exit 1
+            }
+
+            Write-Host "Checking Hetzner API for orphaned rs-delivery VPS for client_uuid=$clientUuid ..."
             try {
               $headers = @{ Authorization = "Bearer $($env:HETZNER_API_TOKEN)" }
-              $resp = Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers?label_selector=app=restreamer" `
+              $selector = "app=restreamer,client_uuid=$clientUuid"
+              $resp = Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers?label_selector=$selector" `
                 -Headers $headers -TimeoutSec 15
               if ($resp.servers -and $resp.servers.Count -gt 0) {
                 foreach ($srv in $resp.servers) {
-                  Write-Host "  Deleting orphaned Hetzner VPS: id=$($srv.id) name=$($srv.name) status=$($srv.status) ip=$($srv.public_net.ipv4.ip)"
+                  Write-Host "  Deleting orphaned VPS (this installation): id=$($srv.id) name=$($srv.name) status=$($srv.status) ip=$($srv.public_net.ipv4.ip)"
                   try {
                     Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers/$($srv.id)" `
                       -Method DELETE -Headers $headers -TimeoutSec 15
@@ -2355,7 +2370,7 @@ jobs:
                 }
                 Start-Sleep -Seconds 3
               } else {
-                Write-Host "  No orphaned Hetzner VPS found"
+                Write-Host "  No orphaned VPS found for this installation"
               }
             } catch {
               Write-Host "  Hetzner API check failed: $_"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.3.66"
+version = "0.3.67"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/docs/superpowers/plans/2026-04-22-ci-hetzner-cleanup-scope.md
+++ b/docs/superpowers/plans/2026-04-22-ci-hetzner-cleanup-scope.md
@@ -1,0 +1,443 @@
+# CI Hetzner Cleanup Scope — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scope the CI pre-flight Hetzner VPS cleanup to the current installation's `client_uuid` label, preventing cross-installation deletion (fixes #137).
+
+**Architecture:** One CI workflow edit + one regression-test assertion + one version bump. No Rust source changes. The VPS already carries a `client_uuid=<uuid>` Hetzner label at creation (`crates/rs-api/src/delivery.rs:185`), and the local API exposes the value via `GET /api/v1/config`. The fix fetches that value in the pre-flight step and narrows the Hetzner `label_selector` from `app=restreamer` to `app=restreamer,client_uuid=<uuid>`.
+
+**Tech Stack:** GitHub Actions workflow (YAML + PowerShell + bash), Hetzner Cloud API.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-ci-hetzner-cleanup-scope-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` line 24 | Version bump 0.3.66 → 0.3.67 |
+| `src-tauri/Cargo.toml` line 3 | Version bump 0.3.66 → 0.3.67 |
+| `src-tauri/tauri.conf.json` | Version bump 0.3.66 → 0.3.67 |
+| `leptos-ui/Cargo.toml` line 3 | Version bump 0.3.66 → 0.3.67 |
+| `.github/workflows/ci.yml` (test-integrity job, ~line 468) | Add regression-test step |
+| `.github/workflows/ci.yml` (pre-flight step, lines 2323-2349) | Replace with client_uuid-scoped cleanup |
+
+No Rust crates are modified. No tests added in the workspace — the only test is the CI-level regression assertion.
+
+---
+
+### Task 1: Version Bump
+
+**Files:**
+- Modify: `Cargo.toml:24`
+- Modify: `src-tauri/Cargo.toml:3`
+- Modify: `src-tauri/tauri.conf.json`
+- Modify: `leptos-ui/Cargo.toml:3`
+
+Per airuleset `version-bumping.md`, this MUST be the first commit on dev — strictly greater than main (0.3.66) before any other change.
+
+- [ ] **Step 1: Confirm starting version**
+
+```bash
+grep "^version = " Cargo.toml src-tauri/Cargo.toml leptos-ui/Cargo.toml
+grep '"version"' src-tauri/tauri.conf.json
+```
+
+Expected: all four show `0.3.66`.
+
+- [ ] **Step 2: Bump Cargo.toml (workspace)**
+
+Change `Cargo.toml:24` from:
+```
+version = "0.3.66"
+```
+To:
+```
+version = "0.3.67"
+```
+
+- [ ] **Step 3: Bump src-tauri/Cargo.toml**
+
+Change `src-tauri/Cargo.toml:3` from:
+```
+version = "0.3.66"
+```
+To:
+```
+version = "0.3.67"
+```
+
+- [ ] **Step 4: Bump leptos-ui/Cargo.toml**
+
+Change `leptos-ui/Cargo.toml:3` from:
+```
+version = "0.3.66"
+```
+To:
+```
+version = "0.3.67"
+```
+
+- [ ] **Step 5: Bump src-tauri/tauri.conf.json**
+
+Change the `"version"` field from:
+```json
+"version": "0.3.66",
+```
+To:
+```json
+"version": "0.3.67",
+```
+
+- [ ] **Step 6: Verify all four files agree**
+
+```bash
+grep "^version = " Cargo.toml src-tauri/Cargo.toml leptos-ui/Cargo.toml
+grep '"version"' src-tauri/tauri.conf.json
+```
+
+Expected: all four show `0.3.67`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.toml src-tauri/Cargo.toml leptos-ui/Cargo.toml src-tauri/tauri.conf.json
+git commit -m "chore: bump version to 0.3.67"
+```
+
+---
+
+### Task 2: Add Regression Test (RED)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (test-integrity job, after line 468 — after "Scan for assert_eq with trivial values", before "Verify zero ignored tests")
+
+This step asserts that no workflow file uses the broad Hetzner `label_selector=app=restreamer` without a `,client_uuid=` scope. It intentionally FAILS against the current ci.yml (which still has the unscoped version at line 2329) — that failure is the TDD "red" proving the test detects the bug.
+
+- [ ] **Step 1: Find the insertion point**
+
+```bash
+grep -n "Scan for assert_eq with trivial values" .github/workflows/ci.yml
+grep -n "Verify zero ignored tests" .github/workflows/ci.yml
+```
+
+Expected output roughly:
+```
+459:      - name: Scan for assert_eq with trivial values
+469:      - name: Verify zero ignored tests in cargo test output
+```
+
+The new step goes between these two (the "Scan for assert_eq" step ends at line 468 with the closing of its `run:` block).
+
+- [ ] **Step 2: Insert the regression-test step**
+
+Insert the following YAML block into `.github/workflows/ci.yml` between the "Scan for assert_eq with trivial values" step (which ends around line 468) and the "Verify zero ignored tests in cargo test output" step (line 469):
+
+```yaml
+      - name: Scan for unscoped Hetzner label_selector
+        run: |
+          BAD=$(grep -Prn 'label_selector=app=restreamer(?!,client_uuid=)' .github/workflows/ || true)
+          if [ -n "$BAD" ]; then
+            echo "ERROR: Hetzner label_selector must include ,client_uuid=<uuid> scope to protect other installations:"
+            echo "$BAD"
+            exit 1
+          fi
+          echo "OK: All Hetzner label_selector usages are client_uuid-scoped."
+```
+
+Indentation: the step's `- name:` must align with the other steps in the `test-integrity` job (6-space leading indent). Copy the whitespace exactly from the surrounding steps.
+
+- [ ] **Step 3: Locally confirm the grep detects the current (broken) pattern**
+
+```bash
+grep -Prn 'label_selector=app=restreamer(?!,client_uuid=)' .github/workflows/
+```
+
+Expected output — exactly one match on the existing unscoped URL at line 2329:
+```
+.github/workflows/ci.yml:2329:              $resp = Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers?label_selector=app=restreamer" `
+```
+
+If the grep finds zero matches, the regex is wrong — stop and fix before committing.
+
+- [ ] **Step 4: Commit the RED test**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "test(ci): regression-test for unscoped Hetzner label_selector (#137)
+
+Adds a test-integrity step that greps all workflow files for
+'label_selector=app=restreamer' without a ',client_uuid=' scope.
+Against the current ci.yml this FAILS on line 2329 — proving the
+assertion detects the bug. The next commit scopes that line and
+turns this test green."
+```
+
+---
+
+### Task 3: Fix Pre-Flight Cleanup (GREEN)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:2323-2349`
+
+- [ ] **Step 1: Locate the block to replace**
+
+```bash
+grep -n "Step 2: Clean up orphaned Hetzner VPS directly" .github/workflows/ci.yml
+```
+
+Expected: one match around line 2323. The block to replace runs from that `# Step 2:` comment line through the closing `}` of the `if ($env:HETZNER_API_TOKEN)` guard (around line 2349).
+
+- [ ] **Step 2: Replace the block**
+
+Replace the block from line 2323 through line 2349 (inclusive — the `# Step 2: Clean up orphaned Hetzner VPS directly...` comment through the closing `}` of the `if ($env:HETZNER_API_TOKEN) { ... }` guard) with:
+
+```powershell
+          # Step 2: Clean up orphaned Hetzner VPS directly (scoped to this installation).
+          # Filters by client_uuid so a CI run on one Restreamer install can never
+          # delete another install's VPS sharing the same Hetzner account (fixes #137).
+          if ($env:HETZNER_API_TOKEN) {
+            $clientUuid = $null
+            try {
+              $cfg = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/config" -TimeoutSec 10
+              $clientUuid = $cfg.client_uuid
+            } catch {
+              Write-Host "  Could not read local client_uuid: $_"
+            }
+
+            if (-not $clientUuid) {
+              Write-Host "ERROR: client_uuid not available - refusing to run Hetzner cleanup (fail-closed to protect other installations)"
+              exit 1
+            }
+
+            Write-Host "Checking Hetzner API for orphaned rs-delivery VPS for client_uuid=$clientUuid ..."
+            try {
+              $headers = @{ Authorization = "Bearer $($env:HETZNER_API_TOKEN)" }
+              $selector = "app=restreamer,client_uuid=$clientUuid"
+              $resp = Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers?label_selector=$selector" `
+                -Headers $headers -TimeoutSec 15
+              if ($resp.servers -and $resp.servers.Count -gt 0) {
+                foreach ($srv in $resp.servers) {
+                  Write-Host "  Deleting orphaned VPS (this installation): id=$($srv.id) name=$($srv.name) status=$($srv.status) ip=$($srv.public_net.ipv4.ip)"
+                  try {
+                    Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers/$($srv.id)" `
+                      -Method DELETE -Headers $headers -TimeoutSec 15
+                    Write-Host "  Deleted VPS $($srv.id)"
+                  } catch {
+                    Write-Host "  Failed to delete VPS $($srv.id): $_"
+                  }
+                }
+                Start-Sleep -Seconds 3
+              } else {
+                Write-Host "  No orphaned VPS found for this installation"
+              }
+            } catch {
+              Write-Host "  Hetzner API check failed: $_"
+            }
+          }
+```
+
+Keep the exact leading indentation (10 spaces) used by the surrounding PowerShell body — copy from the "Step 1" block just above at line 2302.
+
+- [ ] **Step 3: Locally confirm the regression test now passes**
+
+```bash
+grep -Prn 'label_selector=app=restreamer(?!,client_uuid=)' .github/workflows/
+```
+
+Expected output: **empty** (zero matches). The only remaining usage of the selector is `app=restreamer,client_uuid=$clientUuid` which is followed by `,client_uuid=` and therefore excluded by the negative lookahead.
+
+If matches remain, stop and inspect — likely the replacement missed a line.
+
+- [ ] **Step 4: Commit the GREEN fix**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "fix(ci): scope Hetzner pre-flight cleanup by client_uuid (#137)
+
+The pre-flight Hetzner VPS sweep used label_selector=app=restreamer,
+which matches every VPS on the account regardless of which Restreamer
+installation created it. On 2026-04-22 15:57 UTC this deleted an
+active streampp live-event VPS during a stream.lan CI run.
+
+Fix: fetch this installation's client_uuid from the local API and
+scope the Hetzner filter to app=restreamer,client_uuid=<uuid>.
+Fail-closed (exit 1) if client_uuid cannot be resolved, rather than
+falling back to the broad filter.
+
+Closes #137."
+```
+
+---
+
+### Task 4: Local Checks and Push
+
+- [ ] **Step 1: Run local format check**
+
+Per airuleset `ci-push-discipline.md`, `cargo fmt --all --check` is the only local check we run. (No `cargo clippy`, no `cargo test`, no `cargo build` — those run on CI.)
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: no output, exit 0.
+
+If it fails, run `cargo fmt --all` and amend (or add a fixup commit). Since this PR touches only YAML/JSON/TOML (no Rust), it should pass immediately.
+
+- [ ] **Step 2: Confirm three commits on dev ahead of main**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected (exact hashes will differ):
+```
+<hash> fix(ci): scope Hetzner pre-flight cleanup by client_uuid (#137)
+<hash> test(ci): regression-test for unscoped Hetzner label_selector (#137)
+<hash> chore: bump version to 0.3.67
+<hash> docs: spec for CI Hetzner cleanup scope fix (#137)
+```
+
+(The `docs:` commit is the spec from the brainstorming skill, already on dev.)
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin dev
+```
+
+---
+
+### Task 5: Monitor CI, Create PR, Verify Mergeable
+
+Per airuleset `ci-monitoring.md`, monitor CI until ALL jobs reach terminal state before proceeding.
+
+- [ ] **Step 1: Identify the triggered run**
+
+```bash
+gh run list --branch dev --limit 3
+```
+
+Note the run-id for the latest in-progress run.
+
+- [ ] **Step 2: Wait for terminal state (single background command, no polling loop)**
+
+```bash
+# 15 minutes is the typical CI duration for this project
+sleep 900 && gh run view <run-id> --json status,conclusion,jobs
+```
+
+Use the Bash tool's `run_in_background: true` option. When it completes, read the output; do not write a custom monitor script and do not use `/loop` or `gh run watch`.
+
+Expected at terminal state: `"status": "completed"`, `"conclusion": "success"`, and every job in the `jobs` array with `"conclusion": "success"` (or `"skipped"` only for explicitly-skipped jobs like mutation testing on docs-only PRs).
+
+- [ ] **Step 3: If CI fails, diagnose and fix in a single new commit**
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+Common failure modes and their fixes:
+
+- "test-integrity / Scan for unscoped Hetzner label_selector" fails with a hit at line 2329 — the pre-flight replacement in Task 3 missed that line. Re-apply Task 3 Step 2.
+- `deploy-stream-lan` fails because stream.lan has an active receiving event — add `[skip-live-check]` to a new empty commit message, or wait for the live event to end. (This is unlikely for a pure-CI change but per PR #129 the gate is now active.)
+
+If a fix is needed, commit it, `git push origin dev`, and repeat from Step 1.
+
+- [ ] **Step 4: Create PR once CI is green**
+
+```bash
+gh pr create --base main --head dev --title "fix(ci): scope Hetzner pre-flight cleanup by client_uuid (#137)" --body "$(cat <<'EOF'
+## Summary
+
+Pre-flight step in `ci.yml` was filtering Hetzner VPS by `app=restreamer` alone, which matches **every** VPS our Hetzner account creates. When two Restreamer installations share the account (stream.lan + streampp), a CI run on one silently deletes the other's live production VPS.
+
+On 2026-04-22 15:57 UTC, the post-merge CI for PR #129 deleted streampp's active live-event VPS `rs-delivery-evt8` (Hetzner id 127743979) two minutes into streampp's Sunday service.
+
+## Fix
+
+- Fetch this installation's `client_uuid` from `GET /api/v1/config` at the start of the pre-flight step.
+- Filter Hetzner with `label_selector=app=restreamer,client_uuid=<uuid>` so only VPS created by **this** installation are swept.
+- **Fail-closed:** if `client_uuid` can't be resolved, the step exits 1 rather than falling back to the broad filter. Better to leave a genuine orphan than delete another installation's production VPS.
+
+The `client_uuid` label was already applied to every VPS at creation (`crates/rs-api/src/delivery.rs:185`) — no schema or Rust-code change needed.
+
+## Regression test
+
+New step in the `test-integrity` job greps all workflow files for `label_selector=app=restreamer` without a `,client_uuid=` scope. Committed before the fix (RED), turned green by the fix (GREEN).
+
+## Test plan
+
+- [x] `grep -Prn 'label_selector=app=restreamer(?!,client_uuid=)' .github/workflows/` — zero matches on HEAD.
+- [x] Same grep on HEAD~1 (before the fix) — one match at `ci.yml:2329`.
+- [x] Full CI green (`test-integrity` regression step passes, `deploy-stream-lan` deploys, E2E Streaming / OBS-to-YouTube tests exercise the scoped cleanup).
+- [x] Manual verification (documented below) that a VPS with a non-matching `client_uuid` label is NOT deleted.
+
+## Manual cross-installation verification (pre-merge)
+
+Run on the stream.lan runner, or against the Hetzner token from a local machine:
+
+```bash
+# 1. Pre-create a fake "other installation" VPS
+curl -s -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+  -X POST https://api.hetzner.cloud/v1/servers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "rs-delivery-fake-other-install",
+    "server_type": "cpx11",
+    "image": "ubuntu-24.04",
+    "location": "nbg1",
+    "labels": {"app": "restreamer", "client_uuid": "fake-other-install-uuid-0000000"}
+  }' | jq '.server.id'
+# returns e.g. 127999999
+
+# 2. Trigger the pre-flight cleanup manually (or wait for next CI run)
+
+# 3. Confirm the fake VPS is still present
+curl -s -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+  "https://api.hetzner.cloud/v1/servers/127999999" | jq '.server.status'
+# Should return "running", not 404.
+
+# 4. Clean up the fake VPS manually
+curl -s -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+  -X DELETE "https://api.hetzner.cloud/v1/servers/127999999"
+```
+
+Closes #137.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Verify PR is mergeable and clean**
+
+```bash
+gh pr view --json number,url,mergeable,mergeableState
+gh api repos/zbynekdrlik/restreamer/pulls/<pr-number> --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Expected: `"mergeable": true` AND `"mergeable_state": "clean"`.
+
+If `behind`: `git fetch origin && git merge origin/main && git push origin dev` — then wait for CI to re-run.
+If `dirty` or `blocked`: inspect the PR checks for the failing item and fix.
+
+- [ ] **Step 6: Deliver the PR URL to the user**
+
+Per project CLAUDE.md, deliver in this exact format:
+
+```
+PR: <url> | CI: green | Deploy: verified | Dashboard: http://10.77.9.204:8910/
+```
+
+Then wait for the user's explicit merge instruction. Do NOT merge.
+
+---
+
+## Verification Summary
+
+1. **Unit-level (CI)** — test-integrity "Scan for unscoped Hetzner label_selector" step passes. No workflow file uses the broad filter.
+2. **Integration (CI)** — the `deploy-stream-lan` → E2E OBS-to-YouTube sequence runs its own pre-flight cleanup against the scoped filter and still successfully deletes leftover test VPS from prior CI runs.
+3. **Manual cross-installation** — the curl-based procedure in the PR description confirms a foreign-`client_uuid` VPS survives the cleanup.
+4. **Post-merge** — the next scheduled or triggered stream.lan CI run leaves any real streampp/other-installation VPS untouched. (No synthetic test needed — the regression assertion plus the scoped filter is sufficient ongoing guarantee.)

--- a/docs/superpowers/specs/2026-04-22-ci-hetzner-cleanup-scope-design.md
+++ b/docs/superpowers/specs/2026-04-22-ci-hetzner-cleanup-scope-design.md
@@ -1,0 +1,145 @@
+# CI Hetzner Cleanup Scope — Design
+
+**Issue:** #137 — CI pre-flight Hetzner cleanup deletes production VPS from other Restreamer instances (e.g. streampp)
+
+**Goal:** Scope the CI pre-flight Hetzner-VPS cleanup to only delete servers belonging to this Restreamer installation, so a CI run on one installation (e.g. stream.lan) can never delete another installation's active VPS (e.g. streampp).
+
+**Version:** 0.3.67 (strictly greater than 0.3.66 on main)
+
+---
+
+## Incident reference
+
+- **2026-04-22 15:57 UTC** — stream.lan's CI pre-flight step deleted streampp's active production delivery VPS `rs-delivery-evt8` (Hetzner id 127743979) two minutes into streampp's live service. Operator fell back to OBS plugin mid-session.
+- Root cause: `.github/workflows/ci.yml:2323-2349` filters by `label_selector=app=restreamer`. That label is generic across every Restreamer installation sharing the Hetzner account.
+
+## Root cause
+
+```powershell
+# Current code (ci.yml:2329)
+$resp = Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers?label_selector=app=restreamer" ...
+foreach ($srv in $resp.servers) {
+  DELETE /v1/servers/$($srv.id)
+}
+```
+
+The label `app=restreamer` is added to **every** VPS our Hetzner account creates. Two (or more) Restreamer installations sharing a single Hetzner API token will each match the other's VPS in this query.
+
+## Existing infrastructure (no new labels needed)
+
+`crates/rs-api/src/delivery.rs:182-185` already applies three labels to every VPS it creates:
+
+```rust
+let mut labels = HashMap::new();
+labels.insert("app".to_string(), "restreamer".to_string());
+labels.insert("event_id".to_string(), event_id.to_string());
+labels.insert("client_uuid".to_string(), self.config.client_uuid.clone());
+```
+
+`client_uuid` is a UUID generated once per Restreamer installation and persisted in `config.json`. It is unique per installation (stream.lan has one, streampp has another, any future deployment will have its own).
+
+`client_uuid` is exposed over the local API at `GET http://127.0.0.1:8910/api/v1/config` (returns the full `Config` struct, with S3 credentials redacted — `client_uuid` is plain).
+
+## Solution — scope cleanup by `client_uuid`
+
+Change the pre-flight Hetzner cleanup step to:
+
+1. Fetch the local Restreamer's `client_uuid` via `GET /api/v1/config`.
+2. Use Hetzner's multi-label filter: `label_selector=app=restreamer,client_uuid=<local-uuid>` (Hetzner's `label_selector` treats commas as AND).
+3. Delete only VPS matching both labels — the installation's own VPS.
+
+### Fail-closed on missing client_uuid
+
+If the local API is unreachable, returns no `client_uuid`, or returns an empty string, the CI step **aborts with exit 1** rather than falling back to the old broad filter. Better to leave a genuine orphan VPS than risk deleting another installation's production VPS.
+
+### Sketch of new PowerShell block (replaces ci.yml:2323-2349)
+
+```powershell
+# Step 2: Clean up orphaned Hetzner VPS directly (scoped to this installation).
+if ($env:HETZNER_API_TOKEN) {
+  # Resolve this installation's client_uuid to scope the cleanup.
+  $clientUuid = $null
+  try {
+    $cfg = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/config" -TimeoutSec 10
+    $clientUuid = $cfg.client_uuid
+  } catch {
+    Write-Host "  Could not read local client_uuid: $_"
+  }
+
+  if (-not $clientUuid) {
+    Write-Host "ERROR: client_uuid not available — refusing to run Hetzner cleanup (fail-closed to protect other installations)"
+    exit 1
+  }
+
+  Write-Host "Checking Hetzner API for orphaned rs-delivery VPS for client_uuid=$clientUuid ..."
+  try {
+    $headers = @{ Authorization = "Bearer $($env:HETZNER_API_TOKEN)" }
+    $selector = "app=restreamer,client_uuid=$clientUuid"
+    $resp = Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers?label_selector=$selector" `
+      -Headers $headers -TimeoutSec 15
+    if ($resp.servers -and $resp.servers.Count -gt 0) {
+      foreach ($srv in $resp.servers) {
+        Write-Host "  Deleting orphaned VPS (this installation): id=$($srv.id) name=$($srv.name) status=$($srv.status) ip=$($srv.public_net.ipv4.ip)"
+        try {
+          Invoke-RestMethod -Uri "https://api.hetzner.cloud/v1/servers/$($srv.id)" `
+            -Method DELETE -Headers $headers -TimeoutSec 15
+          Write-Host "  Deleted VPS $($srv.id)"
+        } catch {
+          Write-Host "  Failed to delete VPS $($srv.id): $_"
+        }
+      }
+      Start-Sleep -Seconds 3
+    } else {
+      Write-Host "  No orphaned VPS found for this installation"
+    }
+  } catch {
+    Write-Host "  Hetzner API check failed: $_"
+  }
+}
+```
+
+## Regression test
+
+Add a static assertion as a new step in the existing `test-integrity` job (`.github/workflows/ci.yml:420`, runs on `ubuntu-latest` with inline bash). The step scans `.github/workflows/*.yml` for the pattern `label_selector=app=restreamer` and fails if any occurrence is not immediately followed by `,client_uuid=`. Prevents a future copy-paste from reintroducing the broad filter.
+
+```yaml
+- name: Scan for unscoped Hetzner label_selector
+  run: |
+    BAD=$(grep -Prn 'label_selector=app=restreamer(?!,client_uuid=)' .github/workflows/ || true)
+    if [ -n "$BAD" ]; then
+      echo "ERROR: Hetzner label_selector must include ,client_uuid=<uuid> scope to protect other installations:"
+      echo "$BAD"
+      exit 1
+    fi
+    echo "OK: All Hetzner label_selector usages are client_uuid-scoped."
+```
+
+The Perl-compatible negative lookahead (`(?!,client_uuid=)`) catches every occurrence of `label_selector=app=restreamer` that is NOT immediately followed by `,client_uuid=`:
+
+- `label_selector=app=restreamer"` — fails (no `,client_uuid=`).
+- `label_selector=app=restreamer,client_uuid=...` — passes.
+- `label_selector=app=restreamer,event_id=...` — fails (correct: a different scope label also violates the rule).
+- `label_selector=app=restreamer` at end-of-line — fails (catches stray unterminated URLs too).
+
+## Out of scope (YAGNI)
+
+- **Per-installation Hetzner label** (e.g. `installation=stream-lan`). `client_uuid` already uniquely identifies each installation; adding another label is redundant.
+- **Separate Hetzner projects per installation.** Long-term hardening — unnecessary now that the cleanup is scoped.
+- **Retroactive cleanup of pre-0.3.0 VPS** missing `client_uuid` label. All currently-created VPS carry this label; none older than 0.3.0 exist on the account.
+- **Additional Rust code changes.** No crate source needs editing — `client_uuid` is already applied and already exposed.
+
+## Verification
+
+1. **Unit-level** — `test-integrity` regression-test assertion passes on the patched ci.yml, fails on the old pattern.
+2. **Integration-level** — CI run completes its pre-flight cleanup against a Hetzner account that holds:
+   - VPS with `app=restreamer,client_uuid=<stream-lan-uuid>` → deleted (expected).
+   - VPS with `app=restreamer,client_uuid=<some-other-uuid>` (e.g. manually created to simulate streampp) → **not** deleted.
+3. **Post-deploy** — after merge, a stream.lan CI run that coexists with a streampp VPS (real or synthesized) leaves streampp's VPS intact.
+
+## Files changed
+
+- `.github/workflows/ci.yml` — replace the cleanup block (lines 2323-2349) with the scoped version above.
+- `.github/workflows/ci.yml` (test-integrity step) — add the `label_selector` regex assertion.
+- `Cargo.toml`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `leptos-ui/Cargo.toml` — bump `0.3.66` → `0.3.67`.
+
+No Rust crates are modified.

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.3.66"
+version = "0.3.67"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.3.66"
+version = "0.3.67"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.3.66",
+  "version": "0.3.67",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

**Closes #137** and **Closes #132** — two CI-only fixes, one PR.

### #137 — Pre-flight Hetzner cleanup scope (primary fix)

Pre-flight step in `ci.yml` was filtering Hetzner VPS by `app=restreamer` alone, which matches **every** VPS our Hetzner account creates. When two Restreamer installations share the account (stream.lan + streampp), a CI run on one silently deletes the other's live production VPS.

On 2026-04-22 15:57 UTC, the post-merge CI for PR #129 deleted streampp's active live-event VPS `rs-delivery-evt8` (Hetzner id 127743979) two minutes into streampp's Sunday service. Operator fell back to OBS plugin mid-session.

**Fix:**
- Fetch this installation's `client_uuid` from `GET /api/v1/config` at the start of the pre-flight step.
- Filter Hetzner with `label_selector=app=restreamer,client_uuid=<uuid>` so only VPS created by **this** installation are swept.
- **Fail-closed:** if `client_uuid` can't be resolved, the step exits 1 rather than falling back to the broad filter.

The `client_uuid` label was already applied to every VPS at creation (`crates/rs-api/src/delivery.rs:185`) — no schema or Rust-code change needed.

### #132 — Preserve operator-set `extra_ssh_key_names` across CI deploys (bundled fix)

The "Configure Hetzner API token" step in the `e2e-obs-youtube-test` job wrote the `hetzner` config section as a full-object overwrite, wiping operator-set fields such as `extra_ssh_key_names` on every CI run. This fix was already sitting uncommitted in the working tree from a prior session (`M .github/workflows/ci.yml`) and got folded into commit `5b28255` when I staged `ci.yml` for the #137 test-RED step. Rather than rewrite history (airuleset forbids it), the fix is included here with a regression test.

**Fix:** replace the full-object overwrite with per-field `Add-Member -NotePropertyName ... -Force`. Only CI-owned fields (`api_token`, `location`, `default_server_type`, `snapshot_label`, `ssh_key_name`) are rewritten; everything else — crucially `extra_ssh_key_names` — is preserved.

## Regression tests (TDD)

Two new steps in the `test-integrity` job:

1. **Scan for unscoped Hetzner label_selector** — grep rejects any `label_selector=app=restreamer` without a `,client_uuid=` scope. RED against pre-#137 code, GREEN on HEAD.
2. **Scan for destructive Hetzner config overwrite** — grep rejects any `$config.hetzner = @{` multi-line assignment pattern. RED against pre-#132 code, GREEN on HEAD. Forces future CI edits to use the non-destructive `Add-Member -Force` pattern.

Both grep patterns are assembled from `PREFIX`+`SUFFIX` variables so the regression-test steps' own source does not match itself.

## Test plan

- [x] `grep -Prn 'label_selector=app=restreamer(?!,client_uuid=)' .github/workflows/` → 0 matches on HEAD; 1 match on HEAD~N (before the #137 fix)
- [x] `grep -Prn '\$config\.hetzner\s*=\s*@\{\s*$' .github/workflows/` → 0 matches on HEAD; validated against synthetic pre-#132 fixture — catches it
- [x] CI run [24795542824](https://github.com/zbynekdrlik/restreamer/actions/runs/24795542824) on the #137-only commit set: all 18 jobs green
  - `Test integrity check` (new #137 regression step) ✅
  - `Deploy to stream.lan` ✅
  - `E2E Streaming Test` ✅
  - `E2E OBS-to-YouTube Test` ✅ — exercises scoped cleanup end-to-end
- [ ] CI run on current HEAD (includes the #132 regression step) — pending; will update once green

## Manual cross-installation verification (#137)

Pre-creating a VPS with a foreign `client_uuid` label and confirming it survives a stream.lan CI run:

```bash
curl -s -H "Authorization: Bearer $HETZNER_API_TOKEN" \
  -X POST https://api.hetzner.cloud/v1/servers \
  -H "Content-Type: application/json" \
  -d '{
    "name": "rs-delivery-fake-other-install",
    "server_type": "cpx11",
    "image": "ubuntu-24.04",
    "location": "nbg1",
    "labels": {"app": "restreamer", "client_uuid": "fake-other-install-uuid-0000000"}
  }'
# ...run pre-flight cleanup manually or wait for next CI run...
# ...confirm the fake VPS is still present, then delete it manually.
```

## Commits

| Hash | Message | Scope |
|------|---------|-------|
| `9011b2a` | docs: spec for CI Hetzner cleanup scope fix | design doc |
| `9d3d64d` | docs: implementation plan for CI Hetzner cleanup scope | plan doc |
| `e2a7564` | chore: bump version to 0.3.67 | version |
| `5b28255` | test(ci): regression-test for unscoped Hetzner label_selector (#137) | #137 RED + bundled #132 fix (see above) |
| `a7dcd52` | fix(ci): scope Hetzner pre-flight cleanup by client_uuid (#137) | #137 GREEN |
| `e5bf1a8` | test(ci): regression-test for destructive Hetzner config overwrite (#132) | #132 regression test |

Closes #137
Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
