### PR TITLE
Bundle: fix #202 + #201 + #200 + #179 (cleanups + pagination + security)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2999,11 +2999,52 @@ jobs:
 
           # Target the e2e-rtmp specific stream by title -- the default OAuth
           # account may legitimately own other streams that are active (user
-          # OBS testing, parallel production traffic). Only fail if the
-          # specific CI test stream key is already active.
+          # OBS testing, parallel production traffic). When this CI test key
+          # is already active we must distinguish two cases:
+          #   1. Stuck previous run     -- prior CI run's DeliveryStopped was
+          #                                >10 min ago and the stream is still
+          #                                live. That's our residue; throw.
+          #   2. Operator collision     -- recent DeliveryStopped (or none at
+          #                                all in the window) means our last
+          #                                run cleaned up and the active
+          #                                stream is operator OBS testing.
+          #                                Warn and continue; post-delivery
+          #                                health check still validates the
+          #                                round-trip. Issue #201.
           $e2e = $response.streams | Where-Object { $_.title -eq "e2e rtmp" }
           if ($e2e -and $e2e.stream_status -eq "active") {
-            Write-Warning "e2e rtmp stream shows active at baseline -- previous run did not shut down cleanly OR operator testing collision. Continuing; post-delivery health check still validates the round-trip."
+            try {
+              $audit = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/audit?action=DeliveryStopped&limit=1" -TimeoutSec 10
+              $latestStop = $audit.rows | Select-Object -First 1
+            } catch {
+              Write-Warning "audit query for DeliveryStopped failed: $_ -- treating as operator collision"
+              $latestStop = $null
+            }
+
+            $nowUtc = [DateTime]::UtcNow
+            $stuckThresholdMin = 10
+            $isStuck = $false
+
+            if ($latestStop) {
+              try {
+                $stopTs = [DateTime]::Parse($latestStop.ts, $null, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
+                $ageMin = ($nowUtc - $stopTs).TotalMinutes
+                Write-Host "Latest DeliveryStopped: ts=$($latestStop.ts) age=${ageMin}min"
+                if ($ageMin -gt $stuckThresholdMin) {
+                  $isStuck = $true
+                }
+              } catch {
+                Write-Warning "could not parse DeliveryStopped ts '$($latestStop.ts)': $_ -- treating as operator collision"
+              }
+            } else {
+              Write-Host "No DeliveryStopped audit row -- treating as operator collision (or fresh install)"
+            }
+
+            if ($isStuck) {
+              throw "BASELINE FAILED: e2e rtmp stream still active AND latest DeliveryStopped is >$stuckThresholdMin min old. Previous CI run did not shut down cleanly -- investigate before retrying."
+            } else {
+              Write-Warning "e2e rtmp stream shows active at baseline -- recent DeliveryStopped or none, treating as operator OBS testing collision. Continuing; post-delivery health check still validates the round-trip."
+            }
           } else {
             Write-Host "=== Baseline PASSED: e2e rtmp stream is not active ==="
           }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-api/src/diag.rs
+++ b/crates/rs-api/src/diag.rs
@@ -334,3 +334,87 @@ mod tests {
         assert!(dump["audit_60min"].is_array());
     }
 }
+
+#[cfg(test)]
+mod loopback_tests {
+    //! Issue #179 — /api/v1/diag/dump must refuse non-loopback callers.
+    //! The dump exposes the audit log and endpoint state; only the local
+    //! operator (127.0.0.1 / ::1) is allowed to read it.
+
+    use crate::router::build_router;
+    use crate::state::AppState;
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::{Request, StatusCode};
+    use rs_core::config::Config;
+    use rs_core::models::WsEvent;
+    use std::net::SocketAddr;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    async fn test_state() -> AppState {
+        let pool = rs_core::db::create_memory_pool().await.unwrap();
+        rs_core::db::run_migrations(&pool).await.unwrap();
+        let config = Config::for_testing();
+        let (ws_tx, _) = broadcast::channel::<WsEvent>(16);
+        AppState::new_for_tests(pool, config, ws_tx)
+    }
+
+    fn req_with_peer(peer: &str) -> Request<Body> {
+        let addr: SocketAddr = peer.parse().unwrap();
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/diag/dump")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(addr));
+        req
+    }
+
+    #[tokio::test]
+    async fn diag_dump_rejects_non_loopback_ipv4() {
+        let app = build_router(test_state().await);
+        let resp = app.oneshot(req_with_peer("8.8.8.8:65432")).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "non-loopback 8.8.8.8 must be denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn diag_dump_rejects_lan_peer() {
+        let app = build_router(test_state().await);
+        let resp = app
+            .oneshot(req_with_peer("10.77.9.42:54000"))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "LAN peer 10.77.9.42 must be denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn diag_dump_accepts_loopback_ipv4() {
+        let app = build_router(test_state().await);
+        let resp = app.oneshot(req_with_peer("127.0.0.1:54321")).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "loopback 127.0.0.1 must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn diag_dump_accepts_loopback_ipv6() {
+        let app = build_router(test_state().await);
+        let resp = app.oneshot(req_with_peer("[::1]:54321")).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "loopback ::1 must be allowed"
+        );
+    }
+}

--- a/crates/rs-api/src/diag.rs
+++ b/crates/rs-api/src/diag.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{ConnectInfo, State};
 use futures::future::BoxFuture;
 use serde_json::{Value, json};
 use sqlx::SqlitePool;
@@ -169,20 +169,25 @@ pub async fn build_dump<S: DumpSources>(sources: &S) -> Value {
     })
 }
 
-// TODO #176-followup: enforce loopback-only access on /diag/dump
-// ConnectInfo<SocketAddr> requires into_make_service_with_connect_info at the
-// server bind site (crates/rs-api/src/lib.rs::serve). The current server uses
-// axum::serve(listener, app) without connect-info plumbing, so the extractor
-// is unavailable. See GitHub issue "Enforce loopback-only on /api/v1/diag/dump
-// (#176 follow-up)" for the tracking item.
-pub async fn diag_dump_handler(State(state): State<AppState>) -> Json<Value> {
+/// Refuses non-loopback callers. The dump exposes the audit log and
+/// endpoint state; only the local operator (127.0.0.1 / ::1) is allowed
+/// to read it. `lib.rs::serve` wires the request peer address via
+/// `into_make_service_with_connect_info::<SocketAddr>()`. Issue #179.
+pub async fn diag_dump_handler(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+) -> Result<Json<Value>, axum::http::StatusCode> {
+    if !addr.ip().is_loopback() {
+        tracing::warn!("/diag/dump refused: peer {addr} is not loopback");
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
     let event_id = current_event_id_from_state(&state).await;
     let sources = ProductionSources {
         pool: state.pool.clone(),
         event_id,
         orchestrator: state.delivery_orchestrator.clone(),
     };
-    Json(build_dump(&sources).await)
+    Ok(Json(build_dump(&sources).await))
 }
 
 /// Best-effort accessor: returns the most-recent active streaming event

--- a/crates/rs-api/src/lib.rs
+++ b/crates/rs-api/src/lib.rs
@@ -195,7 +195,10 @@ pub async fn serve(
     info!("API server listening on {local_addr}");
 
     let handle = tokio::spawn(async move {
-        if let Err(e) = axum::serve(listener, app).await {
+        // Wire ConnectInfo<SocketAddr> so handlers (e.g. /diag/dump per
+        // issue #179) can refuse non-loopback callers.
+        let make_service = app.into_make_service_with_connect_info::<std::net::SocketAddr>();
+        if let Err(e) = axum::serve(listener, make_service).await {
             tracing::error!("API server error: {e}");
         }
     });

--- a/crates/rs-api/src/lib.rs
+++ b/crates/rs-api/src/lib.rs
@@ -174,8 +174,11 @@ pub async fn serve(
 
             let https_app = app.clone();
             tokio::spawn(async move {
+                // Same ConnectInfo<SocketAddr> wiring as the HTTP listener
+                // below (issue #179) so /diag/dump returns 403, not 500,
+                // on the HTTPS path too.
                 if let Err(e) = axum_server::bind_rustls(https_addr, tls_config)
-                    .serve(https_app.into_make_service())
+                    .serve(https_app.into_make_service_with_connect_info::<std::net::SocketAddr>())
                     .await
                 {
                     tracing::error!("HTTPS server error: {e}");

--- a/crates/rs-youtube/src/device_flow.rs
+++ b/crates/rs-youtube/src/device_flow.rs
@@ -24,7 +24,6 @@ pub enum PollResponse {
         access_token: String,
         refresh_token: String,
         expires_in: Option<i64>,
-        id_token: Option<String>,
     },
     Error(String),
 }
@@ -39,7 +38,6 @@ pub enum PollDecision {
         access_token: String,
         refresh_token: String,
         expires_in: Option<i64>,
-        id_token: Option<String>,
     },
     TerminalError(String),
 }
@@ -73,7 +71,6 @@ struct TokenSuccess {
     access_token: String,
     refresh_token: Option<String>,
     expires_in: Option<i64>,
-    id_token: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -111,7 +108,6 @@ pub async fn poll_token(
             access_token: ts.access_token,
             refresh_token,
             expires_in: ts.expires_in,
-            id_token: ts.id_token,
         });
     }
 
@@ -137,12 +133,10 @@ pub fn poll_decision(resp: &PollResponse) -> PollDecision {
             access_token,
             refresh_token,
             expires_in,
-            id_token,
         } => PollDecision::TerminalGranted {
             access_token: access_token.clone(),
             refresh_token: refresh_token.clone(),
             expires_in: *expires_in,
-            id_token: id_token.clone(),
         },
         PollResponse::Error(e) => PollDecision::TerminalError(e.clone()),
     }

--- a/crates/rs-youtube/src/device_flow_tests.rs
+++ b/crates/rs-youtube/src/device_flow_tests.rs
@@ -41,7 +41,6 @@ fn poll_decision_granted_is_terminal_with_tokens() {
         access_token: "AT".into(),
         refresh_token: "RT".into(),
         expires_in: Some(3600),
-        id_token: None,
     });
     match dec {
         PollDecision::TerminalGranted {

--- a/crates/rs-youtube/src/lib.rs
+++ b/crates/rs-youtube/src/lib.rs
@@ -55,3 +55,5 @@ mod device_flow_tests;
 mod quota_tests;
 #[cfg(test)]
 mod streams_for_label_tests;
+#[cfg(test)]
+mod streams_pagination_tests;

--- a/crates/rs-youtube/src/lib.rs
+++ b/crates/rs-youtube/src/lib.rs
@@ -57,3 +57,5 @@ mod quota_tests;
 mod streams_for_label_tests;
 #[cfg(test)]
 mod streams_pagination_tests;
+#[cfg(test)]
+mod test_env;

--- a/crates/rs-youtube/src/streams.rs
+++ b/crates/rs-youtube/src/streams.rs
@@ -84,7 +84,17 @@ pub struct ConfigurationIssue {
 #[derive(Debug, Deserialize)]
 struct ListResponse<T> {
     items: Vec<T>,
+    #[serde(default, rename = "nextPageToken")]
+    next_page_token: Option<String>,
 }
+
+/// Hard caps on pagination to protect against runaway quota burn on a
+/// misbehaving server (e.g., one that returns the same `nextPageToken`
+/// forever). 10 pages × 50 items = 500 covers every realistic YouTube
+/// account; anything beyond is logged with `warn!` and truncated. See
+/// issue #200.
+const MAX_PAGES: usize = 10;
+const MAX_ITEMS: usize = 500;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LiveBroadcast {
@@ -104,31 +114,11 @@ pub struct BroadcastStatus {
     pub life_cycle_status: String,
 }
 
-/// List live streams (mine=True) to check stream health.
+/// List live streams (mine=True) to check stream health. Follows
+/// `nextPageToken` up to `MAX_PAGES` / `MAX_ITEMS`; emits a `warn!` if
+/// the cap kicks in. Issue #200.
 pub async fn list_live_streams(access_token: &str) -> Result<Vec<LiveStream>> {
-    let client = Client::new();
-    let resp = client
-        .get(format!("{}/liveStreams", youtube_api_base()))
-        .bearer_auth(access_token)
-        .query(&[
-            ("part", "id,snippet,status,cdn"),
-            ("mine", "true"),
-            ("maxResults", "50"),
-        ])
-        .send()
-        .await?;
-
-    if !resp.status().is_success() {
-        let status = resp.status().as_u16();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(YouTubeError::Api {
-            status,
-            message: body,
-        });
-    }
-
-    let body: ListResponse<LiveStream> = resp.json().await?;
-    Ok(body.items)
+    paginate(access_token, "liveStreams", "id,snippet,status,cdn").await
 }
 
 /// Check if any live stream is actively receiving data.
@@ -137,33 +127,73 @@ pub async fn is_stream_receiving(access_token: &str) -> Result<bool> {
     Ok(streams.iter().any(|s| s.status.stream_status == "active"))
 }
 
-/// List all live broadcasts (mine=true, all types, all states).
+/// List all live broadcasts (mine=true, all types, all states). Follows
+/// `nextPageToken` up to `MAX_PAGES` / `MAX_ITEMS`. Issue #200.
 pub async fn list_live_broadcasts(access_token: &str) -> Result<Vec<LiveBroadcast>> {
-    let client = Client::new();
-    // Try mine=true first to get all broadcasts for the authenticated user.
-    // This returns broadcasts in all lifecycle states (ready, testing, live, complete).
-    let resp = client
-        .get(format!("{}/liveBroadcasts", youtube_api_base()))
-        .bearer_auth(access_token)
-        .query(&[
-            ("part", "id,snippet,status"),
-            ("mine", "true"),
-            ("maxResults", "50"),
-        ])
-        .send()
-        .await?;
+    paginate(access_token, "liveBroadcasts", "id,snippet,status").await
+}
 
-    if !resp.status().is_success() {
-        let status = resp.status().as_u16();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(YouTubeError::Api {
-            status,
-            message: body,
-        });
+/// Shared pagination loop for `liveStreams` and `liveBroadcasts`. Sends
+/// `maxResults=50` plus `pageToken=<prev>` and accumulates `items`
+/// until the response omits `nextPageToken` or the hard cap fires.
+async fn paginate<T: for<'de> Deserialize<'de>>(
+    access_token: &str,
+    endpoint: &str,
+    part: &str,
+) -> Result<Vec<T>> {
+    let client = Client::new();
+    let url = format!("{}/{endpoint}", youtube_api_base());
+    let mut acc: Vec<T> = Vec::new();
+    let mut page_token: Option<String> = None;
+
+    for page_idx in 0..MAX_PAGES {
+        let mut params: Vec<(&str, String)> = vec![
+            ("part", part.to_string()),
+            ("mine", "true".to_string()),
+            ("maxResults", "50".to_string()),
+        ];
+        if let Some(t) = &page_token {
+            params.push(("pageToken", t.clone()));
+        }
+
+        let resp = client
+            .get(&url)
+            .bearer_auth(access_token)
+            .query(&params)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(YouTubeError::Api {
+                status,
+                message: body,
+            });
+        }
+
+        let body: ListResponse<T> = resp.json().await?;
+        acc.extend(body.items);
+
+        if acc.len() >= MAX_ITEMS {
+            tracing::warn!(
+                "{endpoint}: hard cap {MAX_ITEMS} items reached at page {} - truncating",
+                page_idx + 1
+            );
+            acc.truncate(MAX_ITEMS);
+            return Ok(acc);
+        }
+
+        match body.next_page_token {
+            Some(t) if !t.is_empty() => page_token = Some(t),
+            _ => return Ok(acc),
+        }
     }
 
-    let body: ListResponse<LiveBroadcast> = resp.json().await?;
-    Ok(body.items)
+    tracing::warn!(
+        "{endpoint}: hard cap {MAX_PAGES} pages reached - truncating, server may be misbehaving"
+    );
+    Ok(acc)
 }
 
 /// Check if any broadcast is in "testing" state (video preview is playing).

--- a/crates/rs-youtube/src/streams_for_label_tests.rs
+++ b/crates/rs-youtube/src/streams_for_label_tests.rs
@@ -1,17 +1,11 @@
 //! Tests for `list_streams_for_label`: token refresh + correct bearer per label.
 
 use crate::streams::list_streams_for_label;
+use crate::test_env::env_guard;
 use rs_core::db::youtube_oauth as yo;
 use rs_core::db::{create_memory_pool, run_migrations};
-use std::sync::OnceLock;
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-/// Serializes tests that mutate the process-global YOUTUBE_API_BASE env.
-fn env_guard() -> &'static tokio::sync::Mutex<()> {
-    static M: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-    M.get_or_init(|| tokio::sync::Mutex::new(()))
-}
 
 async fn pool_with_label(
     label: &str,

--- a/crates/rs-youtube/src/streams_pagination_tests.rs
+++ b/crates/rs-youtube/src/streams_pagination_tests.rs
@@ -7,7 +7,7 @@
 
 use crate::streams::{list_live_broadcasts, list_live_streams};
 use std::sync::OnceLock;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Serializes tests that mutate the process-global YOUTUBE_API_BASE env.
@@ -49,6 +49,7 @@ async fn list_live_streams_follows_next_page_token() {
         .and(path("/liveStreams"))
         .and(query_param("mine", "true"))
         .and(query_param("maxResults", "50"))
+        .and(query_param_is_missing("pageToken"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&page1))
         .expect(1)
         .mount(&server)
@@ -97,6 +98,7 @@ async fn list_live_broadcasts_follows_next_page_token() {
         .and(path("/liveBroadcasts"))
         .and(query_param("mine", "true"))
         .and(query_param("maxResults", "50"))
+        .and(query_param_is_missing("pageToken"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&page1))
         .expect(1)
         .mount(&server)

--- a/crates/rs-youtube/src/streams_pagination_tests.rs
+++ b/crates/rs-youtube/src/streams_pagination_tests.rs
@@ -1,0 +1,158 @@
+//! Tests for paginated `liveStreams.list` / `liveBroadcasts.list` (issue #200).
+//!
+//! Google's API caps a single response at `maxResults=50`. Accounts with
+//! more than 50 streams require following `nextPageToken` to enumerate all
+//! items; otherwise downstream callers see false-negative
+//! `stream_not_in_mine_list`.
+
+use crate::streams::{list_live_broadcasts, list_live_streams};
+use std::sync::OnceLock;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Serializes tests that mutate the process-global YOUTUBE_API_BASE env.
+fn env_guard() -> &'static tokio::sync::Mutex<()> {
+    static M: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn item(id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "snippet": { "title": id, "channelId": "UCabc" },
+        "status": { "streamStatus": "ready" },
+    })
+}
+
+fn broadcast(id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "snippet": { "title": id },
+        "status": { "lifeCycleStatus": "ready" },
+    })
+}
+
+#[tokio::test]
+async fn list_live_streams_follows_next_page_token() {
+    let _g = env_guard().lock().await;
+    let server = MockServer::start().await;
+    unsafe {
+        std::env::set_var("YOUTUBE_API_BASE", server.uri());
+    }
+
+    // Page 1 (no pageToken in request) → 50 items + nextPageToken="PAGE2"
+    let page1 = serde_json::json!({
+        "items": (0..50).map(|i| item(&format!("s{i}"))).collect::<Vec<_>>(),
+        "nextPageToken": "PAGE2",
+    });
+    Mock::given(method("GET"))
+        .and(path("/liveStreams"))
+        .and(query_param("mine", "true"))
+        .and(query_param("maxResults", "50"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&page1))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Page 2 (with pageToken=PAGE2) → 13 items + no nextPageToken
+    let page2 = serde_json::json!({
+        "items": (50..63).map(|i| item(&format!("s{i}"))).collect::<Vec<_>>(),
+    });
+    Mock::given(method("GET"))
+        .and(path("/liveStreams"))
+        .and(query_param("mine", "true"))
+        .and(query_param("pageToken", "PAGE2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&page2))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let streams = list_live_streams("TOK").await.unwrap();
+    assert_eq!(
+        streams.len(),
+        63,
+        "should accumulate items across both pages"
+    );
+    assert_eq!(streams[0].id, "s0");
+    assert_eq!(streams[62].id, "s62");
+
+    unsafe {
+        std::env::remove_var("YOUTUBE_API_BASE");
+    }
+}
+
+#[tokio::test]
+async fn list_live_broadcasts_follows_next_page_token() {
+    let _g = env_guard().lock().await;
+    let server = MockServer::start().await;
+    unsafe {
+        std::env::set_var("YOUTUBE_API_BASE", server.uri());
+    }
+
+    let page1 = serde_json::json!({
+        "items": (0..50).map(|i| broadcast(&format!("b{i}"))).collect::<Vec<_>>(),
+        "nextPageToken": "P2",
+    });
+    Mock::given(method("GET"))
+        .and(path("/liveBroadcasts"))
+        .and(query_param("mine", "true"))
+        .and(query_param("maxResults", "50"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&page1))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let page2 = serde_json::json!({
+        "items": (50..55).map(|i| broadcast(&format!("b{i}"))).collect::<Vec<_>>(),
+    });
+    Mock::given(method("GET"))
+        .and(path("/liveBroadcasts"))
+        .and(query_param("mine", "true"))
+        .and(query_param("pageToken", "P2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&page2))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bs = list_live_broadcasts("TOK").await.unwrap();
+    assert_eq!(bs.len(), 55);
+
+    unsafe {
+        std::env::remove_var("YOUTUBE_API_BASE");
+    }
+}
+
+#[tokio::test]
+async fn list_live_streams_caps_at_hard_limit() {
+    // Hard cap is 500 items / 10 pages — beyond that we warn and stop
+    // to avoid runaway quota burn on a misbehaving API.
+    let _g = env_guard().lock().await;
+    let server = MockServer::start().await;
+    unsafe {
+        std::env::set_var("YOUTUBE_API_BASE", server.uri());
+    }
+
+    // Every page returns 50 items + nextPageToken pointing at itself.
+    // If the cap doesn't kick in, the test hangs / infinite-loops.
+    let body = serde_json::json!({
+        "items": (0..50).map(|i| item(&format!("loop{i}"))).collect::<Vec<_>>(),
+        "nextPageToken": "LOOP",
+    });
+    Mock::given(method("GET"))
+        .and(path("/liveStreams"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&server)
+        .await;
+
+    let streams = list_live_streams("TOK").await.unwrap();
+    // 10 pages × 50 = 500 items max.
+    assert_eq!(
+        streams.len(),
+        500,
+        "hard cap should stop the loop at 500 items"
+    );
+
+    unsafe {
+        std::env::remove_var("YOUTUBE_API_BASE");
+    }
+}

--- a/crates/rs-youtube/src/streams_pagination_tests.rs
+++ b/crates/rs-youtube/src/streams_pagination_tests.rs
@@ -6,15 +6,9 @@
 //! `stream_not_in_mine_list`.
 
 use crate::streams::{list_live_broadcasts, list_live_streams};
-use std::sync::OnceLock;
+use crate::test_env::env_guard;
 use wiremock::matchers::{method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-/// Serializes tests that mutate the process-global YOUTUBE_API_BASE env.
-fn env_guard() -> &'static tokio::sync::Mutex<()> {
-    static M: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-    M.get_or_init(|| tokio::sync::Mutex::new(()))
-}
 
 fn item(id: &str) -> serde_json::Value {
     serde_json::json!({

--- a/crates/rs-youtube/src/test_env.rs
+++ b/crates/rs-youtube/src/test_env.rs
@@ -1,0 +1,16 @@
+//! Shared test mutex for tests that mutate the process-global
+//! `YOUTUBE_API_BASE` environment variable. Cargo runs tests in
+//! parallel; without a single shared mutex, two test files can race
+//! and one ends up hitting the real Google API (HTTP 401) instead of
+//! the other test's wiremock.
+//!
+//! Every test in this crate that touches `YOUTUBE_API_BASE` must lock
+//! [`env_guard`] before set_var and hold the guard until after
+//! remove_var.
+
+use std::sync::OnceLock;
+
+pub fn env_guard() -> &'static tokio::sync::Mutex<()> {
+    static M: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| tokio::sync::Mutex::new(()))
+}

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Four bundle-safe issues. PR #198 follow-up cleanups + one security tightening.

- **#202** — remove dead `id_token` field from Device Flow types. openid scope dropped in PR #198 → Google never returns id_token. Pure cleanup, no behaviour change.
- **#200** — paginate `liveStreams.list` / `liveBroadcasts.list`. Followed `nextPageToken` up to 10 pages / 500 items hard cap; emits `tracing::warn!` and truncates on cap. Accounts with >50 streams (church has 36, multi-site could exceed) no longer hit false-negative `stream_not_in_mine_list`.
- **#201** — CI YT baseline check distinguishes stuck previous CI run from operator OBS testing collision. Queries `/api/v1/audit?action=DeliveryStopped&limit=1`; if latest DeliveryStopped is >10 min old AND `e2e rtmp` stream still live → throw (stuck regression). Otherwise warn and continue.
- **#179** — `/api/v1/diag/dump` returns 403 FORBIDDEN for non-loopback callers. Wired `ConnectInfo<SocketAddr>` via `into_make_service_with_connect_info` at `lib.rs::serve`. Dump exposes audit log + endpoint state; only local operator may read it.

Bundled per `autonomous-batch-issue-development.md` (all ≤300 LoC, no schema, no API break, no cross-cut).

Closes #202
Closes #201
Closes #200
Closes #179

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (workspace 570+ tests)
- [x] New tests RED before GREEN in git history for #200 + #179
- [x] CI green (full pipeline including E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)