### PR TITLE
ci: bump sustained-YT-health gate timeout 18 -> 22 min + dev 0.22.4 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3897,7 +3897,13 @@ jobs:
       - name: "GATE: Sustained YT health + endpoint chunk_delay (15 min observation)"
         if: success()
         shell: powershell
-        timeout-minutes: 18
+        # 30 samples × 30s = 15 min minimum, plus per-sample API latency
+        # (YT Data API + delivery/status + audit query) typically adds
+        # 5-15s per sample at p95. Main CI run 26738025583 reached sample
+        # 29/30 then hit the 18-min step timeout. Bump to 22 min so the
+        # gate budget covers the full sample loop with reasonable CI
+        # network jitter headroom.
+        timeout-minutes: 22
         run: |
           # Phase 1 (#176) sustained gate. The existing one-shot 'good' check
           # passes on the first 'good' reading. Drift-class regressions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.22.3"
+version = "0.22.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.22.3"
+version = "0.22.4"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.22.3"
+version = "0.22.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Hotfix for the OBS-YT sustained gate that timed out on main CI run 26738025583 (post-#241 merge).

- **ci.yml** — `GATE: Sustained YT health + endpoint chunk_delay (15 min observation)` step timeout 18 → 22 min. The 30 samples × 30s = 15 min math minimum + 5-15s p95 API latency per sample overflowed the 18-min budget on a slower run; sample 29/30 reached "ok (YT good, endpoints under threshold)" before the GH Actions timer fired. Not a delivery regression — pure budget issue.
- **version bump** 0.22.3 → 0.22.4 on dev (Cargo.toml workspace + src-tauri/Cargo.toml + leptos-ui/Cargo.toml + src-tauri/tauri.conf.json) per the post-merge version-bump rule.

## Verification

Dev CI run 26763107022 (post-fix) — green across the board, including the OBS-YT sustained gate that previously timed out.

## Test plan
- [x] `cargo fmt --all --check`
- [x] Dev CI run 26763107022: every job green incl. E2E OBS-to-YouTube Test (sustained gate completes with new 22-min budget), E2E FB Push, E2E Gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)