### PR TITLE
fix(workspace): tighten rustls dep + close 3 stale issues (#161)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1", features = ["full"] }
 # Web framework
 axum = { version = "0.8", features = ["ws", "multipart"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 # TLS for rtmps:// pusher (#156)
 tokio-rustls = "0.26"
 webpki-roots = "0.26"

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Tighten workspace \`rustls\` dep to \`default-features = false\` per PR #156 spec §5 (pure-Rust monorepo). Verified during /issue-planner audit that three other backend issues were already implemented but never closed:

- **#161** \(actually fixed\) — workspace \`Cargo.toml\` line 38: \`rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }\`. Cargo.lock still pulls aws-lc-rs transitively via \`attohttpc 0.30 → aws-creds → rust-s3\` (upstream limitation, documented in commit body).
- **#157** \(closed-as-solved\) — \`handle_rust_push\` timeout arm at \`crates/rs-delivery/src/endpoint_consumer_helpers.rs:200-256\` already emits \`emit_rtmp_push_died_detailed\` + force-closes the wedged pusher session. Done in commit \`e76f6ef0\` with comment referencing #157 directly.
- **#158** \(closed-as-solved\) — \`crates/rs-core/src/log_capture.rs:20-37\` filters DEBUG/TRACE from \`target == "log"\` (xiu→log→tracing bridge) plus hyper/h2/rustls/reqwest/axum. Done in commit \`55a84b7c\`, test \`filters_hyper_trace_events\` covers it.
- **#165** \(closed-as-solved\) — \`DeliveryOrchestrator::start_delivery\` at \`crates/rs-api/src/delivery.rs:251-277\` cleans up stale \`failed\`/\`stopped\`/\`stopping\` rows before spawning fresh VPS. Done in commit \`a6ae1905\` with explicit "#165" comment.

Closes #161

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo check --workspace\` passes with new dep spec
- [x] No production code change; CI green confirms unchanged behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)