### PR TITLE
ci: burst-poll for chunk snapshot in audio cadence gate (follow-up to PR #144)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1423,13 +1423,30 @@ jobs:
 
             # Snapshot one chunk for the audio cadence gate while files
             # still exist on disk -- the uploader deletes each chunk
-            # after S3 upload (rs-endpoint/uploader.rs ~line 402).
-            if ($elapsed -ge 60 -and -not (Test-Path "$env:TEMP\audio-test-chunk.bin")) {
-              $latestChunk = Get-ChildItem "C:\ProgramData\Restreamer\chunks\" -File -ErrorAction SilentlyContinue |
-                             Sort-Object LastWriteTime -Descending | Select-Object -First 1
-              if ($latestChunk) {
-                Copy-Item $latestChunk.FullName "$env:TEMP\audio-test-chunk.bin" -Force
-                Write-Host "Audio gate snapshot: $($latestChunk.Name) ($($latestChunk.Length) bytes) -> $env:TEMP\audio-test-chunk.bin"
+            # after S3 upload (rs-endpoint/uploader.rs ~line 402), and
+            # under low Hetzner latency the local-disk window is <50ms
+            # per chunk. Burst-poll up to 3s with 30ms gaps to reliably
+            # catch a transient file. Read bytes into memory before
+            # writing so a mid-read deletion can be retried instead of
+            # producing a corrupt snapshot.
+            if ($elapsed -ge 30 -and -not (Test-Path "$env:TEMP\audio-test-chunk.bin")) {
+              for ($attempt = 0; $attempt -lt 100; $attempt++) {
+                $latestChunk = Get-ChildItem "C:\ProgramData\Restreamer\chunks\" -File -ErrorAction SilentlyContinue |
+                               Sort-Object LastWriteTime -Descending | Select-Object -First 1
+                if ($latestChunk) {
+                  try {
+                    $bytes = [System.IO.File]::ReadAllBytes($latestChunk.FullName)
+                    [System.IO.File]::WriteAllBytes("$env:TEMP\audio-test-chunk.bin", $bytes)
+                    Write-Host "Audio gate snapshot at ${elapsed}s after $($attempt + 1) attempt(s): $($latestChunk.Name) ($($bytes.Length) bytes)"
+                    break
+                  } catch {
+                    # File got pruned between Get-ChildItem and ReadAllBytes -- retry.
+                  }
+                }
+                Start-Sleep -Milliseconds 30
+              }
+              if (-not (Test-Path "$env:TEMP\audio-test-chunk.bin")) {
+                Write-Host "Audio gate snapshot: no chunk caught at ${elapsed}s after 100 attempts (uploader may be saturating local disk); will retry next loop iteration"
               }
             }
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1439,8 +1439,9 @@ jobs:
                     [System.IO.File]::WriteAllBytes("$env:TEMP\audio-test-chunk.bin", $bytes)
                     Write-Host "Audio gate snapshot at ${elapsed}s after $($attempt + 1) attempt(s): $($latestChunk.Name) ($($bytes.Length) bytes)"
                     break
-                  } catch {
-                    # File got pruned between Get-ChildItem and ReadAllBytes -- retry.
+                  } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException], [System.UnauthorizedAccessException] {
+                    # File pruned between Get-ChildItem and ReadAllBytes (FNF / DNF)
+                    # or briefly locked by uploader (UnauthorizedAccess) -- retry.
                   }
                 }
                 Start-Sleep -Milliseconds 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.3.71"
+version = "0.3.72"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-inpoint/src/flv_chunker.rs
+++ b/crates/rs-inpoint/src/flv_chunker.rs
@@ -251,10 +251,11 @@ impl FlvChunkSink {
     ///
     /// `timestamp` is the xiu-forwarded RTMP timestamp (in milliseconds).
     /// Audio uses xiu timestamps directly — unlike video, which is rewritten
-    /// to wall-clock to fix #135 cache drift. AAC frames have fixed cadence
-    /// (1024 samples / 48000 Hz = 21.333 ms), so the producer cannot drift,
-    /// and wall-clock stamping introduces RTMP delivery jitter into PTS,
-    /// causing decoder resampling artefacts (chipmunk pitch + glitches).
+    /// to wall-clock to fix #135 cache drift. AAC frames are 1024 samples;
+    /// cadence = 1024 / sample_rate seconds (e.g. 21.3 ms at 48 kHz, 23.2 ms
+    /// at 44.1 kHz), so the producer cannot drift. Wall-clock stamping would
+    /// inject RTMP delivery jitter into PTS, causing decoder resampling
+    /// artefacts (chipmunk pitch + glitches).
     pub async fn write_audio(&self, timestamp: u32, data: &BytesMut) {
         let is_sequence_header = data.len() > 1 && (data[0] >> 4) == 0x0A && data[1] == 0x00;
 
@@ -922,10 +923,11 @@ mod tests {
     }
 
     /// Audio FLV tags must carry the xiu-supplied RTMP timestamp verbatim,
-    /// not a wall-clock-derived value. AAC at 48 kHz has fixed-cadence frames
-    /// (1024 samples / 48000 Hz = 21.333 ms). Wall-clock stamping introduces
-    /// RTMP jitter into PTS, which the downstream decoder interprets as
-    /// resampling cues — producing chipmunk pitch shift and glitches.
+    /// not a wall-clock-derived value. AAC frames are 1024 samples; cadence
+    /// = 1024 / sample_rate seconds (e.g. 21.3 ms at 48 kHz, 23.2 ms at
+    /// 44.1 kHz). Wall-clock stamping introduces RTMP jitter into PTS,
+    /// which the downstream decoder interprets as resampling cues —
+    /// producing chipmunk pitch shift and glitches.
     /// Regression test for the live-event failure on 2026-04-26.
     #[tokio::test]
     async fn audio_uses_xiu_timestamp_not_wall_clock() {

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -13,7 +13,7 @@ Procedures for running live events with restreamer. Keep this file short — one
   If any of these fail — **do not go live.** Escalate to engineering. The 2026-04-26 live event was lost because this check was skipped after a restreamer version upgrade and audio was unusable from the start.
 
 - [ ] **Dashboard liveness:**
-  Open the dashboard. Confirm the deployed version banner matches the version you intended to run. Confirm the inpoint shows `disconnected` (no leftover stream) and there are no error banners.
+  Open the dashboard at <http://10.77.9.204:8910/>. Confirm the deployed version banner matches the version you intended to run. Confirm the inpoint shows `disconnected` (no leftover stream) and there are no error banners.
 
 - [ ] **No active leftover events:**
   On the dashboard's Events tab, confirm no event other than the one you are about to use shows `receiving_activated` or `delivering_activated`. Deactivate any leftovers.

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.3.71"
+version = "0.3.72"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.3.71"
+version = "0.3.72"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.3.71",
+  "version": "0.3.72",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Follow-up to PR #144 (audio chipmunk fix). The audio cadence gate added in #144 used a one-shot snapshot of the first chunk file it found in \`C:\\ProgramData\\Restreamer\\chunks\\\`. Worked twice on dev runs by lucky timing; failed on the main-branch CI run (24965872742) immediately after merge because the S3 uploader holds \`pending_chunks=0\` throughout streaming -- the local-disk window per chunk is <50 ms, and the snapshot just missed every chunk.

The audio fix in v0.3.71 itself is correct and is live on stream.lan; only the CI gate that validates it was racy.

## Changes

- Burst-poll the chunks directory up to 100 attempts at 30 ms intervals (3 s window) per outer-loop iteration starting at \`elapsed >= 30s\`.
- Use \`[System.IO.File]::ReadAllBytes\` + \`WriteAllBytes\` so a mid-read prune produces a catchable exception we retry from, instead of writing a truncated snapshot.
- Diagnostic \`Write-Host\` on failure surfaces 'no chunk caught' so the next outer-iteration retry is visible in the log.

## CI evidence (run 24966569926, dev)

\`\`\`
Audio gate snapshot at 30s after 24 attempt(s): chunk_1777238534397_000057.bin (73127 bytes)
Audio sample rate:    44100 Hz
Expected AAC cadence: 23.22 ms (1024 samples / 44100 Hz)
Audio packet count:   43
Audio delta median:   23 ms
Audio delta max:      24 ms
=== Audio PTS cadence GATE PASSED ===
clear-s3 elapsed: 4.3384927s, deleted: 375
=== clear-s3 GATE PASSED: 4.3384927s for 375 objects ===
\`\`\`

24 attempts to catch a transient file at 30 ms each = ~720 ms wall time before a hit. With chunks arriving every ~1.5 s, this is consistent with the expected probability model (~3% per attempt, P(catch at least one in 100) ~ 95%).

## Test plan

- [x] Dev CI green (run 24966569926 -- audio gate caught a chunk and passed; clear-s3 gate also passed)
- [ ] PR CI green
- [ ] After merge: main CI green; v0.3.72 auto-release fires

## Note on v0.3.71

The v0.3.71 binary (audio fix) is live on stream.lan but its GitHub Release was skipped because main CI failed on the now-fixed gate. v0.3.72 includes the same audio fix plus this gate fix, so it supersedes v0.3.71 for fresh-install purposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)