### PR TITLE
fix(settings): #128 delete+cleanup button busy state and error surfacing (v0.3.70)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.3.69"
+version = "0.3.70"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/docs/superpowers/plans/2026-04-25-delete-cleanup-button-feedback.md
+++ b/docs/superpowers/plans/2026-04-25-delete-cleanup-button-feedback.md
@@ -1,0 +1,663 @@
+# Delete + Cleanup Button Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issue #128 by surfacing in-progress state and API errors for the Events-tab `Delete + Cleanup` and `Clear S3 chunks` buttons in the Leptos dashboard.
+
+**Architecture:** Pure UI fix in a single Leptos component (`leptos-ui/src/components/settings.rs`). Add two `RwSignal`s — `busy_event_id` and `action_error` — wire them into the existing per-card buttons (disabled + label flip while busy) and render an inline error banner above the events list when the API call fails. Modal still closes immediately on confirm; the visible feedback now lives on the card itself. Backend unchanged.
+
+**Tech Stack:** Rust + Leptos (CSR/WASM frontend), Playwright + TypeScript (E2E), existing CSS classes (`.error-message`, `.btn-danger`, `.btn-secondary`).
+
+**Spec:** `docs/superpowers/specs/2026-04-25-delete-cleanup-button-feedback-design.md`
+
+**Issue:** #128
+
+---
+
+## File map
+
+- **Modify:** `Cargo.toml`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `leptos-ui/Cargo.toml` — version bump 0.3.69 → 0.3.70
+- **Modify:** `e2e/playwright-frontend.config.ts:9` — extend testMatch regex to include the new spec
+- **Create:** `e2e/delete-cleanup-button.spec.ts` — two TDD tests (success path with busy-state assertions, error path with banner assertion)
+- **Modify:** `leptos-ui/src/components/settings.rs:411-700` — add busy/error signals, rewrite both confirm callbacks, make card-actions buttons reactive on busy state, render error banner
+
+---
+
+## Constraints (every task)
+
+- Local checks: `cargo fmt --all --check` only. **No** `cargo build/test/clippy` locally — those run on CI per airuleset `ci-push-discipline`.
+- TDD: failing test first, then implementation. The failing-test commit and the implementation commit go to dev as separate commits in the same push.
+- File size gate: `settings.rs` is currently ~830 lines after the ~50-line addition; well under the 1000-line limit.
+- One commit per task. Don't batch tasks.
+
+---
+
+### Task 1: Version bump
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root, version line near top)
+- Modify: `src-tauri/Cargo.toml` (top-level `version` field)
+- Modify: `src-tauri/tauri.conf.json` (`"version": "0.3.69"`)
+- Modify: `leptos-ui/Cargo.toml` (`version` field)
+
+- [ ] **Step 1: Confirm current version on dev matches main**
+
+```bash
+git fetch origin
+grep '^version' Cargo.toml | head -1
+git show origin/main:Cargo.toml | grep '^version' | head -1
+```
+
+Expected: both lines show `version = "0.3.69"`. If they differ, the bump may already be done — check `git log` and skip this task.
+
+- [ ] **Step 2: Bump `Cargo.toml`**
+
+Change the workspace `version = "0.3.69"` line to `version = "0.3.70"`.
+
+- [ ] **Step 3: Bump `src-tauri/Cargo.toml`**
+
+Change `version = "0.3.69"` to `version = "0.3.70"`.
+
+- [ ] **Step 4: Bump `src-tauri/tauri.conf.json`**
+
+Change `"version": "0.3.69"` to `"version": "0.3.70"`.
+
+- [ ] **Step 5: Bump `leptos-ui/Cargo.toml`**
+
+Change `version = "0.3.69"` to `version = "0.3.70"`.
+
+- [ ] **Step 6: Verify formatting**
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.toml src-tauri/Cargo.toml src-tauri/tauri.conf.json leptos-ui/Cargo.toml
+git commit -m "chore: bump version to 0.3.70"
+```
+
+---
+
+### Task 2: Add failing Playwright spec (TDD red)
+
+**Files:**
+- Create: `e2e/delete-cleanup-button.spec.ts`
+- Modify: `e2e/playwright-frontend.config.ts:9` (extend testMatch regex)
+
+- [ ] **Step 1: Extend testMatch regex in `e2e/playwright-frontend.config.ts`**
+
+Find this line (near line 9):
+
+```ts
+testMatch: /(frontend|audit-panel|zero-endpoint-banner|remove-last-endpoint-modal|endpoint-history-sparkline|cache-drift-panel)\.spec\.ts$/,
+```
+
+Replace with:
+
+```ts
+testMatch: /(frontend|audit-panel|zero-endpoint-banner|remove-last-endpoint-modal|endpoint-history-sparkline|cache-drift-panel|delete-cleanup-button)\.spec\.ts$/,
+```
+
+- [ ] **Step 2: Create `e2e/delete-cleanup-button.spec.ts` with both tests**
+
+Write this exact file:
+
+```ts
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+// Inject Tauri mock so the Leptos app runs in "Tauri mode" for invoke().
+const tauriMockScript = fs.readFileSync(
+  path.join(__dirname, "tauri-mock.js"),
+  "utf-8",
+);
+
+// Chromium-level warnings that are not application bugs.
+const ALLOWED_CONSOLE = [
+  /integrity.*attribute.*currently ignored.*subresource integrity/i,
+];
+
+// The mock-api seeds two events on /__reset; we target id=1 ("Sunday Service").
+const TARGET_EVENT_NAME = "Sunday Service";
+
+test("delete + cleanup shows busy state and removes event on success", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.addInitScript(tauriMockScript);
+  await request.post("http://127.0.0.1:8910/api/v1/__reset");
+
+  // Delay the DELETE response so the busy state is observable.
+  await page.route("**/api/v1/events/1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.continue();
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/settings");
+  await page.locator(".settings-tabs .tab", { hasText: "Events" }).click();
+
+  const card = page.locator(".settings-card", { hasText: TARGET_EVENT_NAME });
+  const deleteBtn = card.locator("button.btn-danger");
+  const clearBtn = card.locator("button.btn-secondary");
+
+  await expect(deleteBtn).toBeEnabled();
+  await deleteBtn.click();
+
+  // Confirm in modal
+  await page.locator(".confirm-modal .confirm-btn-danger").click();
+
+  // Modal closes immediately
+  await expect(page.locator(".confirm-modal")).toHaveCount(0);
+
+  // Busy state: label flips to "Deleting…", both card buttons disabled
+  await expect(deleteBtn).toHaveText(/Deleting/, { timeout: 1000 });
+  await expect(deleteBtn).toBeDisabled();
+  await expect(clearBtn).toBeDisabled();
+
+  // After the delay + DELETE + list refresh, the card is gone
+  await expect(card).toHaveCount(0, { timeout: 5000 });
+
+  const real = consoleMessages.filter(
+    (m) => !ALLOWED_CONSOLE.some((r) => r.test(m)),
+  );
+  expect(real).toEqual([]);
+});
+
+test("delete + cleanup shows error banner on API failure", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.addInitScript(tauriMockScript);
+  await request.post("http://127.0.0.1:8910/api/v1/__reset");
+
+  // Force a 500 response on DELETE
+  await page.route("**/api/v1/events/1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      await new Promise((r) => setTimeout(r, 200));
+      await route.fulfill({ status: 500, body: "internal server error" });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/settings");
+  await page.locator(".settings-tabs .tab", { hasText: "Events" }).click();
+
+  const card = page.locator(".settings-card", { hasText: TARGET_EVENT_NAME });
+  const deleteBtn = card.locator("button.btn-danger");
+
+  await deleteBtn.click();
+  await page.locator(".confirm-modal .confirm-btn-danger").click();
+
+  // Error banner appears with "Delete failed"
+  await expect(
+    page.locator(".error-message", { hasText: /Delete failed/i }),
+  ).toBeVisible({ timeout: 3000 });
+
+  // Event card still present
+  await expect(card).toBeVisible();
+
+  // Button re-enabled and label restored
+  await expect(deleteBtn).toBeEnabled();
+  await expect(deleteBtn).toHaveText(/Delete \+ Cleanup/);
+
+  // Filter out the expected 500-response noise from console.
+  // The application MUST handle the error gracefully — the only allowed
+  // console output is fetch's own network logging for the 500.
+  const real = consoleMessages.filter(
+    (m) =>
+      !ALLOWED_CONSOLE.some((r) => r.test(m)) &&
+      !/500/.test(m) &&
+      !/Failed to load/i.test(m),
+  );
+  expect(real).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Confirm test discovery (no execution)**
+
+The implementation runs on CI; locally we only verify the file is created and the regex is updated. No `npx playwright test` locally — CI runs the suite.
+
+```bash
+ls -la e2e/delete-cleanup-button.spec.ts
+grep delete-cleanup-button e2e/playwright-frontend.config.ts
+```
+
+Expected: file exists; regex contains `delete-cleanup-button`.
+
+- [ ] **Step 4: Commit (TDD red — test fails because busy state and error banner don't exist yet)**
+
+```bash
+git add e2e/delete-cleanup-button.spec.ts e2e/playwright-frontend.config.ts
+git commit -m "test: add failing Playwright spec for delete+cleanup button feedback (#128)"
+```
+
+---
+
+### Task 3: Implement fix in settings.rs (TDD green)
+
+**Files:**
+- Modify: `leptos-ui/src/components/settings.rs:411-700` (`EventsManagement` component)
+
+- [ ] **Step 1: Read the current `EventsManagement` declaration block (lines 411-487) to anchor the edit**
+
+```bash
+sed -n '411,490p' leptos-ui/src/components/settings.rs
+```
+
+Confirm the existing signal declarations end around line 430 (`set_template_error`).
+
+- [ ] **Step 2: Add the two new signals after the existing `s3_usage_error` signal**
+
+In `leptos-ui/src/components/settings.rs`, locate this block (lines 425-426):
+
+```rust
+    let s3_usage = RwSignal::<Option<api::S3UsageResponse>>::new(None);
+    let s3_usage_error = RwSignal::<Option<String>>::new(None);
+```
+
+Add these two lines immediately after:
+
+```rust
+    // Busy and error state for destructive actions on event cards.
+    // `busy_event_id` is `Some(id)` while a delete or clear-S3 call is
+    // in flight for that event; the buttons on that card render disabled
+    // with a "Deleting…"/"Clearing…" label so the operator sees progress.
+    // `action_error` holds the most recent failure message from either
+    // action so it can render in a banner above the list.
+    let busy_event_id = RwSignal::<Option<i64>>::new(None);
+    let action_error = RwSignal::<Option<String>>::new(None);
+```
+
+- [ ] **Step 3: Replace `on_confirm_delete` (lines 451-462) with error-aware version**
+
+Find this block:
+
+```rust
+    let on_confirm_delete = Callback::new(move |_: ()| {
+        let id = delete_target_id.get();
+        spawn_local(async move {
+            let _ = api::delete_event(id).await;
+            if let Ok(events) = api::list_events().await {
+                store.events_list.set(events);
+            }
+            if let Ok(u) = api::get_s3_usage().await {
+                s3_usage.set(Some(u));
+            }
+        });
+    });
+```
+
+Replace with:
+
+```rust
+    let on_confirm_delete = Callback::new(move |_: ()| {
+        let id = delete_target_id.get();
+        busy_event_id.set(Some(id));
+        action_error.set(None);
+        spawn_local(async move {
+            match api::delete_event(id).await {
+                Ok(_) => {
+                    if let Ok(events) = api::list_events().await {
+                        store.events_list.set(events);
+                    }
+                    if let Ok(u) = api::get_s3_usage().await {
+                        s3_usage.set(Some(u));
+                    }
+                }
+                Err(e) => action_error.set(Some(format!("Delete failed: {e}"))),
+            }
+            busy_event_id.set(None);
+        });
+    });
+```
+
+- [ ] **Step 4: Replace `on_confirm_clear` (lines 464-472) with error-aware version**
+
+Find this block:
+
+```rust
+    let on_confirm_clear = Callback::new(move |_: ()| {
+        let id = clear_target_id.get();
+        spawn_local(async move {
+            let _ = api::clear_event_s3_chunks(id).await;
+            if let Ok(u) = api::get_s3_usage().await {
+                s3_usage.set(Some(u));
+            }
+        });
+    });
+```
+
+Replace with:
+
+```rust
+    let on_confirm_clear = Callback::new(move |_: ()| {
+        let id = clear_target_id.get();
+        busy_event_id.set(Some(id));
+        action_error.set(None);
+        spawn_local(async move {
+            match api::clear_event_s3_chunks(id).await {
+                Ok(_) => {
+                    if let Ok(u) = api::get_s3_usage().await {
+                        s3_usage.set(Some(u));
+                    }
+                }
+                Err(e) => action_error.set(Some(format!("Clear failed: {e}"))),
+            }
+            busy_event_id.set(None);
+        });
+    });
+```
+
+- [ ] **Step 5: Render the error banner above the events list**
+
+In `EventsManagement`'s `view!` block, locate the `<div class="events-actions-bar">` (around line 493) — the "+ New from Template" button container. Immediately AFTER that closing `</div>` tag and BEFORE the S3 usage banner (the `{move || { if let Some(usage) = s3_usage.get() ...` block around line 510), insert:
+
+```rust
+            // Action error banner — surfaces the most recent failure from
+            // delete/clear actions. Dismissable with the "×" button.
+            {move || action_error.get().map(|err| view! {
+                <div class="error-message">
+                    {err}
+                    <button
+                        class="modal-cancel-btn"
+                        style="margin-left: var(--spacing-md);"
+                        on:click=move |_| action_error.set(None)
+                    >
+                        "×"
+                    </button>
+                </div>
+            })}
+```
+
+- [ ] **Step 6: Make the per-card buttons reactive on busy state**
+
+Locate the card-actions block (lines 593-621). The current `Clear S3 chunks` button is:
+
+```rust
+                                    <button
+                                        class="btn-secondary"
+                                        disabled=is_streaming
+                                        on:click=move |_| {
+                                            clear_target_id.set(id);
+                                            clear_target_name.set(name_for_clear.clone());
+                                            show_clear_modal.set(true);
+                                        }
+                                        title="Delete S3 chunks for this event but keep the event row"
+                                    >
+                                        "Clear S3 chunks"
+                                    </button>
+```
+
+Replace with:
+
+```rust
+                                    <button
+                                        class="btn-secondary"
+                                        disabled=move || is_streaming || busy_event_id.get() == Some(id)
+                                        on:click=move |_| {
+                                            clear_target_id.set(id);
+                                            clear_target_name.set(name_for_clear.clone());
+                                            show_clear_modal.set(true);
+                                        }
+                                        title="Delete S3 chunks for this event but keep the event row"
+                                    >
+                                        {move || {
+                                            if busy_event_id.get() == Some(id) {
+                                                "Clearing…"
+                                            } else {
+                                                "Clear S3 chunks"
+                                            }
+                                        }}
+                                    </button>
+```
+
+The current `Delete + Cleanup` button is:
+
+```rust
+                                    <button
+                                        class="btn-danger"
+                                        disabled=is_streaming
+                                        on:click=move |_| {
+                                            delete_target_id.set(id);
+                                            delete_target_name.set(name_for_modal.clone());
+                                            show_delete_modal.set(true);
+                                        }
+                                    >
+                                        {if is_streaming {
+                                            "Delete (stop stream first)"
+                                        } else {
+                                            "Delete + Cleanup"
+                                        }}
+                                    </button>
+```
+
+Replace with:
+
+```rust
+                                    <button
+                                        class="btn-danger"
+                                        disabled=move || is_streaming || busy_event_id.get() == Some(id)
+                                        on:click=move |_| {
+                                            delete_target_id.set(id);
+                                            delete_target_name.set(name_for_modal.clone());
+                                            show_delete_modal.set(true);
+                                        }
+                                    >
+                                        {move || {
+                                            if is_streaming {
+                                                "Delete (stop stream first)"
+                                            } else if busy_event_id.get() == Some(id) {
+                                                "Deleting…"
+                                            } else {
+                                                "Delete + Cleanup"
+                                            }
+                                        }}
+                                    </button>
+```
+
+- [ ] **Step 7: Verify formatting**
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: no output. If output appears, run `cargo fmt --all` and re-check.
+
+- [ ] **Step 8: Commit (TDD green — implementation makes the failing test pass on CI)**
+
+```bash
+git add leptos-ui/src/components/settings.rs
+git commit -m "fix(settings): show busy state + surface errors for delete/clear actions (#128)"
+```
+
+---
+
+### Task 4: Push and monitor CI to terminal state
+
+This task is run by the orchestrator (main agent), not a subagent.
+
+- [ ] **Step 1: Final formatting check**
+
+```bash
+cargo fmt --all --check
+```
+
+- [ ] **Step 2: Review what will be pushed**
+
+```bash
+git log --oneline origin/dev..HEAD
+git diff --stat origin/dev..HEAD
+```
+
+Expected: 3 commits (`chore: bump version`, `test: add failing Playwright spec`, `fix(settings): show busy state`). Diff touches: 4 version files + Playwright config + new e2e spec + settings.rs.
+
+- [ ] **Step 3: Push to dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 4: Identify the CI run triggered by your push**
+
+```bash
+sleep 10 && gh run list --branch dev --limit 3 --json databaseId,workflowName,status,conclusion,createdAt
+```
+
+Note the `databaseId` of the latest "Rust CI" run. Save as `RUN_ID`.
+
+- [ ] **Step 5: Monitor that run to terminal state**
+
+Use the airuleset-approved single-command pattern:
+
+```bash
+sleep 600 && gh run view <RUN_ID> --json status,conclusion,jobs
+```
+
+Run with `run_in_background: true`. Wait for the result; the orchestrator gets a notification when the background command finishes.
+
+- [ ] **Step 6: Handle the result**
+
+- If `conclusion == "success"`: proceed to Task 5.
+- If failed: `gh run view <RUN_ID> --log-failed`, fix the root cause in ONE commit, push once, monitor again. Never blindly rerun.
+
+---
+
+### Task 5: Create PR dev → main
+
+This task is run by the orchestrator.
+
+- [ ] **Step 1: Verify dev is ahead of main**
+
+```bash
+git fetch origin
+git log --oneline origin/main..origin/dev
+```
+
+Expected: 3 commits listed.
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --base main --head dev --title "fix(settings): #128 delete+cleanup button busy state and error surfacing (v0.3.70)" --body "$(cat <<'EOF'
+## Summary
+- Add `busy_event_id` + `action_error` signals to `EventsManagement`; both confirm callbacks now flip these signals around the async API call instead of fire-and-forget with swallowed errors.
+- Per-card `Clear S3 chunks` and `Delete + Cleanup` buttons render disabled with `Clearing…` / `Deleting…` labels while their event's mutation is in flight.
+- A dismissable `.error-message` banner above the events list surfaces the failure reason if the API returns non-2xx.
+- Backend untouched — issue was purely UI feedback.
+
+Closes #128
+
+## Test plan
+- [ ] CI: `e2e/delete-cleanup-button.spec.ts` passes (success + error tests)
+- [ ] CI: existing E2E specs still pass (frontend, audit-panel, etc.)
+- [ ] CI: `deploy-stream-lan` job succeeds
+- [ ] Post-deploy: open dashboard via Playwright MCP, navigate to Settings → Events, confirm `Delete + Cleanup` shows the busy state and error banner behaviors on stream.lan v0.3.70
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Save the PR URL.
+
+---
+
+### Task 6: Monitor PR CI to green and verify deployment
+
+This task is run by the orchestrator.
+
+- [ ] **Step 1: Identify the PR CI run**
+
+```bash
+gh pr checks <PR_URL>
+```
+
+If checks haven't started yet: `sleep 20 && gh pr checks <PR_URL>`.
+
+- [ ] **Step 2: Wait for ALL jobs (including deploy-stream-lan + e2e-gate) to reach terminal state**
+
+```bash
+sleep 900 && gh pr checks <PR_URL>
+```
+
+Run in background. When done, check the result.
+
+- [ ] **Step 3: Verify mergeable**
+
+```bash
+gh api repos/zbynekdrlik/restreamer/pulls/<PR_NUMBER> --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Expected: `mergeable: true`, `mergeable_state: "clean"`.
+
+- [ ] **Step 4: Verify deploy on stream.lan**
+
+After `deploy-stream-lan` is green:
+
+```
+mcp__win-stream-snv__ListProcesses with filter "Restreamer"
+mcp__win-stream-snv__Shell: Invoke-RestMethod -Uri http://127.0.0.1:8910/api/v1/status
+mcp__win-stream-snv__Shell: (Get-Item "C:\Program Files\Restreamer\Restreamer.exe").VersionInfo.FileVersion
+```
+
+Expected: process running in user session; API returns valid status; FileVersion shows `0.3.70`.
+
+- [ ] **Step 5: Functional verification via Playwright MCP**
+
+```
+mcp__plugin_playwright_playwright__browser_navigate to http://10.77.9.204:8910/settings
+mcp__plugin_playwright_playwright__browser_click on "Events" tab
+mcp__plugin_playwright_playwright__browser_snapshot
+```
+
+Confirm the events tab renders. Pick an idle event (not streaming), click `Delete + Cleanup`, observe modal → confirm → verify the button label flips to `Deleting…` and the card disappears after a moment. (If no idle test event exists, just confirm the new button text/disabled-attribute wiring renders correctly via the snapshot.)
+
+- [ ] **Step 6: Report the URL and wait for explicit merge instruction**
+
+Per `pr-merge-policy`: provide the green PR URL and the dashboard URL (`http://10.77.9.204:8910/`) in a completion report. **Do not merge.** Wait for the user to say "merge it".
+
+---
+
+## Post-merge (only after user says "merge it")
+
+- Merge the PR: `gh pr merge <PR_NUMBER> --merge` (no squash, no rebase)
+- Monitor main CI run + Release workflow `restreamer-v0.3.70` to terminal state with the same `sleep N && gh run view` pattern
+- Verify GitHub Release published with assets (`Restreamer_0.3.70_x64-setup.exe`, `rs-delivery-0.3.70-linux-amd64`, `.sha256`)
+- Verify stream.lan now runs `0.3.70` post-deploy
+- Final completion report per `completion-report` rule
+
+---
+
+## Verification checklist (collated for the final completion report)
+
+1. **CI**: all jobs green (lint, test, mutation-testing, test-integrity, e2e-frontend, e2e-youtube, e2e-gate, deploy-stream-lan, security-audit, build, file-size)
+2. **Playwright**: both new tests pass; existing E2E specs unaffected
+3. **Mergeable**: `mergeable: true, mergeable_state: clean`
+4. **Deploy**: stream.lan running `Restreamer.exe` v0.3.70 in user session with API responding
+5. **Functional**: dashboard /settings → Events tab → button label flips to `Deleting…` while delete is in flight; error banner appears on API failure; event removed from list on success
+6. **No console errors**: zero browser console errors/warnings on the deployed dashboard

--- a/docs/superpowers/specs/2026-04-25-delete-cleanup-button-feedback-design.md
+++ b/docs/superpowers/specs/2026-04-25-delete-cleanup-button-feedback-design.md
@@ -1,0 +1,141 @@
+# Delete + Cleanup Button: Visible Progress and Error Surfacing — Design Spec
+
+**Issue:** #128 — "delete and cleanup button on dashboard settings not work and not do anything!!!! TDD"
+
+**Date:** 2026-04-25
+
+## Problem
+
+The Events tab in `Settings` exposes two destructive actions per event:
+
+- `Delete + Cleanup` — deletes the event row and all its S3 chunks
+- `Clear S3 chunks` — keeps the event row, deletes only its chunks
+
+Both fire long-running async work (S3 deletion can take up to 60s for events with thousands of chunks) but offer the operator zero feedback during that window. The user reports clicking the button and seeing nothing happen, then clicking again and finding the event gone — concluding the button is broken.
+
+## Root cause (confirmed)
+
+`leptos-ui/src/components/confirm_modal.rs:28-34` — `on_confirm_click` runs the user's callback synchronously, then immediately closes the modal:
+
+```rust
+let on_confirm_click = move |_| {
+    on_confirm.run(());            // synchronous; spawn_local returns immediately
+    defer_set_false(show);          // modal closes
+};
+```
+
+`leptos-ui/src/components/settings.rs:451-472` — both confirm callbacks fire-and-forget the async work and silently swallow errors:
+
+```rust
+let on_confirm_delete = Callback::new(move |_: ()| {
+    let id = delete_target_id.get();
+    spawn_local(async move {
+        let _ = api::delete_event(id).await;     // ← error discarded
+        if let Ok(events) = api::list_events().await {
+            store.events_list.set(events);
+        }
+        if let Ok(u) = api::get_s3_usage().await {
+            s3_usage.set(Some(u));
+        }
+    });
+});
+```
+
+Result: modal closes → 10–60s of unchanged UI → events_list silently refreshes when the async block finishes. If the API returned 500/504/409, nothing surfaces.
+
+The backend is correct (`crates/rs-api/src/handlers.rs:474-569`): 60s timeout, parallel-batched S3 deletes (20 concurrent), proper status codes (200/204, 404, 409, 500, 504). No backend changes needed.
+
+## Approach: inline busy state + error banner (single-component scope)
+
+Add two `RwSignal`s inside `EventsManagement`:
+
+- `busy_event_id: RwSignal<Option<i64>>` — shared by both Delete and Clear; only one mutation in flight at a time per event
+- `action_error: RwSignal<Option<String>>` — last error text from either action; cleared on next attempt
+
+The two confirm callbacks become:
+
+1. Set `busy_event_id = Some(id)`, `action_error = None`
+2. `spawn_local` the API call
+3. On `Err(e)`: set `action_error = Some(format!("Delete failed: {e}"))`, do NOT refresh
+4. On `Ok(_)`: refresh `events_list` + `s3_usage`
+5. **Always** set `busy_event_id = None` at the end of the spawned task (regardless of outcome)
+
+The card UI (`settings.rs` lines ~593-621) gates on `busy_event_id.get() == Some(id)`:
+
+- When busy: render a `<span class="card-busy-text">"Deleting…"</span>` (or `"Clearing chunks…"`) in place of the action buttons, OR keep buttons visible but `disabled=true` with the same label change. Pick one — see "Implementation choice" below.
+- When not busy: render the existing two buttons unchanged.
+
+The error banner sits above the events list (next to / below the existing `s3-usage-banner`):
+
+- When `action_error.is_some()`: render an `error-message` div with the text + a small "×" button that sets `action_error = None`
+- When `None`: render nothing
+
+Modal closes immediately on confirm — same UX as today. The visible feedback lives on the card itself, which is where the user is already looking.
+
+### Implementation choice — disabled buttons vs. replacement text
+
+Use **disabled buttons + label change**. Reasons:
+
+1. Layout doesn't shift (button widths preserved → no card jitter)
+2. Reuses existing `disabled=is_streaming` infrastructure on the same buttons
+3. Single line of conditional: `disabled = is_streaming || busy`
+
+The disabled buttons get a CSS rule (`button:disabled` already covers most styling). Add an italic label change: `"Delete + Cleanup"` → `"Deleting…"` and `"Clear S3 chunks"` → `"Clearing…"` while busy.
+
+## Out of scope
+
+- **Modal-stays-open-with-spinner** (alternative B from brainstorming): more code, no measurable UX gain over the inline busy state.
+- **Toast/notification component infrastructure**: overkill for one error site. The single-element error banner pattern is already used elsewhere (`s3_usage_error` at lines 522-528).
+- **Backend changes**: backend is correct; problem is purely UI.
+- **Other action buttons** (Start Delivering, Stop, etc.): different surface, separate concerns. Issue #128 is specifically about Events-tab destructive actions.
+
+## Testing — TDD with Playwright
+
+`e2e/delete-cleanup-button.spec.ts` (new file). Two tests:
+
+### Test 1: success path
+
+1. Mock `GET /api/v1/events` → return one event `{id: 1, name: "test-event", receiving_activated: false, delivering_activated: false, ...}`
+2. Mock `GET /api/v1/s3/usage` → return `{total_bytes: 1000, total_objects: 5, by_event: [{event_name: "test-event", bytes: 1000, objects: 5}]}`
+3. Mock `DELETE /api/v1/events/1` → 1500ms artificial delay, then 204 No Content
+4. After the DELETE returns, mock `GET /api/v1/events` to return `[]` (event is gone)
+5. Navigate to `/settings`, click `Events` tab
+6. Click `Delete + Cleanup` → modal appears
+7. Click confirm in modal
+8. **Assert**: modal closes within 200ms
+9. **Assert**: `Delete + Cleanup` button label shows "Deleting…" and is disabled
+10. **Assert**: `Clear S3 chunks` button is disabled
+11. Wait until event card disappears (max 3s timeout)
+12. **Assert**: zero browser console errors per airuleset `browser-console-zero-errors`
+
+### Test 2: error path
+
+1. Same setup as Test 1, but mock `DELETE /api/v1/events/1` → 500 Internal Server Error after 500ms
+2. Navigate, click Delete + Cleanup, confirm
+3. Wait for the 500 to land
+4. **Assert**: an error banner appears containing the text "Delete failed"
+5. **Assert**: event card still present (not removed)
+6. **Assert**: action buttons re-enabled (not stuck in busy state)
+7. **Assert**: zero unhandled console errors (the 500 must be CAUGHT, not surfaced as an unhandled rejection)
+
+### Optional Test 3 (stretch): clear-S3 path
+
+Mirror Test 1 for the `Clear S3 chunks` button — confirms the same busy-state pattern applies to both actions. Can be added to the same spec file. If time-boxed, ship the two delete tests first.
+
+## File surface
+
+- `leptos-ui/src/components/settings.rs` — add busy/error signals, wire into UI, modify both confirm callbacks
+- `leptos-ui/styles/settings.css` (or wherever `.s3-usage-banner` lives) — `.action-error-banner` class if not reusing
+- `e2e/delete-cleanup-button.spec.ts` — new TDD spec
+- Version bump: `Cargo.toml`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `leptos-ui/Cargo.toml` (0.3.69 → 0.3.70)
+
+## Acceptance criteria
+
+- [ ] Playwright spec passes locally and in CI
+- [ ] On confirm of Delete + Cleanup: button immediately shows "Deleting…" and is disabled until the API call completes
+- [ ] On API error: error banner appears with the failure reason; event card remains; buttons re-enable
+- [ ] On API success: event removed from list; S3 usage refreshes; no error banner
+- [ ] Same behavior for Clear S3 chunks
+- [ ] Zero new browser console errors or warnings
+- [ ] CI green (all jobs including E2E + deploy)
+- [ ] Post-deploy verification on stream.lan via Playwright MCP confirms the new behavior on the live dashboard

--- a/e2e/delete-cleanup-button.spec.ts
+++ b/e2e/delete-cleanup-button.spec.ts
@@ -126,3 +126,61 @@ test("delete + cleanup shows error banner on API failure", async ({
   );
   expect(real).toEqual([]);
 });
+
+test("clear S3 chunks shows busy state and keeps event after success", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.addInitScript(tauriMockScript);
+  await request.post("http://127.0.0.1:8910/api/v1/__reset");
+
+  // Delay the clear-s3 POST so the busy state is observable.
+  await page.route("**/api/v1/events/1/clear-s3", async (route) => {
+    if (route.request().method() === "POST") {
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.continue();
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/settings");
+  await page.locator(".settings-tabs .tab", { hasText: "Events" }).click();
+
+  const card = page.locator(".settings-card", { hasText: TARGET_EVENT_NAME });
+  const clearBtn = card.locator("button.btn-secondary");
+  const deleteBtn = card.locator("button.btn-danger");
+
+  await expect(clearBtn).toBeEnabled();
+  await clearBtn.click();
+
+  // Confirm in the clear-s3 modal (same modal class, different confirm label
+  // text but same confirm-btn-danger selector).
+  await page.locator(".confirm-modal .confirm-btn-danger").click();
+
+  // Modal closes immediately
+  await expect(page.locator(".confirm-modal")).toHaveCount(0);
+
+  // Busy state: clear button label flips to "Clearing…", both card buttons disabled
+  await expect(clearBtn).toHaveText(/Clearing/, { timeout: 1000 });
+  await expect(clearBtn).toBeDisabled();
+  await expect(deleteBtn).toBeDisabled();
+
+  // After the delay + POST + s3_usage refresh, the card stays (clear does
+  // not remove the event), but the busy label clears.
+  await expect(clearBtn).toHaveText(/Clear S3 chunks/, { timeout: 5000 });
+  await expect(clearBtn).toBeEnabled();
+  await expect(card).toBeVisible();
+
+  const real = consoleMessages.filter(
+    (m) => !ALLOWED_CONSOLE.some((r) => r.test(m)),
+  );
+  expect(real).toEqual([]);
+});

--- a/e2e/delete-cleanup-button.spec.ts
+++ b/e2e/delete-cleanup-button.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+// Inject Tauri mock so the Leptos app runs in "Tauri mode" for invoke().
+const tauriMockScript = fs.readFileSync(
+  path.join(__dirname, "tauri-mock.js"),
+  "utf-8",
+);
+
+// Chromium-level warnings that are not application bugs.
+const ALLOWED_CONSOLE = [
+  /integrity.*attribute.*currently ignored.*subresource integrity/i,
+];
+
+// The mock-api seeds two events on /__reset; we target id=1 ("Sunday Service").
+const TARGET_EVENT_NAME = "Sunday Service";
+
+test("delete + cleanup shows busy state and removes event on success", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.addInitScript(tauriMockScript);
+  await request.post("http://127.0.0.1:8910/api/v1/__reset");
+
+  // Delay the DELETE response so the busy state is observable.
+  await page.route("**/api/v1/events/1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.continue();
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/settings");
+  await page.locator(".settings-tabs .tab", { hasText: "Events" }).click();
+
+  const card = page.locator(".settings-card", { hasText: TARGET_EVENT_NAME });
+  const deleteBtn = card.locator("button.btn-danger");
+  const clearBtn = card.locator("button.btn-secondary");
+
+  await expect(deleteBtn).toBeEnabled();
+  await deleteBtn.click();
+
+  // Confirm in modal
+  await page.locator(".confirm-modal .confirm-btn-danger").click();
+
+  // Modal closes immediately
+  await expect(page.locator(".confirm-modal")).toHaveCount(0);
+
+  // Busy state: label flips to "Deleting…", both card buttons disabled
+  await expect(deleteBtn).toHaveText(/Deleting/, { timeout: 1000 });
+  await expect(deleteBtn).toBeDisabled();
+  await expect(clearBtn).toBeDisabled();
+
+  // After the delay + DELETE + list refresh, the card is gone
+  await expect(card).toHaveCount(0, { timeout: 5000 });
+
+  const real = consoleMessages.filter(
+    (m) => !ALLOWED_CONSOLE.some((r) => r.test(m)),
+  );
+  expect(real).toEqual([]);
+});
+
+test("delete + cleanup shows error banner on API failure", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.addInitScript(tauriMockScript);
+  await request.post("http://127.0.0.1:8910/api/v1/__reset");
+
+  // Force a 500 response on DELETE
+  await page.route("**/api/v1/events/1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      await new Promise((r) => setTimeout(r, 200));
+      await route.fulfill({ status: 500, body: "internal server error" });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/settings");
+  await page.locator(".settings-tabs .tab", { hasText: "Events" }).click();
+
+  const card = page.locator(".settings-card", { hasText: TARGET_EVENT_NAME });
+  const deleteBtn = card.locator("button.btn-danger");
+
+  await deleteBtn.click();
+  await page.locator(".confirm-modal .confirm-btn-danger").click();
+
+  // Error banner appears with "Delete failed"
+  await expect(
+    page.locator(".error-message", { hasText: /Delete failed/i }),
+  ).toBeVisible({ timeout: 3000 });
+
+  // Event card still present
+  await expect(card).toBeVisible();
+
+  // Button re-enabled and label restored
+  await expect(deleteBtn).toBeEnabled();
+  await expect(deleteBtn).toHaveText(/Delete \+ Cleanup/);
+
+  // Filter out the expected 500-response noise from console.
+  // The application MUST handle the error gracefully — the only allowed
+  // console output is fetch's own network logging for the 500.
+  const real = consoleMessages.filter(
+    (m) =>
+      !ALLOWED_CONSOLE.some((r) => r.test(m)) &&
+      !/500/.test(m) &&
+      !/Failed to load/i.test(m),
+  );
+  expect(real).toEqual([]);
+});

--- a/e2e/delete-cleanup-button.spec.ts
+++ b/e2e/delete-cleanup-button.spec.ts
@@ -184,3 +184,58 @@ test("clear S3 chunks shows busy state and keeps event after success", async ({
   );
   expect(real).toEqual([]);
 });
+
+test("clear S3 chunks shows error banner on API failure", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.addInitScript(tauriMockScript);
+  await request.post("http://127.0.0.1:8910/api/v1/__reset");
+
+  // Force a 500 response on the clear-s3 POST
+  await page.route("**/api/v1/events/1/clear-s3", async (route) => {
+    if (route.request().method() === "POST") {
+      await new Promise((r) => setTimeout(r, 200));
+      await route.fulfill({ status: 500, body: "internal server error" });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/settings");
+  await page.locator(".settings-tabs .tab", { hasText: "Events" }).click();
+
+  const card = page.locator(".settings-card", { hasText: TARGET_EVENT_NAME });
+  const clearBtn = card.locator("button.btn-secondary");
+
+  await clearBtn.click();
+  await page.locator(".confirm-modal .confirm-btn-danger").click();
+
+  // Error banner appears with "Clear failed"
+  await expect(
+    page.locator(".error-message", { hasText: /Clear failed/i }),
+  ).toBeVisible({ timeout: 3000 });
+
+  // Event card still present
+  await expect(card).toBeVisible();
+
+  // Button re-enabled and label restored
+  await expect(clearBtn).toBeEnabled();
+  await expect(clearBtn).toHaveText(/Clear S3 chunks/);
+
+  // Filter out the expected 500-response noise from console.
+  const real = consoleMessages.filter(
+    (m) =>
+      !ALLOWED_CONSOLE.some((r) => r.test(m)) &&
+      !/500/.test(m) &&
+      !/Failed to load/i.test(m),
+  );
+  expect(real).toEqual([]);
+});

--- a/e2e/playwright-frontend.config.ts
+++ b/e2e/playwright-frontend.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   // `start-delivery-rtmp-gate` was removed — the RTMP-stable gate is
   // verified by backend unit tests (`rs-api/src/router_tests.rs`) and
   // the E2E version keeps hitting parallel-worker shared-state races.
-  testMatch: /(frontend|audit-panel|zero-endpoint-banner|remove-last-endpoint-modal|endpoint-history-sparkline|cache-drift-panel)\.spec\.ts$/,
+  testMatch: /(frontend|audit-panel|zero-endpoint-banner|remove-last-endpoint-modal|endpoint-history-sparkline|cache-drift-panel|delete-cleanup-button)\.spec\.ts$/,
   timeout: 30000,
   retries: 0,
   // Single worker — the new post-mortem specs (audit-panel,

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.3.69"
+version = "0.3.70"
 edition = "2024"
 license = "MIT"
 

--- a/leptos-ui/src/components/settings.rs
+++ b/leptos-ui/src/components/settings.rs
@@ -531,8 +531,7 @@ fn EventsManagement() -> impl IntoView {
                 <div class="error-message">
                     {err}
                     <button
-                        class="modal-cancel-btn"
-                        style="margin-left: var(--spacing-md);"
+                        class="banner-dismiss-btn"
                         on:click=move |_| action_error.set(None)
                     >
                         "×"

--- a/leptos-ui/src/components/settings.rs
+++ b/leptos-ui/src/components/settings.rs
@@ -464,11 +464,26 @@ fn EventsManagement() -> impl IntoView {
         spawn_local(async move {
             match api::delete_event(id).await {
                 Ok(_) => {
-                    if let Ok(events) = api::list_events().await {
-                        store.events_list.set(events);
+                    // Refresh both views; surface the FIRST refresh failure so
+                    // the operator knows the underlying delete succeeded but
+                    // the UI may be stale and a reload is needed.
+                    let mut refresh_err: Option<String> = None;
+                    match api::list_events().await {
+                        Ok(events) => store.events_list.set(events),
+                        Err(e) => refresh_err = Some(e),
                     }
-                    if let Ok(u) = api::get_s3_usage().await {
-                        s3_usage.set(Some(u));
+                    match api::get_s3_usage().await {
+                        Ok(u) => s3_usage.set(Some(u)),
+                        Err(e) => {
+                            if refresh_err.is_none() {
+                                refresh_err = Some(e);
+                            }
+                        }
+                    }
+                    if let Some(e) = refresh_err {
+                        action_error.set(Some(format!(
+                            "Event deleted but UI refresh failed: {e}. Reload the page."
+                        )));
                     }
                 }
                 Err(e) => action_error.set(Some(format!("Delete failed: {e}"))),
@@ -484,8 +499,14 @@ fn EventsManagement() -> impl IntoView {
         spawn_local(async move {
             match api::clear_event_s3_chunks(id).await {
                 Ok(_) => {
-                    if let Ok(u) = api::get_s3_usage().await {
-                        s3_usage.set(Some(u));
+                    // Surface S3 usage refresh failures: the chunks ARE cleared
+                    // but the banner numbers will be stale until reload, which
+                    // could mislead the operator into thinking the clear failed.
+                    match api::get_s3_usage().await {
+                        Ok(u) => s3_usage.set(Some(u)),
+                        Err(e) => action_error.set(Some(format!(
+                            "Chunks cleared but S3 usage refresh failed: {e}. Reload the page."
+                        ))),
                     }
                 }
                 Err(e) => action_error.set(Some(format!("Clear failed: {e}"))),

--- a/leptos-ui/src/components/settings.rs
+++ b/leptos-ui/src/components/settings.rs
@@ -425,6 +425,15 @@ fn EventsManagement() -> impl IntoView {
     let s3_usage = RwSignal::<Option<api::S3UsageResponse>>::new(None);
     let s3_usage_error = RwSignal::<Option<String>>::new(None);
 
+    // Busy and error state for destructive actions on event cards.
+    // `busy_event_id` is `Some(id)` while a delete or clear-S3 call is
+    // in flight for that event; the buttons on that card render disabled
+    // with a "Deleting…"/"Clearing…" label so the operator sees progress.
+    // `action_error` holds the most recent failure message from either
+    // action so it can render in a banner above the list.
+    let busy_event_id = RwSignal::<Option<i64>>::new(None);
+    let action_error = RwSignal::<Option<String>>::new(None);
+
     // Template picker modal state
     let show_template_modal = RwSignal::new(false);
     let (template_error, set_template_error) = signal::<Option<String>>(None);
@@ -450,24 +459,38 @@ fn EventsManagement() -> impl IntoView {
 
     let on_confirm_delete = Callback::new(move |_: ()| {
         let id = delete_target_id.get();
+        busy_event_id.set(Some(id));
+        action_error.set(None);
         spawn_local(async move {
-            let _ = api::delete_event(id).await;
-            if let Ok(events) = api::list_events().await {
-                store.events_list.set(events);
+            match api::delete_event(id).await {
+                Ok(_) => {
+                    if let Ok(events) = api::list_events().await {
+                        store.events_list.set(events);
+                    }
+                    if let Ok(u) = api::get_s3_usage().await {
+                        s3_usage.set(Some(u));
+                    }
+                }
+                Err(e) => action_error.set(Some(format!("Delete failed: {e}"))),
             }
-            if let Ok(u) = api::get_s3_usage().await {
-                s3_usage.set(Some(u));
-            }
+            busy_event_id.set(None);
         });
     });
 
     let on_confirm_clear = Callback::new(move |_: ()| {
         let id = clear_target_id.get();
+        busy_event_id.set(Some(id));
+        action_error.set(None);
         spawn_local(async move {
-            let _ = api::clear_event_s3_chunks(id).await;
-            if let Ok(u) = api::get_s3_usage().await {
-                s3_usage.set(Some(u));
+            match api::clear_event_s3_chunks(id).await {
+                Ok(_) => {
+                    if let Ok(u) = api::get_s3_usage().await {
+                        s3_usage.set(Some(u));
+                    }
+                }
+                Err(e) => action_error.set(Some(format!("Clear failed: {e}"))),
             }
+            busy_event_id.set(None);
         });
     });
 
@@ -501,6 +524,21 @@ fn EventsManagement() -> impl IntoView {
                     "+ New from Template"
                 </button>
             </div>
+
+            // Action error banner — surfaces the most recent failure from
+            // delete/clear actions. Dismissable with the "×" button.
+            {move || action_error.get().map(|err| view! {
+                <div class="error-message">
+                    {err}
+                    <button
+                        class="modal-cancel-btn"
+                        style="margin-left: var(--spacing-md);"
+                        on:click=move |_| action_error.set(None)
+                    >
+                        "×"
+                    </button>
+                </div>
+            })}
 
             // S3 storage usage banner. Shows total bucket usage and lets the
             // operator see at a glance which event is using the most space.
@@ -593,7 +631,7 @@ fn EventsManagement() -> impl IntoView {
                                 <div class="card-actions">
                                     <button
                                         class="btn-secondary"
-                                        disabled=is_streaming
+                                        disabled=move || is_streaming || busy_event_id.get() == Some(id)
                                         on:click=move |_| {
                                             clear_target_id.set(id);
                                             clear_target_name.set(name_for_clear.clone());
@@ -601,21 +639,31 @@ fn EventsManagement() -> impl IntoView {
                                         }
                                         title="Delete S3 chunks for this event but keep the event row"
                                     >
-                                        "Clear S3 chunks"
+                                        {move || {
+                                            if busy_event_id.get() == Some(id) {
+                                                "Clearing…"
+                                            } else {
+                                                "Clear S3 chunks"
+                                            }
+                                        }}
                                     </button>
                                     <button
                                         class="btn-danger"
-                                        disabled=is_streaming
+                                        disabled=move || is_streaming || busy_event_id.get() == Some(id)
                                         on:click=move |_| {
                                             delete_target_id.set(id);
                                             delete_target_name.set(name_for_modal.clone());
                                             show_delete_modal.set(true);
                                         }
                                     >
-                                        {if is_streaming {
-                                            "Delete (stop stream first)"
-                                        } else {
-                                            "Delete + Cleanup"
+                                        {move || {
+                                            if is_streaming {
+                                                "Delete (stop stream first)"
+                                            } else if busy_event_id.get() == Some(id) {
+                                                "Deleting…"
+                                            } else {
+                                                "Delete + Cleanup"
+                                            }
                                         }}
                                     </button>
                                 </div>

--- a/leptos-ui/src/components/settings.rs
+++ b/leptos-ui/src/components/settings.rs
@@ -608,6 +608,11 @@ fn EventsManagement() -> impl IntoView {
                         let name = evt.name.clone();
                         let recv = evt.receiving_activated;
                         let deliv = evt.delivering_activated;
+                        // Snapshot-at-render: this bool is captured by value
+                        // into the per-card reactive closures below. If a
+                        // future WebSocket push updates streaming state without
+                        // rebuilding `events_list`, those closures would read a
+                        // stale value — re-fetch the events list on such pushes.
                         let is_streaming = recv || deliv;
                         let created_from = evt.created_from.clone();
                         let name_for_modal = name.clone();

--- a/leptos-ui/style.css
+++ b/leptos-ui/style.css
@@ -318,6 +318,12 @@ h1 { font-size: 1.1rem; font-weight: 600; margin: 0; }
     border-radius: var(--radius); background: transparent; color: var(--text-secondary);
     cursor: pointer; font-family: var(--font-mono); font-size: 12px;
 }
+.banner-dismiss-btn {
+    padding: var(--spacing-xs) var(--spacing-sm); border: 1px solid var(--border);
+    border-radius: var(--radius); background: transparent; color: var(--text-secondary);
+    cursor: pointer; font-family: var(--font-mono); font-size: 12px;
+    margin-left: var(--spacing-md);
+}
 
 /* Confirm Modal (reusable danger confirmation) */
 .confirm-modal {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.3.69"
+version = "0.3.70"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Add `busy_event_id` + `action_error` `RwSignal`s to `EventsManagement`; both confirm callbacks now flip these signals around the async API call instead of fire-and-forget with swallowed errors.
- Per-card `Clear S3 chunks` and `Delete + Cleanup` buttons render disabled with `Clearing…` / `Deleting…` labels while their event's mutation is in flight.
- A dismissable `.error-message` banner above the events list surfaces the failure reason if the API returns non-2xx.
- Backend untouched — issue was purely UI feedback.

Closes #128

## Test plan
- [x] CI Frontend E2E: 3 new Playwright tests in `e2e/delete-cleanup-button.spec.ts` (delete success, delete error, clear-s3 success) — green
- [x] CI E2E Streaming Test (real RTMP → S3 → Hetzner VPS pipeline) — green
- [x] CI E2E OBS-to-YouTube Test (full live stream → YouTube ingest) — green
- [x] CI Deploy-to-stream-lan — green (Restreamer.exe v0.3.70 running on stream.lan)
- [ ] Post-deploy functional verification on stream.lan via Playwright MCP after PR CI completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)