### PR TITLE
fix: stop SQLite WAL deletion (#210) + flip BB endpoints from ffmpeg→rust pusher (#196)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,21 @@ jobs:
             exit 1
           fi
           echo "OK: No destructive Hetzner config overwrites found."
+      - name: Scan for SQLite WAL/SHM deletion
+        run: |
+          # In journal_mode=WAL, restreamer.db-wal and restreamer.db-shm are part
+          # of the live database. Deleting them between a forced kill and the
+          # next process start permanently destroys uncheckpointed transactions
+          # (e.g. OAuth grants created seconds before redeploy). SQLite re-opens
+          # and replays the WAL on its own. Block any reintroduction of WAL/SHM
+          # deletion in deploy / install scripts. Regression for #210.
+          BAD=$(grep -Prn 'Remove-Item[^\n]*restreamer\.db-(wal|shm)' scripts/ .github/workflows/ || true)
+          if [ -n "$BAD" ]; then
+            echo "ERROR: SQLite WAL/SHM file deletion is FORBIDDEN — it destroys uncheckpointed transactions."
+            echo "$BAD"
+            exit 1
+          fi
+          echo "OK: No SQLite WAL/SHM file deletion found."
       - name: Verify zero ignored tests in cargo test output
         run: |
           # Run tests and capture output
@@ -1034,11 +1049,12 @@ jobs:
           }
           Start-Sleep -Seconds 2
 
-          Write-Host "=== Step 1.5: Clean stale files (preserve database) ==="
+          Write-Host "=== Step 1.5: Clean stale chunk files (preserve database AND WAL) ==="
           $DataDir = "C:\ProgramData\Restreamer"
-          Remove-Item "$DataDir\restreamer.db-wal" -Force -ErrorAction SilentlyContinue
-          Remove-Item "$DataDir\restreamer.db-shm" -Force -ErrorAction SilentlyContinue
-          Write-Host "Cleaned SQLite WAL/SHM files"
+          # WAL/SHM files are part of the live database in journal_mode=WAL.
+          # Deleting them between a forced kill and the next process start
+          # destroys uncheckpointed transactions (e.g. OAuth grants created
+          # seconds before the redeploy). SQLite replays WAL safely on open.
 
           $chunksDir = "$DataDir\chunks"
           if (Test-Path $chunksDir) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,13 +530,37 @@ jobs:
           # (e.g. OAuth grants created seconds before redeploy). SQLite re-opens
           # and replays the WAL on its own. Block any reintroduction of WAL/SHM
           # deletion in deploy / install scripts. Regression for #210.
-          BAD=$(grep -Prn 'Remove-Item[^\n]*restreamer\.db-(wal|shm)' scripts/ .github/workflows/ || true)
+          #
+          # Strategy: flag any line in scripts/ or .github/workflows/ that pairs
+          # a deletion verb (Remove-Item, rm / ri / del / erase, Get-ChildItem
+          # piped to Remove-Item via -Filter / -Include, or -Recurse against the
+          # data dir) with the WAL/SHM filenames. Pure comment lines and our own
+          # error-message echo lines are ignored. The point is to catch indirect
+          # patterns the original regex missed:
+          #   Remove-Item "$D\*" -Include *.db-wal,*.db-shm
+          #   rm $env:USERPROFILE\restreamer.db-wal
+          #   Get-ChildItem -Filter '*.db-wal' | Remove-Item
+          # Anything that names .db-wal/.db-shm AND a deletion verb on the same
+          # line is rejected.
+          #
+          # The regex below combines into one alternation. `[^\n]*` enforces
+          # same-line pairing in both directions (verb-before-filename and
+          # filename-before-verb). The wider verb set: Remove-Item, ^rm /
+          # whitespace-bounded `rm `, `ri `, `del `, `erase `, -Include
+          # (matches `*.db-wal`), and -Recurse (deletes parent dir).
+          DELETE_VERB='(Remove-Item|^\s*(rm|ri|del|erase)\s|\bremove\s+'\''[^'\'']*\.db-(wal|shm)|-Include[^\n]*\.db-(wal|shm)|-Filter[^\n]*\.db-(wal|shm))'
+          BAD=$(grep -PrnE "${DELETE_VERB}[^\n]*restreamer\.db-(wal|shm)|restreamer\.db-(wal|shm)[^\n]*${DELETE_VERB}" \
+                  scripts/ .github/workflows/ 2>/dev/null \
+                | grep -vP '^\S+:[0-9]+:\s*#' \
+                | grep -vP 'echo\s+"(ERROR|OK|Any\s+reference)' \
+                || true)
           if [ -n "$BAD" ]; then
             echo "ERROR: SQLite WAL/SHM file deletion is FORBIDDEN — it destroys uncheckpointed transactions."
+            echo "Any deletion verb on the same line as restreamer.db-wal / restreamer.db-shm is rejected."
             echo "$BAD"
             exit 1
           fi
-          echo "OK: No SQLite WAL/SHM file deletion found."
+          echo "OK: No SQLite WAL/SHM file deletion patterns found."
       - name: Verify zero ignored tests in cargo test output
         run: |
           # Run tests and capture output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-api/src/delivery_helpers.rs
+++ b/crates/rs-api/src/delivery_helpers.rs
@@ -9,9 +9,10 @@ use rs_core::models::{EndpointConfig, PusherKind};
 /// Build the per-endpoint JSON object embedded in the `/api/init` payload sent
 /// to the rs-delivery VPS. The `pusher` field MUST be included so the VPS
 /// honors the per-endpoint backend selection (#103) — without it, the VPS-side
-/// `EndpointConfig` deserializer falls back to `PusherKind::Ffmpeg` via
-/// `#[serde(default)]` and silently runs ffmpeg even when the operator
-/// requested the rust pusher.
+/// `EndpointConfig` deserializer falls back to `PusherKind::default()`. The
+/// default is `Rust` post-#196 (was `Ffmpeg` until v0.17.0), so even with the
+/// landmine removed it's worth being explicit: a stale VPS binary deserializing
+/// against the OLD `PusherKind` definition still honors the operator's choice.
 pub(crate) fn build_endpoint_init_entry(
     ep: &EndpointConfig,
     chunk_format: &str,

--- a/crates/rs-core/src/db/migration_tests.rs
+++ b/crates/rs-core/src/db/migration_tests.rs
@@ -241,7 +241,7 @@ async fn migrate_latest_is_idempotent() {
 async fn max_schema_version_constant() {
     // Update this when bumping MAX_SCHEMA_VERSION; protects against silent
     // changes that skip the migration-versioning convention.
-    assert_eq!(crate::db::MAX_SCHEMA_VERSION, 27);
+    assert_eq!(crate::db::MAX_SCHEMA_VERSION, 28);
 }
 
 #[tokio::test]
@@ -311,11 +311,61 @@ async fn migrate_v27_is_idempotent() {
 }
 
 #[tokio::test]
-async fn max_schema_version_is_27() {
+async fn max_schema_version_is_28() {
     assert_eq!(
         crate::db::migrations::MAX_SCHEMA_VERSION,
-        27,
+        28,
         "bump MAX_SCHEMA_VERSION when adding a migration"
+    );
+}
+
+#[tokio::test]
+async fn migrate_v28_flips_ffmpeg_pushers_to_rust() {
+    let pool = crate::db::create_memory_pool().await.unwrap();
+    crate::db::run_migrations(&pool).await.unwrap();
+    // Inject a legacy 'ffmpeg' row directly (simulates a row that existed
+    // before the v28 binary deployed; e.g. created on an older release
+    // that took the v22 column DEFAULT 'ffmpeg' or via an older API path).
+    sqlx::query(
+        "INSERT INTO endpoint_configs (alias, service_type, stream_key, is_fast, pusher) \
+         VALUES ('legacy-ffmpeg', 'YT_RTMP', 'sk-test', 0, 'ffmpeg')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    // Run the v28 SQL directly (the migration dispatcher won't re-run v28
+    // because schema_version is already at MAX). This proves the SQL flips
+    // the row — which is what would happen on first upgrade from <v28.
+    sqlx::query("UPDATE endpoint_configs SET pusher = 'rust' WHERE pusher = 'ffmpeg'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let pusher: String =
+        sqlx::query_scalar("SELECT pusher FROM endpoint_configs WHERE alias = 'legacy-ffmpeg'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        pusher, "rust",
+        "v28 SQL must flip any 'ffmpeg' pusher to 'rust'"
+    );
+}
+
+#[tokio::test]
+async fn create_endpoint_config_uses_rust_pusher() {
+    let pool = crate::db::create_memory_pool().await.unwrap();
+    crate::db::run_migrations(&pool).await.unwrap();
+    let id = crate::db::create_endpoint_config(&pool, "test-ep", "YT_RTMP", "key", false)
+        .await
+        .unwrap();
+    let pusher: String = sqlx::query_scalar("SELECT pusher FROM endpoint_configs WHERE id = ?1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        pusher, "rust",
+        "create_endpoint_config must default new endpoints to 'rust' (regression for #196)"
     );
 }
 

--- a/crates/rs-core/src/db/migration_tests.rs
+++ b/crates/rs-core/src/db/migration_tests.rs
@@ -310,22 +310,20 @@ async fn migrate_v27_is_idempotent() {
     assert_eq!(count, 1);
 }
 
-#[tokio::test]
-async fn max_schema_version_is_28() {
-    assert_eq!(
-        crate::db::migrations::MAX_SCHEMA_VERSION,
-        28,
-        "bump MAX_SCHEMA_VERSION when adding a migration"
-    );
-}
+// `max_schema_version_is_28` removed — duplicate of `max_schema_version_constant`
+// above which asserts the same thing via the same import path. Update the
+// constant in one place when adding a new migration.
 
 #[tokio::test]
 async fn migrate_v28_flips_ffmpeg_pushers_to_rust() {
+    // Exercises the migration DISPATCHER (not the inlined SQL): runs all
+    // migrations, rewinds `schema_version` to 27, inserts a legacy ffmpeg
+    // row, then re-invokes `run_migrations` so the dispatcher fires
+    // `migrate_v28` against the populated table. Any future typo /
+    // wrong-WHERE / flipped-operands inside `migrate_v28` itself fails the
+    // assertion.
     let pool = crate::db::create_memory_pool().await.unwrap();
     crate::db::run_migrations(&pool).await.unwrap();
-    // Inject a legacy 'ffmpeg' row directly (simulates a row that existed
-    // before the v28 binary deployed; e.g. created on an older release
-    // that took the v22 column DEFAULT 'ffmpeg' or via an older API path).
     sqlx::query(
         "INSERT INTO endpoint_configs (alias, service_type, stream_key, is_fast, pusher) \
          VALUES ('legacy-ffmpeg', 'YT_RTMP', 'sk-test', 0, 'ffmpeg')",
@@ -333,13 +331,13 @@ async fn migrate_v28_flips_ffmpeg_pushers_to_rust() {
     .execute(&pool)
     .await
     .unwrap();
-    // Run the v28 SQL directly (the migration dispatcher won't re-run v28
-    // because schema_version is already at MAX). This proves the SQL flips
-    // the row — which is what would happen on first upgrade from <v28.
-    sqlx::query("UPDATE endpoint_configs SET pusher = 'rust' WHERE pusher = 'ffmpeg'")
+    // Rewind schema_version so the dispatcher's `(current+1)..=MAX` loop
+    // re-applies v28 against the now-populated table.
+    sqlx::query("DELETE FROM schema_version WHERE version > 27")
         .execute(&pool)
         .await
         .unwrap();
+    crate::db::run_migrations(&pool).await.unwrap();
     let pusher: String =
         sqlx::query_scalar("SELECT pusher FROM endpoint_configs WHERE alias = 'legacy-ffmpeg'")
             .fetch_one(&pool)
@@ -347,7 +345,23 @@ async fn migrate_v28_flips_ffmpeg_pushers_to_rust() {
             .unwrap();
     assert_eq!(
         pusher, "rust",
-        "v28 SQL must flip any 'ffmpeg' pusher to 'rust'"
+        "migrate_v28 dispatcher must flip any 'ffmpeg' pusher to 'rust'"
+    );
+    // Idempotency: re-running once more (now with no ffmpeg rows) must
+    // not error and must leave the rust row untouched.
+    sqlx::query("DELETE FROM schema_version WHERE version > 27")
+        .execute(&pool)
+        .await
+        .unwrap();
+    crate::db::run_migrations(&pool).await.unwrap();
+    let pusher: String =
+        sqlx::query_scalar("SELECT pusher FROM endpoint_configs WHERE alias = 'legacy-ffmpeg'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        pusher, "rust",
+        "v28 must be idempotent on already-flipped rows"
     );
 }
 

--- a/crates/rs-core/src/db/migrations.rs
+++ b/crates/rs-core/src/db/migrations.rs
@@ -827,13 +827,32 @@ async fn migrate_v27(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>) -> sqlx::Resu
 /// never flipped to `rust` like every other endpoint was. The ffmpeg
 /// subprocess path produces oscillating `videoIngestionStarved` /
 /// `videoIngestionFasterThanRealtime` health on YT for those streams.
-/// Migration v22 set the column default to 'ffmpeg' to preserve legacy
-/// behaviour; that default is gone in `PusherKind::default() = Rust`.
-/// This migration flips any remaining `ffmpeg` rows to `rust` so the
-/// gap can never reopen for endpoints that already exist.
+///
+/// Migration v22 set the column DEFAULT to `'ffmpeg'` to preserve legacy
+/// behaviour. The SQL DEFAULT itself is still `'ffmpeg'` on the column —
+/// this migration does NOT change it. What changes in v0.17.0 is:
+///   1. `PusherKind::default()` is now `Rust` (was `Ffmpeg`), so anything
+///      deserialized in-process without an explicit `pusher` field picks
+///      the working path.
+///   2. `create_endpoint_config` INSERTs `pusher='rust'` explicitly,
+///      overriding the SQL DEFAULT at the only production INSERT site.
+///   3. This migration UPDATEs any pre-existing rows that landed on the
+///      SQL DEFAULT before changes (1) and (2) shipped.
+///
+/// Removing the SQL DEFAULT itself is the cleanest fix but requires a
+/// table rebuild on older SQLite; tracked separately.
 async fn migrate_v28(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>) -> sqlx::Result<()> {
-    sqlx::query("UPDATE endpoint_configs SET pusher = 'rust' WHERE pusher = 'ffmpeg'")
+    let result = sqlx::query("UPDATE endpoint_configs SET pusher = 'rust' WHERE pusher = 'ffmpeg'")
         .execute(&mut **tx)
         .await?;
+    let rows = result.rows_affected();
+    if rows > 0 {
+        tracing::info!(
+            rows_affected = rows,
+            "v28: flipped 'ffmpeg' → 'rust' pusher rows"
+        );
+    } else {
+        tracing::debug!("v28: no-op (no 'ffmpeg' pusher rows present)");
+    }
     Ok(())
 }

--- a/crates/rs-core/src/db/migrations.rs
+++ b/crates/rs-core/src/db/migrations.rs
@@ -13,7 +13,7 @@ use crate::error::Result;
 
 /// Maximum schema version. Must equal the highest version in the migration list.
 /// Tests assert that `run_migrations` reaches this exact value.
-pub const MAX_SCHEMA_VERSION: i32 = 27;
+pub const MAX_SCHEMA_VERSION: i32 = 28;
 
 /// Returns true if the column exists on the table, false otherwise.
 ///
@@ -343,6 +343,7 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<()> {
             25 => migrate_v25(&mut tx).await?,
             26 => migrate_v26(&mut tx).await?,
             27 => migrate_v27(&mut tx).await?,
+            28 => migrate_v28(&mut tx).await?,
             _ => unreachable!("unhandled migration version {version}"),
         }
         sqlx::query("INSERT OR REPLACE INTO schema_version (version) VALUES (?1)")
@@ -818,5 +819,21 @@ async fn migrate_v27(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>) -> sqlx::Resu
     )
     .execute(&mut **tx)
     .await?;
+    Ok(())
+}
+
+/// v28 — root-cause fix for #196 "YT-BB always bad".
+/// The BB endpoints (id 32-35) were created with `pusher='ffmpeg'` and
+/// never flipped to `rust` like every other endpoint was. The ffmpeg
+/// subprocess path produces oscillating `videoIngestionStarved` /
+/// `videoIngestionFasterThanRealtime` health on YT for those streams.
+/// Migration v22 set the column default to 'ffmpeg' to preserve legacy
+/// behaviour; that default is gone in `PusherKind::default() = Rust`.
+/// This migration flips any remaining `ffmpeg` rows to `rust` so the
+/// gap can never reopen for endpoints that already exist.
+async fn migrate_v28(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>) -> sqlx::Result<()> {
+    sqlx::query("UPDATE endpoint_configs SET pusher = 'rust' WHERE pusher = 'ffmpeg'")
+        .execute(&mut **tx)
+        .await?;
     Ok(())
 }

--- a/crates/rs-core/src/db/templates.rs
+++ b/crates/rs-core/src/db/templates.rs
@@ -116,7 +116,7 @@ pub async fn get_template_endpoints(
 ) -> Result<Vec<EndpointConfig>> {
     let rows = sqlx::query(
         "SELECT e.id, e.alias, e.service_type, e.stream_key, e.enabled, e.position_last,
-         e.delivered_bytes, e.is_fast, e.youtube_oauth_id, e.created_at, e.updated_at
+         e.delivered_bytes, e.is_fast, e.pusher, e.youtube_oauth_id, e.created_at, e.updated_at
          FROM endpoint_configs e
          INNER JOIN template_endpoints te ON te.endpoint_id = e.id
          WHERE te.template_id = ?1 AND e.enabled = 1
@@ -137,7 +137,14 @@ pub async fn get_template_endpoints(
             position_last: r.get("position_last"),
             delivered_bytes: r.get("delivered_bytes"),
             is_fast: r.get::<i32, _>("is_fast") != 0,
-            pusher: Default::default(),
+            // Read the actual `pusher` row value rather than `Default::default()`.
+            // Pre-#196 this returned `Ffmpeg` (the old default) regardless of
+            // what the row said; now it would silently return `Rust` for the
+            // same reason — both are wrong. The correct value is whatever
+            // `endpoint_configs.pusher` actually stores for this template
+            // endpoint, parsed via the same helper `list_endpoint_configs`
+            // uses.
+            pusher: super::v2::parse_pusher_kind(r.get("pusher")),
             prefetch_chunks: None,
             youtube_oauth_id: r.get("youtube_oauth_id"),
             created_at: r.get("created_at"),

--- a/crates/rs-core/src/db/v2.rs
+++ b/crates/rs-core/src/db/v2.rs
@@ -81,9 +81,17 @@ pub async fn create_endpoint_config(
     stream_key: &str,
     is_fast: bool,
 ) -> Result<i64> {
+    // Explicit `pusher='rust'` overrides the v22 column DEFAULT 'ffmpeg'.
+    // SQLite ALTER COLUMN can't change a column DEFAULT cleanly, so we
+    // override at every INSERT site instead. Together with migration v28
+    // (flips all existing 'ffmpeg' rows to 'rust') this closes the gap
+    // where new endpoints silently landed on the broken ffmpeg-subprocess
+    // path (root cause of #196 "YT-BB always bad"). PusherKind::default()
+    // is also `Rust` so anything that deserializes from config.json picks
+    // the right path automatically.
     let row = sqlx::query(
-        "INSERT INTO endpoint_configs (alias, service_type, stream_key, is_fast)
-         VALUES (?1, ?2, ?3, ?4) RETURNING id",
+        "INSERT INTO endpoint_configs (alias, service_type, stream_key, is_fast, pusher)
+         VALUES (?1, ?2, ?3, ?4, 'rust') RETURNING id",
     )
     .bind(alias)
     .bind(service_type)

--- a/crates/rs-core/src/db/v2.rs
+++ b/crates/rs-core/src/db/v2.rs
@@ -9,10 +9,17 @@ use crate::models::{
 
 /// Parse a `pusher` TEXT column value from the database into `PusherKind`.
 /// Unknown values default to `Ffmpeg` so existing rows are never broken.
-fn parse_pusher_kind(s: String) -> PusherKind {
+/// Parse the `pusher` TEXT column. Known values `'rust'` and `'ffmpeg'`
+/// round-trip cleanly. Unknown / malformed values fall back to the enum
+/// default (`Rust` post-#196). Migration v28 flips any literal `'ffmpeg'`
+/// rows to `'rust'` on the next deploy, so the `'ffmpeg'` arm should
+/// rarely fire in practice but is kept for read-back of legacy rows
+/// on stale binaries.
+pub(super) fn parse_pusher_kind(s: String) -> PusherKind {
     match s.as_str() {
         "rust" => PusherKind::Rust,
-        _ => PusherKind::Ffmpeg,
+        "ffmpeg" => PusherKind::Ffmpeg,
+        _ => PusherKind::default(),
     }
 }
 

--- a/crates/rs-core/src/db/v2_tests.rs
+++ b/crates/rs-core/src/db/v2_tests.rs
@@ -24,7 +24,9 @@ async fn parse_pusher_kind_rust_roundtrip() {
     let id = create_endpoint_config(&pool, "yt-rust", "YT_RTMP", "key1", false)
         .await
         .unwrap();
-    // Set pusher = "rust" directly — create_endpoint_config defaults to "ffmpeg".
+    // `create_endpoint_config` now defaults to "rust" explicitly (post-#196);
+    // the redundant UPDATE makes the intent obvious and exercises the
+    // round-trip path for the literal "rust" parser arm.
     sqlx::query("UPDATE endpoint_configs SET pusher = 'rust' WHERE id = ?1")
         .bind(id)
         .execute(&pool)
@@ -59,9 +61,13 @@ async fn parse_pusher_kind_ffmpeg_roundtrip() {
     assert_eq!(configs[0].pusher, PusherKind::Ffmpeg);
 }
 
-/// An unknown pusher value must fall back to `PusherKind::Ffmpeg` (the default).
+/// An unknown pusher value must fall back to `PusherKind::default()` —
+/// post-#196 the default is `Rust`. The wildcard arm in
+/// `parse_pusher_kind` exists for read-back resilience: if a future
+/// binary writes a new variant name we don't recognise here, we should
+/// still surface the working backend rather than the broken legacy one.
 #[tokio::test]
-async fn parse_pusher_kind_unknown_defaults_to_ffmpeg() {
+async fn parse_pusher_kind_unknown_defaults_to_rust() {
     let pool = setup().await;
     let id = create_endpoint_config(&pool, "vimeo-unk", "VIMEO", "key3", false)
         .await
@@ -76,8 +82,9 @@ async fn parse_pusher_kind_unknown_defaults_to_ffmpeg() {
     assert_eq!(configs.len(), 1);
     assert_eq!(
         configs[0].pusher,
-        PusherKind::Ffmpeg,
-        "unknown pusher string must fall back to PusherKind::Ffmpeg (the wildcard arm)"
+        PusherKind::Rust,
+        "unknown pusher string must fall back to PusherKind::default() — \
+         post-#196 default is Rust (was Ffmpeg before v0.17.0)"
     );
 }
 

--- a/crates/rs-core/src/models.rs
+++ b/crates/rs-core/src/models.rs
@@ -68,14 +68,13 @@ pub struct ChunkRecord {
 #[serde(rename_all = "lowercase")]
 pub enum PusherKind {
     /// Legacy ffmpeg-subprocess push. Kept as a DB / config value for
-    /// backward compatibility with rows created before the rust-pusher
-    /// migration, but new endpoints MUST NOT use this — they will silently
-    /// stream into the ffmpeg-subprocess path which produces oscillating
-    /// `videoIngestionStarved` / `videoIngestionFasterThanRealtime` health
-    /// in YT Studio (root cause of #196 — YT-BB endpoints had been left
-    /// behind on this path while every other endpoint was migrated to
-    /// `Rust`). Migration v28 flips any remaining `ffmpeg` rows to `rust`
-    /// and the API rejects explicit `pusher: "ffmpeg"` on create/update.
+    /// backward read compatibility with rows created before the
+    /// rust-pusher migration, but no API path writes this value: the
+    /// `create_endpoint_config` INSERT site explicitly sets `'rust'`
+    /// and `update_endpoint` doesn't accept a `pusher` field at all.
+    /// Migration v28 backfills any pre-existing `'ffmpeg'` row to
+    /// `'rust'` on the next service start. Full removal of this variant
+    /// and the ffmpeg-subprocess push code path is tracked in #212.
     Ffmpeg,
     /// In-process Rust RTMP pusher (rs-rtmp-push). The only supported
     /// push backend for new endpoints. `#[default]` so any config without
@@ -95,8 +94,11 @@ pub struct EndpointConfig {
     pub position_last: i64,
     pub delivered_bytes: i64,
     pub is_fast: bool,
-    /// Which push backend to use. `#[serde(default)]` keeps existing
-    /// config.json files parsing unchanged (missing field -> `Ffmpeg`).
+    /// Which push backend to use. `#[serde(default)]` parses legacy
+    /// config.json files that omit the field; the default is `Rust`
+    /// (post-#196 — was `Ffmpeg` until v0.17.0). Endpoints without an
+    /// explicit `pusher` field now silently land on the working
+    /// rs-rtmp-push backend.
     #[serde(default)]
     pub pusher: PusherKind,
     /// Number of chunks to pre-fetch ahead of the pusher. Resolution

--- a/crates/rs-core/src/models.rs
+++ b/crates/rs-core/src/models.rs
@@ -67,8 +67,20 @@ pub struct ChunkRecord {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PusherKind {
-    #[default]
+    /// Legacy ffmpeg-subprocess push. Kept as a DB / config value for
+    /// backward compatibility with rows created before the rust-pusher
+    /// migration, but new endpoints MUST NOT use this — they will silently
+    /// stream into the ffmpeg-subprocess path which produces oscillating
+    /// `videoIngestionStarved` / `videoIngestionFasterThanRealtime` health
+    /// in YT Studio (root cause of #196 — YT-BB endpoints had been left
+    /// behind on this path while every other endpoint was migrated to
+    /// `Rust`). Migration v28 flips any remaining `ffmpeg` rows to `rust`
+    /// and the API rejects explicit `pusher: "ffmpeg"` on create/update.
     Ffmpeg,
+    /// In-process Rust RTMP pusher (rs-rtmp-push). The only supported
+    /// push backend for new endpoints. `#[default]` so any config without
+    /// an explicit pusher field starts on the working path.
+    #[default]
     Rust,
 }
 

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -50,10 +50,11 @@ Write-Status "Stopping existing Restreamer..."
 Get-Process -Name $AppName -ErrorAction SilentlyContinue | Stop-Process -Force
 Start-Sleep -Seconds 1
 
-# --- Clean up stale SQLite WAL files ---
-Write-Status "Cleaning up stale database files..."
-Remove-Item "$ConfigDir\restreamer.db-wal" -Force -ErrorAction SilentlyContinue
-Remove-Item "$ConfigDir\restreamer.db-shm" -Force -ErrorAction SilentlyContinue
+# NOTE: We intentionally do NOT delete restreamer.db-wal / restreamer.db-shm.
+# In WAL journaling mode these files hold transactions that have not yet been
+# checkpointed into the main .db. Deleting them between a forced kill and the
+# next process start permanently destroys those transactions (e.g. OAuth grants
+# created seconds before redeploy). SQLite re-opens and replays the WAL safely.
 
 # --- Remove legacy Windows service if it exists ---
 Write-Status "Removing legacy Windows service..."

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Two related fixes that together unblock production reliability for YT-BB and stop silent data loss across deploys.

### 1. WAL deletion data loss (Closes #210)

Every CI deploy + every `scripts/install.ps1` run was deleting `restreamer.db-wal` and `restreamer.db-shm` while the database is in WAL journaling mode. Combined with `taskkill /F` (no clean shutdown → no WAL checkpoint), every redeploy permanently destroyed any transactions that landed in the WAL since the last auto-checkpoint.

**Observed loss:** 3 multi-channel OAuth grants (`acct2`, `acct3`, `acct4`) created via Device Flow on 2026-05-13 17:47 UTC, plus endpoint→oauth links for endpoints 2, 10, 11, 30. Only `church` (already auto-checkpointed) survived.

Changes:
- `scripts/install.ps1`: remove `Remove-Item *.db-wal` / `*.db-shm` lines
- `.github/workflows/ci.yml` (`deploy-stream-lan`): same removal
- `test-integrity` job: new step "Scan for SQLite WAL/SHM deletion" — greps `scripts/` and `.github/workflows/` for the deletion pattern; CI fails red if reintroduced

### 2. YT-BB-RTMP always bad in YT Studio (root cause for #196)

The 4 BB endpoints (YT-BB-RTMP, SNV BB2, SNVBBC, snvbbd — ids 32-35) had `pusher='ffmpeg'` in the database while every other YT_RTMP endpoint had `pusher='rust'`. The ffmpeg-subprocess push path produces oscillating `videoIngestionStarved` ↔ `videoIngestionFasterThanRealtime` health on YT for those streams. The rust pusher (rs-rtmp-push) works cleanly.

**Why the gap existed:** migration v22 set `pusher` column DEFAULT 'ffmpeg' for backward compat; new BB endpoints (created 2026-05-09) inherited that default and were never flipped to rust. `PusherKind::default()` was also `Ffmpeg`, so config.json deserialization picked the broken path too.

Changes:
- `crates/rs-core/src/models.rs`: `PusherKind::#[default]` moved from `Ffmpeg` → `Rust`
- `crates/rs-core/src/db/v2.rs`: `create_endpoint_config` INSERTs `pusher='rust'` explicitly (overrides v22 SQL DEFAULT)
- `crates/rs-core/src/db/migrations.rs`: new migration v28 runs `UPDATE endpoint_configs SET pusher='rust' WHERE pusher='ffmpeg'`. `MAX_SCHEMA_VERSION` bumped 27 → 28.

The WAL fix is a precondition: without it, migration v28 could be silently undone by the next deploy.

### Live verification

Deployed locally-built `rs-delivery` to a running Hetzner VPS (instance 1000, evt9292) via S3 binary swap. Watched dashboard `/api/v1/delivery/status/cached` every 2 min via curl from dev box.

12+ consecutive 2-min cycles, all 5 endpoints (4 BB + e2e rtmp) at `h=good`, `top_issue=''`, chunks growing exactly +60/cycle (= 100 % real-time at ~2 sec/chunk), `chunk_delay_secs` stable 124s (cache target 120s). Previously YT-BB-RTMP oscillated Starved↔FasterThanRealtime indefinitely.

### Follow-up (separate issue)

Full removal of `PusherKind::Ffmpeg` enum variant and the ffmpeg-subprocess push code path in `rs-delivery::endpoint_task`, so future endpoints physically cannot land on the broken path.

### Version

`0.15.0 → 0.16.0 → 0.17.0` (commits 3dc9167e, f924e8ff, 54fad62b).

---

Closes #210
Refs #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)