### PR TITLE
fix(ci): scope post-deactivation YT check to e2e rtmp title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4478,15 +4478,19 @@ jobs:
                 }
               }
 
-              if (-not $response.stream_receiving) {
+              # Scope to e2e rtmp specifically -- default OAuth account owns
+              # multiple streams; other titles (operator OBS testing, parallel
+              # production traffic) must not gate the CI deactivation check.
+              $e2e = $response.streams | Where-Object { $_.title -eq "e2e rtmp" }
+              if (-not $e2e -or $e2e.stream_status -ne "active") {
                 Write-Host "=========================================="
-                Write-Host "  YOUTUBE CONFIRMED NOT RECEIVING (post-deactivation)"
+                Write-Host "  YOUTUBE CONFIRMED NOT RECEIVING for e2e rtmp (post-deactivation)"
                 Write-Host "  3-phase lifecycle verified: inactive -> active -> inactive"
                 Write-Host "=========================================="
                 return
               }
 
-              Write-Host "  YouTube still receiving stream data"
+              Write-Host "  e2e rtmp stream still active on YouTube"
             } catch {
               Write-Host "  Request failed: $_"
             }
@@ -4497,7 +4501,7 @@ jobs:
             }
           }
 
-          throw "FAILED: YouTube is still receiving stream data after deactivation ($maxRetries attempts, ~$($maxRetries * $retryDelay)s). Deactivation did not stop delivery to YouTube."
+          throw "FAILED: e2e rtmp stream still active on YouTube after deactivation ($maxRetries attempts, ~$($maxRetries * $retryDelay)s). Deactivation did not stop delivery to YouTube."
 
       - name: Restore OBS scene
         if: always()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- CI's post-deactivation YT-stopped-receiving check used \`\$response.stream_receiving\` (true if ANY stream in default account active). Operator OBS testing + parallel production traffic could legit hold "any-stream-active" → check timed out at 12 retries × 15s = 180s.
- Scope check to title == "e2e rtmp" specifically. Mirrors the baseline check fix (commit 38a1a82) from PR #198.

Related: #197

## Test plan
- [x] cargo fmt + clippy + tests green
- [x] Full CI green on dev (push run 25852XXX including 15-min sustained gate + post-deactivation check on rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)