### PR TITLE
Fast-stream self-healing: adaptive read-delay + never-crash keepalive (fixes restart loop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.22.3"
+version = "0.22.6"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.22.4"
+version = "0.22.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.22.5"
+version = "0.22.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-core/src/audit.rs
+++ b/crates/rs-core/src/audit.rs
@@ -161,6 +161,11 @@ pub enum Action {
     /// {alias, old_start_chunk_id, new_start_chunk_id}.
     EndpointStartChunkUpdated,
 
+    FastDelayGrown,
+    FastDelayShrank,
+    FastKeepaliveStarted,
+    FastKeepaliveEnded,
+
     /// Host-side: YT health probe observed `configurationIssues[0].type`
     /// change for an endpoint. Detail JSON:
     /// `{from: Option<String>, to: Option<String>}`. Bounded at most once
@@ -385,5 +390,37 @@ mod tests {
         );
         let back: Action = serde_json::from_str(r#""endpoint_lifecycle_predeath""#).unwrap();
         assert_eq!(back, Action::EndpointLifecyclePredeath);
+    }
+
+    #[test]
+    fn action_fast_delay_grown_serdes() {
+        let a = Action::FastDelayGrown;
+        let s = serde_json::to_string(&a).unwrap();
+        assert_eq!(s, "\"fast_delay_grown\"");
+        assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+    }
+
+    #[test]
+    fn action_fast_delay_shrank_serdes() {
+        let a = Action::FastDelayShrank;
+        let s = serde_json::to_string(&a).unwrap();
+        assert_eq!(s, "\"fast_delay_shrank\"");
+        assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+    }
+
+    #[test]
+    fn action_fast_keepalive_started_serdes() {
+        let a = Action::FastKeepaliveStarted;
+        let s = serde_json::to_string(&a).unwrap();
+        assert_eq!(s, "\"fast_keepalive_started\"");
+        assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+    }
+
+    #[test]
+    fn action_fast_keepalive_ended_serdes() {
+        let a = Action::FastKeepaliveEnded;
+        let s = serde_json::to_string(&a).unwrap();
+        assert_eq!(s, "\"fast_keepalive_ended\"");
+        assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
     }
 }

--- a/crates/rs-delivery/src/endpoint_producer.rs
+++ b/crates/rs-delivery/src/endpoint_producer.rs
@@ -1,0 +1,260 @@
+//! Producer half of the per-endpoint delivery pipeline.
+//!
+//! Extracted from `endpoint_task.rs` so that file stays under the 1000-line
+//! CI cap while `consumer_task` keeps room to grow. This is a pure move of
+//! the `producer_task` async fn — no behaviour change. The producer fetches
+//! chunks from S3 (via the `ChunkFetcher`) and sends them into the bounded
+//! mpsc channel that the consumer drains.
+
+use std::sync::{Arc, atomic::Ordering as AtomicOrdering};
+use tokio::sync::{mpsc, watch};
+
+use crate::audit_ring::AuditRing;
+use crate::buffer_state::BufferState;
+use crate::endpoint_stats::Stats;
+use crate::endpoint_task::{
+    ChunkFetcher, MAX_CHUNK_MISS_COUNT, PrefetchedChunk, S3_BACKOFF_BASE_SECS, S3_BACKOFF_MAX_SECS,
+    SKIP_AHEAD_PROBE,
+};
+use crate::fast_delay::FastDelayController;
+use crate::producer_lag::maybe_jump as maybe_jump_ahead;
+
+/// Producer task: fetches chunks from S3 and sends them into the bounded channel.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn producer_task<F: ChunkFetcher>(
+    fetcher: F,
+    tx: mpsc::Sender<PrefetchedChunk>,
+    start_chunk_id: i64,
+    delivery_delay_ms: u64,
+    is_fast: bool,
+    mut stop_rx: watch::Receiver<bool>,
+    stats: Stats,
+    alias: String,
+    buffer_state: Arc<BufferState>,
+    audit_ring: Option<Arc<AuditRing>>,
+) {
+    let mut chunk_id = start_chunk_id;
+    let mut consecutive_chunk_misses: u32 = 0;
+    let mut s3_backoff_secs: u64 = S3_BACKOFF_BASE_SECS;
+    // Issue #173: rate-limited audit-row emitter, owned by this task.
+    let mut s3_fetch_audit = crate::endpoint_audit::S3FetchAuditLimiter::new();
+    // Lag-detect state. typical_chunk_dur_ms is updated from observed
+    // `duration_ms` so it tracks operator config without a hardcode.
+    let mut typical_chunk_dur_ms: u64 = 1000;
+    let mut iters_since_lag_probe: u32 = 0;
+    // Adaptive read-delay controller — fast endpoints only. Grows the
+    // read-delay on starvation (so the live-edge lag-probe leaves a buffer
+    // instead of re-pinning to the edge) and shrinks slowly when healthy.
+    // None for non-fast endpoints → byte-for-byte unchanged behaviour.
+    let mut fast_delay = if is_fast {
+        Some(FastDelayController::new(std::time::Instant::now()))
+    } else {
+        None
+    };
+
+    loop {
+        if *stop_rx.borrow() {
+            tracing::info!(alias = %alias, "Producer: stop signal received");
+            break;
+        }
+
+        // Fetch chunk with metadata in one S3 GET
+        match fetcher.fetch_chunk_with_meta(chunk_id).await {
+            Ok(Some((data, duration_ms))) => {
+                consecutive_chunk_misses = 0;
+                s3_backoff_secs = S3_BACKOFF_BASE_SECS;
+                {
+                    let mut s = stats.lock().await;
+                    s.consecutive_chunk_misses = 0;
+                    if s.stall_reason.as_deref() == Some("chunk_gap") {
+                        s.stall_reason = None;
+                    }
+                }
+
+                let chunk = PrefetchedChunk {
+                    chunk_id,
+                    data,
+                    duration_ms,
+                };
+
+                // Track buffer growth for rescue mode
+                let current_buf = buffer_state
+                    .buffer_duration_ms
+                    .load(AtomicOrdering::Relaxed);
+                buffer_state.buffer_duration_ms.store(
+                    current_buf.saturating_add(duration_ms.max(0) as u64),
+                    AtomicOrdering::Relaxed,
+                );
+                buffer_state
+                    .producer_active
+                    .store(true, AtomicOrdering::Relaxed);
+
+                // Send into channel; blocks if buffer full (backpressure).
+                // If receiver is dropped (consumer gone), stop.
+                if tx.send(chunk).await.is_err() {
+                    tracing::info!(alias = %alias, "Producer: consumer gone, stopping");
+                    break;
+                }
+
+                chunk_id += 1;
+                // EWMA + [500,5000]ms clamp guards against outlier duration_ms.
+                if duration_ms > 0 {
+                    let c = (duration_ms as u64).clamp(500, 5000);
+                    typical_chunk_dur_ms = (3 * typical_chunk_dur_ms + c) / 4;
+                }
+                // Fast endpoints: read-delay is ADAPTIVE via the controller. On
+                // every healthy fetch we let it opportunistically shrink one step
+                // toward the floor; `delay_chunks()` is always >= 1 so the
+                // live-edge lag-probe trails the edge and keeps a buffer (#232,
+                // adaptive controller). Non-fast endpoints keep the prior exact
+                // math: delay_ms==0 → live edge (0), else >=1 floor. RTMP push
+                // stays strictly 1× — this only moves the READ pointer.
+                let delivery_delay_chunks: i64 = match fast_delay.as_mut() {
+                    Some(ctrl) => {
+                        if let Some((from, to)) = ctrl.on_healthy(std::time::Instant::now()) {
+                            crate::fast_delay_audit::emit_delay_shrank(
+                                &audit_ring,
+                                &alias,
+                                from,
+                                to,
+                            );
+                        }
+                        ctrl.delay_chunks(typical_chunk_dur_ms)
+                    }
+                    None if delivery_delay_ms == 0 => 0,
+                    None => ((delivery_delay_ms / typical_chunk_dur_ms.max(1)) as i64).max(1),
+                };
+                maybe_jump_ahead(
+                    &fetcher,
+                    &mut chunk_id,
+                    delivery_delay_chunks,
+                    delivery_delay_ms,
+                    &mut iters_since_lag_probe,
+                    &alias,
+                )
+                .await;
+                tokio::task::yield_now().await;
+            }
+            Ok(None) => {
+                consecutive_chunk_misses += 1;
+
+                // Chunk gap skip-ahead logic
+                if consecutive_chunk_misses >= MAX_CHUNK_MISS_COUNT {
+                    // Captured BEFORE the probe loop mutates chunk_id, so the
+                    // controller can measure how far ahead we had to skip
+                    // (the read-side deficit) when a gap was crossed.
+                    let stuck_at = chunk_id;
+                    tracing::warn!(
+                        alias = %alias,
+                        chunk_id,
+                        misses = consecutive_chunk_misses,
+                        "Producer: probing ahead for chunks"
+                    );
+
+                    let mut found_ahead = false;
+                    for offset in 1..=SKIP_AHEAD_PROBE {
+                        let probe_id = chunk_id + offset;
+                        // Use HEAD (duration check) instead of GET to avoid downloading data
+                        if let Ok(Some(_)) = fetcher.chunk_duration_ms(probe_id).await {
+                            tracing::info!(
+                                alias = %alias,
+                                from = chunk_id,
+                                to = probe_id,
+                                "Producer: skipping ahead to chunk"
+                            );
+                            chunk_id = probe_id;
+                            consecutive_chunk_misses = 0;
+                            let mut s = stats.lock().await;
+                            s.consecutive_chunk_misses = 0;
+                            s.stall_reason = None;
+                            found_ahead = true;
+                            break;
+                        }
+                    }
+
+                    if !found_ahead {
+                        let mut s = stats.lock().await;
+                        s.stall_reason = Some("chunk_gap".to_string());
+                        s.consecutive_chunk_misses = consecutive_chunk_misses;
+                        drop(s);
+                        tracing::warn!(
+                            alias = %alias,
+                            chunk_id,
+                            "Producer: no chunks found in probe range"
+                        );
+                        // Reset counter so we probe again after another cycle
+                        consecutive_chunk_misses = 0;
+                    }
+
+                    // Fast endpoints only: a starvation event fired (probe
+                    // cycle). Grow the adaptive read-delay so the live-edge
+                    // lag-probe trails the edge by enough to absorb the spike.
+                    // `deficit_secs` is the media-time gap we had to skip when
+                    // a forward chunk was found; 0 when the gap was unbounded
+                    // (no chunk found → grow by the floor margin only). Runs
+                    // ONLY on the probe cycle, never on every miss.
+                    if let Some(ctrl) = fast_delay.as_mut() {
+                        let deficit_secs = if found_ahead {
+                            ((chunk_id - stuck_at).max(0) as u64)
+                                .saturating_mul(typical_chunk_dur_ms)
+                                / 1000
+                        } else {
+                            0
+                        };
+                        if let Some((from, to)) =
+                            ctrl.on_starvation(deficit_secs, std::time::Instant::now())
+                        {
+                            crate::fast_delay_audit::emit_delay_grown(
+                                &audit_ring,
+                                &alias,
+                                from,
+                                to,
+                                deficit_secs,
+                            );
+                        }
+                    }
+                } else {
+                    let mut s = stats.lock().await;
+                    s.consecutive_chunk_misses = consecutive_chunk_misses;
+                }
+
+                // Signal producer stall for rescue mode detection.
+                // Polls are 2s apart, so 3 misses = ~6s of genuinely no new
+                // chunks on S3. Triggering sooner means rescue activates
+                // faster after OBS stops, at the cost of occasional false
+                // positives on transient S3 errors (which self-heal on the
+                // next successful fetch — producer_active returns to true).
+                if consecutive_chunk_misses >= 3 {
+                    buffer_state
+                        .producer_active
+                        .store(false, AtomicOrdering::Relaxed);
+                }
+
+                tracing::debug!(alias = %alias, chunk_id, "Producer: chunk not found, waiting");
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
+                    _ = stop_rx.changed() => {
+                        if *stop_rx.borrow() { break; }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    alias = %alias,
+                    chunk_id,
+                    backoff_secs = s3_backoff_secs,
+                    "Producer: S3 fetch error, retrying in {s3_backoff_secs}s: {e}"
+                );
+                // Issue #173: emit audit row (rate-limited per error_class).
+                s3_fetch_audit.try_emit(&audit_ring, &alias, chunk_id, &e, s3_backoff_secs);
+                let mut s = stats.lock().await;
+                s.last_error = Some(e);
+                drop(s);
+                tokio::time::sleep(std::time::Duration::from_secs(s3_backoff_secs)).await;
+                s3_backoff_secs = (s3_backoff_secs * 2).min(S3_BACKOFF_MAX_SECS);
+            }
+        }
+    }
+
+    tracing::info!(alias = %alias, "Producer task stopped");
+}

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -781,8 +781,8 @@ async fn consumer_task<P: OutputProcessFactory>(
 /// channel. NEVER closes the connection on starvation — a push error just
 /// backs off briefly and the pusher lazy-reconnects on the next push.
 #[allow(clippy::too_many_arguments)]
-async fn keepalive_until_chunk(
-    pusher: &mut rs_rtmp_push::RtmpPusher,
+async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
+    pusher: &mut P,
     rx: &mut tokio::sync::mpsc::Receiver<PrefetchedChunk>,
     last_chunk_bytes: &Option<std::sync::Arc<Vec<u8>>>,
     alias: &str,
@@ -790,7 +790,13 @@ async fn keepalive_until_chunk(
     stop_rx: &mut tokio::sync::watch::Receiver<bool>,
 ) -> Option<PrefetchedChunk> {
     use crate::fast_keepalive::{KeepaliveMode, keepalive_bytes, keepalive_mode};
-    let started = std::time::Instant::now();
+    // `tokio::time::Instant` (not `std::time::Instant`) so the gap clock tracks
+    // the same time source as the `tokio::time::sleep` pacing in this loop.
+    // In production it reads the real clock identically to `std::Instant`; under
+    // `tokio::time::pause()`/`start_paused` (the Task-6 regression gate) it
+    // advances with `tokio::time::advance`, making the freeze→rescue transition
+    // deterministically testable without real wall-clock waits.
+    let started = tokio::time::Instant::now();
     let mut current_mode = keepalive_mode(0, last_chunk_bytes.is_some());
     crate::fast_delay_audit::emit_keepalive_started(
         audit_ring,

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -17,26 +17,26 @@ use crate::endpoint_audit;
 mod flv_normalizer;
 pub use flv_normalizer::FlvStreamNormalizer;
 
-use crate::producer_lag::maybe_jump as maybe_jump_ahead;
-
 const MAX_FFMPEG_RESTARTS: u32 = 10;
-const MAX_CHUNK_MISS_COUNT: u32 = 40; // ~80s at 2s polls
-const SKIP_AHEAD_PROBE: i64 = 10;
+// Producer-loop consts: `pub(crate)` so the extracted `endpoint_producer`
+// module (and the producer tests in `fast_self_healing_tests`) can reach them.
+pub(crate) const MAX_CHUNK_MISS_COUNT: u32 = 40; // ~80s at 2s polls
+pub(crate) const SKIP_AHEAD_PROBE: i64 = 10;
 pub(crate) const WRITE_TIMEOUT_SECS: u64 = 30;
 const MAX_WRITE_FAILURES_PER_CHUNK: u32 = 3;
 /// Base S3 backoff (doubles per error, max 60s, resets on success).
-const S3_BACKOFF_BASE_SECS: u64 = 2;
-const S3_BACKOFF_MAX_SECS: u64 = 60;
+pub(crate) const S3_BACKOFF_BASE_SECS: u64 = 2;
+pub(crate) const S3_BACKOFF_MAX_SECS: u64 = 60;
 const ENDPOINT_HEARTBEAT_SECS: u64 = 60;
 /// Pre-fetch buffer size: 10 chunks (~20s of media). disk_cache lives on
 /// local SSD; this mpsc just smooths producer/consumer pacing. See #174.
-const PREFETCH_BUFFER_SIZE: usize = 10;
+pub(crate) const PREFETCH_BUFFER_SIZE: usize = 10;
 
 /// A chunk that has been fetched from S3 and is ready for the consumer.
-struct PrefetchedChunk {
-    chunk_id: i64,
-    data: Vec<u8>,
-    duration_ms: i64,
+pub(crate) struct PrefetchedChunk {
+    pub(crate) chunk_id: i64,
+    pub(crate) data: Vec<u8>,
+    pub(crate) duration_ms: i64,
 }
 
 /// Trait for fetching chunks (S3 or mock).
@@ -220,247 +220,9 @@ use crate::endpoint_rtmp_url::build_rtmp_url;
 #[cfg(test)]
 pub(crate) use crate::endpoint_rtmp_url::build_rtmp_url_pub;
 
-/// Producer task: fetches chunks from S3 and sends them into the bounded channel.
-#[allow(clippy::too_many_arguments)]
-async fn producer_task<F: ChunkFetcher>(
-    fetcher: F,
-    tx: mpsc::Sender<PrefetchedChunk>,
-    start_chunk_id: i64,
-    delivery_delay_ms: u64,
-    is_fast: bool,
-    mut stop_rx: watch::Receiver<bool>,
-    stats: Stats,
-    alias: String,
-    buffer_state: Arc<BufferState>,
-    audit_ring: Option<Arc<AuditRing>>,
-) {
-    let mut chunk_id = start_chunk_id;
-    let mut consecutive_chunk_misses: u32 = 0;
-    let mut s3_backoff_secs: u64 = S3_BACKOFF_BASE_SECS;
-    // Issue #173: rate-limited audit-row emitter, owned by this task.
-    let mut s3_fetch_audit = crate::endpoint_audit::S3FetchAuditLimiter::new();
-    // Lag-detect state. typical_chunk_dur_ms is updated from observed
-    // `duration_ms` so it tracks operator config without a hardcode.
-    let mut typical_chunk_dur_ms: u64 = 1000;
-    let mut iters_since_lag_probe: u32 = 0;
-    // Adaptive read-delay controller — fast endpoints only. Grows the
-    // read-delay on starvation (so the live-edge lag-probe leaves a buffer
-    // instead of re-pinning to the edge) and shrinks slowly when healthy.
-    // None for non-fast endpoints → byte-for-byte unchanged behaviour.
-    let mut fast_delay = if is_fast {
-        Some(crate::fast_delay::FastDelayController::new(
-            std::time::Instant::now(),
-        ))
-    } else {
-        None
-    };
-
-    loop {
-        if *stop_rx.borrow() {
-            tracing::info!(alias = %alias, "Producer: stop signal received");
-            break;
-        }
-
-        // Fetch chunk with metadata in one S3 GET
-        match fetcher.fetch_chunk_with_meta(chunk_id).await {
-            Ok(Some((data, duration_ms))) => {
-                consecutive_chunk_misses = 0;
-                s3_backoff_secs = S3_BACKOFF_BASE_SECS;
-                {
-                    let mut s = stats.lock().await;
-                    s.consecutive_chunk_misses = 0;
-                    if s.stall_reason.as_deref() == Some("chunk_gap") {
-                        s.stall_reason = None;
-                    }
-                }
-
-                let chunk = PrefetchedChunk {
-                    chunk_id,
-                    data,
-                    duration_ms,
-                };
-
-                // Track buffer growth for rescue mode
-                let current_buf = buffer_state
-                    .buffer_duration_ms
-                    .load(AtomicOrdering::Relaxed);
-                buffer_state.buffer_duration_ms.store(
-                    current_buf.saturating_add(duration_ms.max(0) as u64),
-                    AtomicOrdering::Relaxed,
-                );
-                buffer_state
-                    .producer_active
-                    .store(true, AtomicOrdering::Relaxed);
-
-                // Send into channel; blocks if buffer full (backpressure).
-                // If receiver is dropped (consumer gone), stop.
-                if tx.send(chunk).await.is_err() {
-                    tracing::info!(alias = %alias, "Producer: consumer gone, stopping");
-                    break;
-                }
-
-                chunk_id += 1;
-                // EWMA + [500,5000]ms clamp guards against outlier duration_ms.
-                if duration_ms > 0 {
-                    let c = (duration_ms as u64).clamp(500, 5000);
-                    typical_chunk_dur_ms = (3 * typical_chunk_dur_ms + c) / 4;
-                }
-                // Fast endpoints: read-delay is ADAPTIVE via the controller. On
-                // every healthy fetch we let it opportunistically shrink one step
-                // toward the floor; `delay_chunks()` is always >= 1 so the
-                // live-edge lag-probe trails the edge and keeps a buffer (#232,
-                // adaptive controller). Non-fast endpoints keep the prior exact
-                // math: delay_ms==0 → live edge (0), else >=1 floor. RTMP push
-                // stays strictly 1× — this only moves the READ pointer.
-                let delivery_delay_chunks: i64 = match fast_delay.as_mut() {
-                    Some(ctrl) => {
-                        if let Some((from, to)) = ctrl.on_healthy(std::time::Instant::now()) {
-                            crate::fast_delay_audit::emit_delay_shrank(
-                                &audit_ring,
-                                &alias,
-                                from,
-                                to,
-                            );
-                        }
-                        ctrl.delay_chunks(typical_chunk_dur_ms)
-                    }
-                    None if delivery_delay_ms == 0 => 0,
-                    None => ((delivery_delay_ms / typical_chunk_dur_ms.max(1)) as i64).max(1),
-                };
-                maybe_jump_ahead(
-                    &fetcher,
-                    &mut chunk_id,
-                    delivery_delay_chunks,
-                    delivery_delay_ms,
-                    &mut iters_since_lag_probe,
-                    &alias,
-                )
-                .await;
-                tokio::task::yield_now().await;
-            }
-            Ok(None) => {
-                consecutive_chunk_misses += 1;
-
-                // Chunk gap skip-ahead logic
-                if consecutive_chunk_misses >= MAX_CHUNK_MISS_COUNT {
-                    // Captured BEFORE the probe loop mutates chunk_id, so the
-                    // controller can measure how far ahead we had to skip
-                    // (the read-side deficit) when a gap was crossed.
-                    let stuck_at = chunk_id;
-                    tracing::warn!(
-                        alias = %alias,
-                        chunk_id,
-                        misses = consecutive_chunk_misses,
-                        "Producer: probing ahead for chunks"
-                    );
-
-                    let mut found_ahead = false;
-                    for offset in 1..=SKIP_AHEAD_PROBE {
-                        let probe_id = chunk_id + offset;
-                        // Use HEAD (duration check) instead of GET to avoid downloading data
-                        if let Ok(Some(_)) = fetcher.chunk_duration_ms(probe_id).await {
-                            tracing::info!(
-                                alias = %alias,
-                                from = chunk_id,
-                                to = probe_id,
-                                "Producer: skipping ahead to chunk"
-                            );
-                            chunk_id = probe_id;
-                            consecutive_chunk_misses = 0;
-                            let mut s = stats.lock().await;
-                            s.consecutive_chunk_misses = 0;
-                            s.stall_reason = None;
-                            found_ahead = true;
-                            break;
-                        }
-                    }
-
-                    if !found_ahead {
-                        let mut s = stats.lock().await;
-                        s.stall_reason = Some("chunk_gap".to_string());
-                        s.consecutive_chunk_misses = consecutive_chunk_misses;
-                        drop(s);
-                        tracing::warn!(
-                            alias = %alias,
-                            chunk_id,
-                            "Producer: no chunks found in probe range"
-                        );
-                        // Reset counter so we probe again after another cycle
-                        consecutive_chunk_misses = 0;
-                    }
-
-                    // Fast endpoints only: a starvation event fired (probe
-                    // cycle). Grow the adaptive read-delay so the live-edge
-                    // lag-probe trails the edge by enough to absorb the spike.
-                    // `deficit_secs` is the media-time gap we had to skip when
-                    // a forward chunk was found; 0 when the gap was unbounded
-                    // (no chunk found → grow by the floor margin only). Runs
-                    // ONLY on the probe cycle, never on every miss.
-                    if let Some(ctrl) = fast_delay.as_mut() {
-                        let deficit_secs = if found_ahead {
-                            ((chunk_id - stuck_at).max(0) as u64)
-                                .saturating_mul(typical_chunk_dur_ms)
-                                / 1000
-                        } else {
-                            0
-                        };
-                        if let Some((from, to)) =
-                            ctrl.on_starvation(deficit_secs, std::time::Instant::now())
-                        {
-                            crate::fast_delay_audit::emit_delay_grown(
-                                &audit_ring,
-                                &alias,
-                                from,
-                                to,
-                                deficit_secs,
-                            );
-                        }
-                    }
-                } else {
-                    let mut s = stats.lock().await;
-                    s.consecutive_chunk_misses = consecutive_chunk_misses;
-                }
-
-                // Signal producer stall for rescue mode detection.
-                // Polls are 2s apart, so 3 misses = ~6s of genuinely no new
-                // chunks on S3. Triggering sooner means rescue activates
-                // faster after OBS stops, at the cost of occasional false
-                // positives on transient S3 errors (which self-heal on the
-                // next successful fetch — producer_active returns to true).
-                if consecutive_chunk_misses >= 3 {
-                    buffer_state
-                        .producer_active
-                        .store(false, AtomicOrdering::Relaxed);
-                }
-
-                tracing::debug!(alias = %alias, chunk_id, "Producer: chunk not found, waiting");
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
-                    _ = stop_rx.changed() => {
-                        if *stop_rx.borrow() { break; }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::error!(
-                    alias = %alias,
-                    chunk_id,
-                    backoff_secs = s3_backoff_secs,
-                    "Producer: S3 fetch error, retrying in {s3_backoff_secs}s: {e}"
-                );
-                // Issue #173: emit audit row (rate-limited per error_class).
-                s3_fetch_audit.try_emit(&audit_ring, &alias, chunk_id, &e, s3_backoff_secs);
-                let mut s = stats.lock().await;
-                s.last_error = Some(e);
-                drop(s);
-                tokio::time::sleep(std::time::Duration::from_secs(s3_backoff_secs)).await;
-                s3_backoff_secs = (s3_backoff_secs * 2).min(S3_BACKOFF_MAX_SECS);
-            }
-        }
-    }
-
-    tracing::info!(alias = %alias, "Producer task stopped");
-}
+// `producer_task` was extracted to `crate::endpoint_producer` so this file
+// stays under the 1000-line CI cap while `consumer_task` keeps room to grow.
+// `endpoint_loop` calls it as `crate::endpoint_producer::producer_task(...)`.
 
 /// Consumer task: pulls pre-fetched chunks from the channel, normalizes FLV,
 /// writes to the configured output backend (ffmpeg subprocess or Rust RTMP
@@ -966,7 +728,7 @@ pub async fn endpoint_loop<F: ChunkFetcher + 'static, P: OutputProcessFactory + 
     let producer_audit_ring = audit_ring.clone();
     // `is_fast` is Copy — read it before `ep_cfg` is moved into consumer_task.
     let producer_is_fast = ep_cfg.is_fast;
-    let producer = tokio::spawn(producer_task(
+    let producer = tokio::spawn(crate::endpoint_producer::producer_task(
         fetcher,
         tx,
         start_chunk_id,

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -482,6 +482,7 @@ async fn consumer_task<P: OutputProcessFactory>(
                             &alias,
                             &audit_ring,
                             &mut stop_rx,
+                            &stats,
                         )
                         .await
                         {
@@ -780,6 +781,10 @@ async fn consumer_task<P: OutputProcessFactory>(
 /// Returns the next real chunk when one arrives, or `None` on stop/closed
 /// channel. NEVER closes the connection on starvation — a push error just
 /// backs off briefly and the pusher lazy-reconnects on the next push.
+///
+/// Sets `stats.delivery_mode = "rescue"` on entry and resets it to
+/// `"normal"` on both exit paths so the dashboard correctly reflects the
+/// keepalive gap instead of showing stale `"normal"` state.
 #[allow(clippy::too_many_arguments)]
 async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
     pusher: &mut P,
@@ -788,6 +793,7 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
     alias: &str,
     audit_ring: &Option<std::sync::Arc<crate::audit_ring::AuditRing>>,
     stop_rx: &mut tokio::sync::watch::Receiver<bool>,
+    stats: &Stats,
 ) -> Option<PrefetchedChunk> {
     use crate::fast_keepalive::{KeepaliveMode, keepalive_bytes, keepalive_mode};
     // `tokio::time::Instant` (not `std::time::Instant`) so the gap clock tracks
@@ -807,6 +813,13 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
             "freeze"
         },
     );
+    // Surface keepalive gap on the dashboard: set delivery_mode to "rescue"
+    // so the UI doesn't falsely show "normal" during the starvation window.
+    // Lock is released immediately (not held across any .await).
+    {
+        let mut s = stats.lock().await;
+        s.delivery_mode = "rescue".to_string();
+    }
     loop {
         let gap = started.elapsed().as_secs();
         let mode = keepalive_mode(gap, last_chunk_bytes.is_some());
@@ -822,10 +835,19 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
                 },
             );
         }
-        let bytes = keepalive_bytes(mode, last_chunk_bytes).into_owned();
+        // Finding 2: keep the Cow (borrowing last_chunk_bytes) instead of
+        // cloning with .into_owned() — avoids a multi-MB heap allocation on
+        // every keepalive tick for the freeze window.
+        let bytes = keepalive_bytes(mode, last_chunk_bytes);
         tokio::select! {
             maybe = rx.recv() => {
                 crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+                // Reset delivery_mode before returning so the dashboard
+                // reflects normal delivery as soon as the real chunk resumes.
+                {
+                    let mut s = stats.lock().await;
+                    s.delivery_mode = "normal".to_string();
+                }
                 return maybe;
             }
             res = pusher.push_flv_bytes(&bytes) => {
@@ -838,6 +860,11 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
             _ = stop_rx.changed() => {
                 if *stop_rx.borrow() {
                     crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+                    // Reset delivery_mode before returning None (stop path).
+                    {
+                        let mut s = stats.lock().await;
+                        s.delivery_mode = "normal".to_string();
+                    }
                     return None;
                 }
             }

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -227,6 +227,7 @@ async fn producer_task<F: ChunkFetcher>(
     tx: mpsc::Sender<PrefetchedChunk>,
     start_chunk_id: i64,
     delivery_delay_ms: u64,
+    is_fast: bool,
     mut stop_rx: watch::Receiver<bool>,
     stats: Stats,
     alias: String,
@@ -242,6 +243,17 @@ async fn producer_task<F: ChunkFetcher>(
     // `duration_ms` so it tracks operator config without a hardcode.
     let mut typical_chunk_dur_ms: u64 = 1000;
     let mut iters_since_lag_probe: u32 = 0;
+    // Adaptive read-delay controller — fast endpoints only. Grows the
+    // read-delay on starvation (so the live-edge lag-probe leaves a buffer
+    // instead of re-pinning to the edge) and shrinks slowly when healthy.
+    // None for non-fast endpoints → byte-for-byte unchanged behaviour.
+    let mut fast_delay = if is_fast {
+        Some(crate::fast_delay::FastDelayController::new(
+            std::time::Instant::now(),
+        ))
+    } else {
+        None
+    };
 
     loop {
         if *stop_rx.borrow() {
@@ -293,14 +305,27 @@ async fn producer_task<F: ChunkFetcher>(
                     let c = (duration_ms as u64).clamp(500, 5000);
                     typical_chunk_dur_ms = (3 * typical_chunk_dur_ms + c) / 4;
                 }
-                // Fast endpoints (delay_ms==0) target the LIVE EDGE (delay_chunks=0
-                // → maybe_jump skips to the highest existing chunk); delayed keep a
-                // >=1 floor so the jump trails live by the configured delay. RTMP
-                // push stays strictly 1× — this only moves the READ pointer. (#232)
-                let delivery_delay_chunks: i64 = if delivery_delay_ms == 0 {
-                    0
-                } else {
-                    ((delivery_delay_ms / typical_chunk_dur_ms.max(1)) as i64).max(1)
+                // Fast endpoints: read-delay is ADAPTIVE via the controller. On
+                // every healthy fetch we let it opportunistically shrink one step
+                // toward the floor; `delay_chunks()` is always >= 1 so the
+                // live-edge lag-probe trails the edge and keeps a buffer (#232,
+                // adaptive controller). Non-fast endpoints keep the prior exact
+                // math: delay_ms==0 → live edge (0), else >=1 floor. RTMP push
+                // stays strictly 1× — this only moves the READ pointer.
+                let delivery_delay_chunks: i64 = match fast_delay.as_mut() {
+                    Some(ctrl) => {
+                        if let Some((from, to)) = ctrl.on_healthy(std::time::Instant::now()) {
+                            crate::fast_delay_audit::emit_delay_shrank(
+                                &audit_ring,
+                                &alias,
+                                from,
+                                to,
+                            );
+                        }
+                        ctrl.delay_chunks(typical_chunk_dur_ms)
+                    }
+                    None if delivery_delay_ms == 0 => 0,
+                    None => ((delivery_delay_ms / typical_chunk_dur_ms.max(1)) as i64).max(1),
                 };
                 maybe_jump_ahead(
                     &fetcher,
@@ -318,6 +343,10 @@ async fn producer_task<F: ChunkFetcher>(
 
                 // Chunk gap skip-ahead logic
                 if consecutive_chunk_misses >= MAX_CHUNK_MISS_COUNT {
+                    // Captured BEFORE the probe loop mutates chunk_id, so the
+                    // controller can measure how far ahead we had to skip
+                    // (the read-side deficit) when a gap was crossed.
+                    let stuck_at = chunk_id;
                     tracing::warn!(
                         alias = %alias,
                         chunk_id,
@@ -358,6 +387,34 @@ async fn producer_task<F: ChunkFetcher>(
                         );
                         // Reset counter so we probe again after another cycle
                         consecutive_chunk_misses = 0;
+                    }
+
+                    // Fast endpoints only: a starvation event fired (probe
+                    // cycle). Grow the adaptive read-delay so the live-edge
+                    // lag-probe trails the edge by enough to absorb the spike.
+                    // `deficit_secs` is the media-time gap we had to skip when
+                    // a forward chunk was found; 0 when the gap was unbounded
+                    // (no chunk found → grow by the floor margin only). Runs
+                    // ONLY on the probe cycle, never on every miss.
+                    if let Some(ctrl) = fast_delay.as_mut() {
+                        let deficit_secs = if found_ahead {
+                            ((chunk_id - stuck_at).max(0) as u64)
+                                .saturating_mul(typical_chunk_dur_ms)
+                                / 1000
+                        } else {
+                            0
+                        };
+                        if let Some((from, to)) =
+                            ctrl.on_starvation(deficit_secs, std::time::Instant::now())
+                        {
+                            crate::fast_delay_audit::emit_delay_grown(
+                                &audit_ring,
+                                &alias,
+                                from,
+                                to,
+                                deficit_secs,
+                            );
+                        }
                     }
                 } else {
                     let mut s = stats.lock().await;
@@ -907,11 +964,14 @@ pub async fn endpoint_loop<F: ChunkFetcher + 'static, P: OutputProcessFactory + 
     let producer_alias = alias.clone();
     let producer_buffer_state = buffer_state.clone();
     let producer_audit_ring = audit_ring.clone();
+    // `is_fast` is Copy — read it before `ep_cfg` is moved into consumer_task.
+    let producer_is_fast = ep_cfg.is_fast;
     let producer = tokio::spawn(producer_task(
         fetcher,
         tx,
         start_chunk_id,
         delivery_delay_ms,
+        producer_is_fast,
         producer_stop,
         producer_stats,
         producer_alias,

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -272,6 +272,10 @@ async fn consumer_task<P: OutputProcessFactory>(
     let mut consecutive_write_failures: u32 = 0;
     // Last delivered chunk id, recorded in the rescue audit row on stall.
     let mut last_delivered_chunk_id: i64 = -1;
+    // Last full FLV chunk pushed — replayed as a freeze during keepalive.
+    // Only populated for fast endpoints (avoids a per-chunk clone on the
+    // high-bitrate normal endpoints).
+    let mut last_chunk_bytes: Option<std::sync::Arc<Vec<u8>>> = None;
     let mut last_heartbeat = std::time::Instant::now();
     // Consecutive push errors for the Rust pusher exponential backoff ladder.
     let mut consecutive_push_errors: u32 = 0;
@@ -415,8 +419,97 @@ async fn consumer_task<P: OutputProcessFactory>(
             }
         }
 
-        // Pull next chunk from channel (rescue-mode-aware)
-        let chunk = tokio::select! {
+        // Pull next chunk from channel (rescue-mode-aware).
+        //
+        // FAST + rust pusher only: a short producer gap triggers the
+        // never-crash keepalive (freeze last chunk → default rescue) on the
+        // SAME rtmp session, so starvation never tears the connection down.
+        // EVERY other path (normal YT/FB, any ffmpeg endpoint) keeps the
+        // existing select! verbatim — the 8s `run_outage_rescue` behaviour is
+        // unchanged byte-for-byte.
+        let chunk = if ep_cfg.is_fast && use_rust_pusher {
+            tokio::select! {
+                maybe_chunk = rx.recv() => {
+                    match maybe_chunk {
+                        Some(c) => {
+                            // SAME buffer bookkeeping as the existing Some(c) arm.
+                            let dur = c.duration_ms.max(0) as u64;
+                            let current = buffer_state.buffer_duration_ms.load(AtomicOrdering::Relaxed);
+                            buffer_state.buffer_duration_ms.store(current.saturating_sub(dur), AtomicOrdering::Relaxed);
+                            last_delivered_chunk_id = c.chunk_id;
+                            c
+                        }
+                        None => {
+                            // SAME defensive-rescue None branch as the existing
+                            // path (producer gone, rescue before teardown).
+                            tracing::warn!(
+                                alias = %alias,
+                                "Consumer: producer gone, entering defensive rescue before teardown"
+                            );
+                            let svc_type: rs_ffmpeg::ServiceType = ep_cfg
+                                .service_type
+                                .parse()
+                                .unwrap_or(rs_ffmpeg::ServiceType::TestFile);
+                            crate::rescue::run_defensive_rescue(
+                                &alias,
+                                rescue_video_url.as_deref(),
+                                svc_type,
+                                &ep_cfg.stream_key,
+                                &buffer_state,
+                                &stats,
+                                &mut stop_rx,
+                                &audit_ring,
+                                last_delivered_chunk_id,
+                                &mut proc,
+                                &mut rust_pusher,
+                            )
+                            .await;
+                            break;
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_secs(crate::fast_keepalive::FAST_KEEPALIVE_TRIGGER_SECS)) => {
+                    // Producer gap exceeded the fast trigger. Feed the existing
+                    // session with keepalive frames until a real chunk arrives.
+                    // The `if let` borrow of `rust_pusher` is scoped to this
+                    // arm: it ends when the arm produces the owned chunk value,
+                    // BEFORE the write section below re-borrows `rust_pusher`.
+                    if let Some(ref mut pusher) = rust_pusher {
+                        match keepalive_until_chunk(
+                            pusher,
+                            &mut rx,
+                            &last_chunk_bytes,
+                            &alias,
+                            &audit_ring,
+                            &mut stop_rx,
+                        )
+                        .await
+                        {
+                            Some(c) => {
+                                // SAME buffer bookkeeping as the Some(c) arm.
+                                let dur = c.duration_ms.max(0) as u64;
+                                let current = buffer_state.buffer_duration_ms.load(AtomicOrdering::Relaxed);
+                                buffer_state.buffer_duration_ms.store(current.saturating_sub(dur), AtomicOrdering::Relaxed);
+                                last_delivered_chunk_id = c.chunk_id;
+                                c
+                            }
+                            None => break,
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+                _ = stop_rx.changed() => {
+                    if *stop_rx.borrow() {
+                        tracing::info!(alias = %alias, "Consumer: stop signal during recv");
+                        break;
+                    }
+                    continue;
+                }
+            }
+        } else {
+            // EXISTING chunk-pull select! — non-fast and ffmpeg paths, UNCHANGED.
+            tokio::select! {
             maybe_chunk = rx.recv() => {
                 match maybe_chunk {
                     Some(c) => {
@@ -519,6 +612,7 @@ async fn consumer_task<P: OutputProcessFactory>(
                 }
                 continue;
             }
+            }
         };
 
         let chunk_id = chunk.chunk_id;
@@ -565,6 +659,12 @@ async fn consumer_task<P: OutputProcessFactory>(
                         chunk_duration_ms,
                         cumulative_pushed_secs,
                     );
+                    // Fast endpoints only: remember the chunk so keepalive can
+                    // replay it as a freeze during a producer gap. Skipped on
+                    // normal endpoints to avoid the per-chunk clone.
+                    if ep_cfg.is_fast {
+                        last_chunk_bytes = Some(std::sync::Arc::new(chunk.data.clone()));
+                    }
                 }
             }
         } else if let Some(ref mut p) = proc {
@@ -674,6 +774,69 @@ async fn consumer_task<P: OutputProcessFactory>(
         pusher.close().await;
     }
     tracing::info!(alias = %alias, "Consumer task stopped");
+}
+
+/// Keep the existing rust session alive during a fast-endpoint producer gap.
+/// Returns the next real chunk when one arrives, or `None` on stop/closed
+/// channel. NEVER closes the connection on starvation — a push error just
+/// backs off briefly and the pusher lazy-reconnects on the next push.
+#[allow(clippy::too_many_arguments)]
+async fn keepalive_until_chunk(
+    pusher: &mut rs_rtmp_push::RtmpPusher,
+    rx: &mut tokio::sync::mpsc::Receiver<PrefetchedChunk>,
+    last_chunk_bytes: &Option<std::sync::Arc<Vec<u8>>>,
+    alias: &str,
+    audit_ring: &Option<std::sync::Arc<crate::audit_ring::AuditRing>>,
+    stop_rx: &mut tokio::sync::watch::Receiver<bool>,
+) -> Option<PrefetchedChunk> {
+    use crate::fast_keepalive::{KeepaliveMode, keepalive_bytes, keepalive_mode};
+    let started = std::time::Instant::now();
+    let mut current_mode = keepalive_mode(0, last_chunk_bytes.is_some());
+    crate::fast_delay_audit::emit_keepalive_started(
+        audit_ring,
+        alias,
+        if current_mode == KeepaliveMode::Rescue {
+            "rescue"
+        } else {
+            "freeze"
+        },
+    );
+    loop {
+        let gap = started.elapsed().as_secs();
+        let mode = keepalive_mode(gap, last_chunk_bytes.is_some());
+        if mode != current_mode {
+            current_mode = mode;
+            crate::fast_delay_audit::emit_keepalive_started(
+                audit_ring,
+                alias,
+                if mode == KeepaliveMode::Rescue {
+                    "rescue"
+                } else {
+                    "freeze"
+                },
+            );
+        }
+        let bytes = keepalive_bytes(mode, last_chunk_bytes).into_owned();
+        tokio::select! {
+            maybe = rx.recv() => {
+                crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+                return maybe;
+            }
+            res = pusher.push_flv_bytes(&bytes) => {
+                if let Err(e) = res {
+                    tracing::warn!(alias = %alias, "keepalive push error: {e}; will reconnect on next push");
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+                // push_flv_bytes self-paces ~1x; loop to push the next tick.
+            }
+            _ = stop_rx.changed() => {
+                if *stop_rx.borrow() {
+                    crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+                    return None;
+                }
+            }
+        }
+    }
 }
 
 /// Core endpoint loop -- generic over ChunkFetcher and OutputProcessFactory for testability.

--- a/crates/rs-delivery/src/endpoint_task_test_root.rs
+++ b/crates/rs-delivery/src/endpoint_task_test_root.rs
@@ -4,6 +4,8 @@
 
 #[path = "endpoint_task_backoff_tests.rs"]
 mod backoff_tests;
+#[path = "fast_self_healing_tests.rs"]
+mod fast_self_healing_tests;
 #[path = "endpoint_task_flv_tests.rs"]
 mod flv_tests;
 #[path = "endpoint_task_rescue_tests.rs"]

--- a/crates/rs-delivery/src/endpoint_task_tests.rs
+++ b/crates/rs-delivery/src/endpoint_task_tests.rs
@@ -89,7 +89,9 @@ impl OutputProcess for MockProcess {
     }
 }
 
-struct MockProcessFactory {
+// `pub(crate)` so the sibling `fast_self_healing_tests` module (which holds
+// the moved fast-delay / chunk-gap tests) can reuse this shared mock factory.
+pub(crate) struct MockProcessFactory {
     alive: Arc<AtomicBool>,
     writes: Arc<TokioMutex<Vec<Vec<u8>>>>,
     fail_after_writes: Option<u32>,
@@ -99,7 +101,7 @@ struct MockProcessFactory {
 }
 
 impl MockProcessFactory {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             alive: Arc::new(AtomicBool::new(true)),
             writes: Arc::new(TokioMutex::new(Vec::new())),
@@ -130,7 +132,9 @@ impl OutputProcessFactory for MockProcessFactory {
     }
 }
 
-fn test_ep_cfg() -> EndpointConfig {
+// `pub(crate)` so the sibling `fast_self_healing_tests` module can build the
+// same default endpoint config for the moved tests.
+pub(crate) fn test_ep_cfg() -> EndpointConfig {
     EndpointConfig {
         alias: "test-ep".to_string(),
         service_type: "TEST_FILE".to_string(),
@@ -773,7 +777,9 @@ async fn test_stats_struct_serializes() {
 
 // TimedMockFetcher: chunks available at configured rate.
 // 2000ms chunk duration matches buffer-fill/chunk-gap tests.
-struct TimedMockFetcher {
+// `pub(crate)` so the sibling `fast_self_healing_tests` module can reuse it
+// for the moved fast-delay / chunk-gap tests.
+pub(crate) struct TimedMockFetcher {
     chunks: Arc<TokioMutex<std::collections::HashMap<i64, Vec<u8>>>>,
     available_up_to: Arc<AtomicI64>,
     duration_ms_per_chunk: i64,
@@ -787,7 +793,7 @@ struct TimedMockFetcher {
 }
 
 impl TimedMockFetcher {
-    fn new(chunks: Vec<(i64, Vec<u8>)>, initially_available: i64) -> Self {
+    pub(crate) fn new(chunks: Vec<(i64, Vec<u8>)>, initially_available: i64) -> Self {
         Self {
             chunks: Arc::new(TokioMutex::new(chunks.into_iter().collect())),
             available_up_to: Arc::new(AtomicI64::new(initially_available)),
@@ -797,16 +803,16 @@ impl TimedMockFetcher {
         }
     }
 
-    fn with_latency(mut self, d: std::time::Duration) -> Self {
+    pub(crate) fn with_latency(mut self, d: std::time::Duration) -> Self {
         self.fetch_latency = d;
         self
     }
 
-    fn available_up_to(&self) -> Arc<AtomicI64> {
+    pub(crate) fn available_up_to(&self) -> Arc<AtomicI64> {
         self.available_up_to.clone()
     }
 
-    fn max_fetched_id(&self) -> Arc<AtomicI64> {
+    pub(crate) fn max_fetched_id(&self) -> Arc<AtomicI64> {
         self.max_fetched_id.clone()
     }
 }
@@ -917,253 +923,4 @@ async fn test_buffer_fill_waits_for_target_chunk() {
 
     let _ = stop_tx.send(true);
     let _ = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
-}
-#[tokio::test]
-async fn test_chunk_gap_maintained_at_delay_target() {
-    // With delivery_delay_ms=20000, start_chunk_id=1, pre-load chunks 1-30 (2000ms each):
-    // After buffer fill (chunk 11 available), VPS starts consuming from chunk 1.
-    // Elapsed-aware pacing: 1000ms per chunk (non-fast).
-    tokio::time::pause();
-
-    let all_chunks: Vec<(i64, Vec<u8>)> = (1..=30).map(|i| (i, vec![i as u8; 100])).collect();
-    // All 30 chunks available immediately
-    let fetcher = TimedMockFetcher::new(all_chunks, 30);
-    let factory = MockProcessFactory::new();
-
-    let (stop_tx, stop_rx) = watch::channel(false);
-    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
-
-    let stats_clone = stats.clone();
-    let handle = tokio::spawn(async move {
-        endpoint_loop(
-            fetcher,
-            factory,
-            test_ep_cfg(),
-            1,     // start_chunk_id
-            20000, // delivery_delay_ms (10 chunks * 2000ms)
-            stop_rx,
-            stats_clone,
-            None,
-            Arc::new(BufferState::new()),
-            None,
-        )
-        .await;
-    });
-
-    // Buffer fill needs 10 chunks (20000ms / 2000ms) which are already
-    // available. Consumer pacing sleeps ~2000ms per chunk. 30 chunks require
-    // ~60s of wall-clock advancement for pacing. Each iteration advances
-    // 100ms, so we need at least 600 iterations; use 2000 for slack.
-    for _ in 0..2000 {
-        tokio::time::advance(std::time::Duration::from_millis(100)).await;
-        tokio::task::yield_now().await;
-    }
-
-    let s = stats.lock().await;
-    assert_eq!(
-        s.chunks_processed, 30,
-        "Should have processed all 30 chunks, got {}",
-        s.chunks_processed
-    );
-    drop(s);
-
-    let _ = stop_tx.send(true);
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
-}
-#[tokio::test]
-async fn test_buffer_fill_stops_on_signal() {
-    // If stop signal is sent during buffer fill, the loop should exit
-    // without processing any chunks.
-    tokio::time::pause();
-
-    let all_chunks: Vec<(i64, Vec<u8>)> = (1..=5).map(|i| (i, vec![i as u8; 100])).collect();
-    // Only chunk 1 available, target_chunk = 1 + 10 = 11 -- will never be available
-    let fetcher = TimedMockFetcher::new(all_chunks, 1);
-    let factory = MockProcessFactory::new();
-
-    let (stop_tx, stop_rx) = watch::channel(false);
-    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
-
-    let stats_clone = stats.clone();
-    let handle = tokio::spawn(async move {
-        endpoint_loop(
-            fetcher,
-            factory,
-            test_ep_cfg(),
-            1,
-            20000, // delivery_delay_ms (10 chunks * 2000ms)
-            stop_rx,
-            stats_clone,
-            None,
-            Arc::new(BufferState::new()),
-            None,
-        )
-        .await;
-    });
-
-    // Let it poll a few times during buffer fill
-    for _ in 0..3 {
-        tokio::time::advance(std::time::Duration::from_secs(2)).await;
-        tokio::task::yield_now().await;
-    }
-
-    // Send stop signal
-    let _ = stop_tx.send(true);
-
-    let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
-    assert!(
-        result.is_ok(),
-        "Task should have stopped during buffer fill"
-    );
-
-    let s = stats.lock().await;
-    assert_eq!(
-        s.chunks_processed, 0,
-        "Should not have processed any chunks, stopped during buffer fill"
-    );
-}
-
-#[tokio::test(start_paused = true)]
-async fn test_fast_endpoint_producer_trails_live_edge() {
-    // A FAST endpoint must build a buffer: even with the live edge far ahead
-    // and S3 fetches incurring latency (the upload-spike scenario), the
-    // adaptive controller keeps the read pointer BEHIND the edge. The
-    // live-edge lag-probe jumps to `edge - delay_chunks` with delay_chunks
-    // >= 1 (the controller floor), so the producer leaves a buffer instead of
-    // re-pinning to the absolute edge.
-    //
-    // Old behaviour (delivery_delay_ms == 0 → delivery_delay_chunks == 0)
-    // pinned the read pointer to the live edge, so any S3 latency spike
-    // instantly starved the push. This test drives `producer_task` directly
-    // and asserts the producer's highest requested chunk_id stays strictly
-    // below the live edge after the lag-probe fires (a buffer was built) and
-    // that it JUMPED forward (did not replay the whole backlog one-by-one).
-    let live_edge: i64 = 30_000;
-    // All chunks exist and are available from t=0; the producer is "behind"
-    // the live edge purely because it reads at 1x + the injected latency.
-    let chunks: Vec<(i64, Vec<u8>)> = (1..=live_edge).map(|i| (i, vec![0u8; 4])).collect();
-    // 50ms per fetch simulates real S3 GET/HEAD latency. Each fetch advances
-    // virtual time, so the producer reads at a bounded rate well below the
-    // far-ahead live edge.
-    let fetcher =
-        TimedMockFetcher::new(chunks, live_edge).with_latency(std::time::Duration::from_millis(50));
-    let max_fetched = fetcher.max_fetched_id();
-
-    let (tx, mut rx) = mpsc::channel::<PrefetchedChunk>(PREFETCH_BUFFER_SIZE);
-    let (stop_tx, stop_rx) = watch::channel(false);
-    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
-    let buffer_state = Arc::new(BufferState::new());
-
-    // Draining consumer: pull chunks as fast as they arrive so the producer
-    // never blocks on the bounded channel.
-    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
-
-    let producer = tokio::spawn(producer_task(
-        fetcher,
-        tx,
-        1,    // start_chunk_id
-        0,    // delivery_delay_ms (fast endpoints pass 0)
-        true, // is_fast → adaptive controller engaged
-        stop_rx,
-        stats.clone(),
-        "fast-ep".to_string(),
-        buffer_state,
-        None,
-    ));
-
-    // Drive virtual time. With 50ms/fetch latency, ~12s of advance lets the
-    // producer read > LAG_PROBE_INTERVAL_ITERS (30) chunks, fire the lag-probe
-    // once, jump forward by the ladder window (~8k chunks), and keep reading.
-    // It stays far below the 30_000 live edge so the trailing assertion holds
-    // deterministically (it cannot collapse onto the edge in this window).
-    for _ in 0..1200 {
-        tokio::time::advance(std::time::Duration::from_millis(10)).await;
-        tokio::task::yield_now().await;
-    }
-
-    let observed = max_fetched.load(Ordering::Relaxed);
-    assert!(
-        observed > 1,
-        "fast endpoint must JUMP forward toward live (skip backlog), got {observed}"
-    );
-    assert!(
-        observed < live_edge,
-        "fast endpoint must read BEHIND the live edge (built a buffer); \
-         observed read position {observed} reached the edge {live_edge}"
-    );
-
-    let _ = stop_tx.send(true);
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), producer).await;
-    drain.abort();
-}
-
-#[tokio::test]
-async fn test_controller_grow_makes_lag_jump_trail_edge() {
-    // Focused integration of the two pieces the producer wires together:
-    // `FastDelayController` (read-delay) + `producer_lag::detect_lag_and_jump`
-    // (live-edge jump target). After the controller GROWS on starvation, the
-    // jump target must trail the live edge by the grown delay — proving the
-    // fast endpoint keeps a real buffer rather than re-pinning to the edge.
-    //
-    // This is the assertion the full-producer test above cannot make sharply:
-    // at the bare floor (~2 chunks) the inter-probe catch-up can momentarily
-    // reach the edge; only AFTER a grow is the gap unambiguous. Old behaviour
-    // (delivery_delay_chunks == 0) would jump to the absolute edge here.
-    let now = std::time::Instant::now();
-    let mut ctrl = crate::fast_delay::FastDelayController::new(now);
-
-    let current: i64 = 100;
-    // Edge chosen so BOTH the floor-delay and grown-delay probe ladders land
-    // their highest existing rung on exactly the same chunk (8292), isolating
-    // the delay's effect on the gap. The exponential ladder breaks at the
-    // first missing probe, so the block must be contiguous up to the edge.
-    //   floor (offset seed 4):  104,108,116,132,164,228,356,612,1124,2148,4196,8292 → last=8292 (12-rung cap)
-    //   grown (offset seed 64): 164,228,356,612,1124,2148,4196,8292,16484(miss)      → last=8292
-    let edge: i64 = 8292;
-    let chunks: Vec<(i64, Vec<u8>)> = (1..=edge).map(|i| (i, vec![0u8; 1])).collect();
-    let fetcher = TimedMockFetcher::new(chunks, edge); // 2000ms chunks
-
-    // Floor delay (5s / 2s chunks = 2 chunks): jump target trails the
-    // highest-found chunk (the live edge) by exactly 2.
-    let floor_chunks = ctrl.delay_chunks(2000);
-    assert_eq!(floor_chunks, 2, "floor 5s / 2s chunks = 2 chunks");
-    let floor_target = crate::producer_lag::detect_lag_and_jump(&fetcher, current, floor_chunks)
-        .await
-        .expect("chunks exist far ahead → a jump target");
-    assert_eq!(floor_target, edge - 2, "floor target trails the edge by 2");
-
-    // Starvation: a 60s deficit grows the controller to 65s (deficit + margin).
-    let grown = ctrl.on_starvation(60, now);
-    assert_eq!(grown, Some((5, 65)), "grow to deficit(60)+margin(5)=65s");
-    let grown_chunks = ctrl.delay_chunks(2000); // 65000 / 2000 = 32 chunks
-    assert_eq!(grown_chunks, 32);
-
-    let grown_target = crate::producer_lag::detect_lag_and_jump(&fetcher, current, grown_chunks)
-        .await
-        .expect("chunks exist far ahead → a jump target");
-    assert_eq!(
-        grown_target,
-        edge - 32,
-        "grown target trails the edge by 32"
-    );
-
-    // After growth the producer reads FURTHER behind the SAME detected edge
-    // chunk (8292) → a strictly larger buffer. Both delays found 8292, so the
-    // gap-behind-edge difference equals the chunk-delay difference (32-2=30):
-    // detect_lag_and_jump subtracts delivery_delay_chunks from the highest
-    // found chunk.
-    assert!(
-        grown_target < floor_target,
-        "grown delay must trail the edge further: grown_target={grown_target} \
-         floor_target={floor_target}"
-    );
-    assert!(
-        grown_target < edge,
-        "grown jump target must be behind the edge"
-    );
-    assert_eq!(
-        floor_target - grown_target,
-        grown_chunks - floor_chunks,
-        "extra buffer = extra read-delay chunks"
-    );
 }

--- a/crates/rs-delivery/src/endpoint_task_tests.rs
+++ b/crates/rs-delivery/src/endpoint_task_tests.rs
@@ -777,6 +777,13 @@ struct TimedMockFetcher {
     chunks: Arc<TokioMutex<std::collections::HashMap<i64, Vec<u8>>>>,
     available_up_to: Arc<AtomicI64>,
     duration_ms_per_chunk: i64,
+    // Injected per-fetch latency to simulate S3 GET / HEAD slowness. Default
+    // ZERO keeps existing tests byte-for-byte identical.
+    fetch_latency: std::time::Duration,
+    // Highest chunk_id ever requested via fetch_chunk_with_meta. Lets a test
+    // observe the producer's READ position without a real consumer. Starts at
+    // i64::MIN; updated monotonically. ZERO impact when unread.
+    max_fetched_id: Arc<AtomicI64>,
 }
 
 impl TimedMockFetcher {
@@ -785,16 +792,31 @@ impl TimedMockFetcher {
             chunks: Arc::new(TokioMutex::new(chunks.into_iter().collect())),
             available_up_to: Arc::new(AtomicI64::new(initially_available)),
             duration_ms_per_chunk: 2000,
+            fetch_latency: std::time::Duration::ZERO,
+            max_fetched_id: Arc::new(AtomicI64::new(i64::MIN)),
         }
+    }
+
+    fn with_latency(mut self, d: std::time::Duration) -> Self {
+        self.fetch_latency = d;
+        self
     }
 
     fn available_up_to(&self) -> Arc<AtomicI64> {
         self.available_up_to.clone()
     }
+
+    fn max_fetched_id(&self) -> Arc<AtomicI64> {
+        self.max_fetched_id.clone()
+    }
 }
 
 impl ChunkFetcher for TimedMockFetcher {
     async fn fetch_chunk_with_meta(&self, chunk_id: i64) -> Result<Option<(Vec<u8>, i64)>, String> {
+        if !self.fetch_latency.is_zero() {
+            tokio::time::sleep(self.fetch_latency).await;
+        }
+        self.max_fetched_id.fetch_max(chunk_id, Ordering::Relaxed);
         let available = self.available_up_to.load(Ordering::Relaxed);
         if chunk_id > available {
             return Ok(None);
@@ -806,6 +828,9 @@ impl ChunkFetcher for TimedMockFetcher {
     }
 
     async fn chunk_duration_ms(&self, chunk_id: i64) -> Result<Option<i64>, String> {
+        if !self.fetch_latency.is_zero() {
+            tokio::time::sleep(self.fetch_latency).await;
+        }
         let available = self.available_up_to.load(Ordering::Relaxed);
         if chunk_id > available {
             return Ok(None);
@@ -995,5 +1020,150 @@ async fn test_buffer_fill_stops_on_signal() {
     assert_eq!(
         s.chunks_processed, 0,
         "Should not have processed any chunks, stopped during buffer fill"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_fast_endpoint_producer_trails_live_edge() {
+    // A FAST endpoint must build a buffer: even with the live edge far ahead
+    // and S3 fetches incurring latency (the upload-spike scenario), the
+    // adaptive controller keeps the read pointer BEHIND the edge. The
+    // live-edge lag-probe jumps to `edge - delay_chunks` with delay_chunks
+    // >= 1 (the controller floor), so the producer leaves a buffer instead of
+    // re-pinning to the absolute edge.
+    //
+    // Old behaviour (delivery_delay_ms == 0 → delivery_delay_chunks == 0)
+    // pinned the read pointer to the live edge, so any S3 latency spike
+    // instantly starved the push. This test drives `producer_task` directly
+    // and asserts the producer's highest requested chunk_id stays strictly
+    // below the live edge after the lag-probe fires (a buffer was built) and
+    // that it JUMPED forward (did not replay the whole backlog one-by-one).
+    let live_edge: i64 = 30_000;
+    // All chunks exist and are available from t=0; the producer is "behind"
+    // the live edge purely because it reads at 1x + the injected latency.
+    let chunks: Vec<(i64, Vec<u8>)> = (1..=live_edge).map(|i| (i, vec![0u8; 4])).collect();
+    // 50ms per fetch simulates real S3 GET/HEAD latency. Each fetch advances
+    // virtual time, so the producer reads at a bounded rate well below the
+    // far-ahead live edge.
+    let fetcher =
+        TimedMockFetcher::new(chunks, live_edge).with_latency(std::time::Duration::from_millis(50));
+    let max_fetched = fetcher.max_fetched_id();
+
+    let (tx, mut rx) = mpsc::channel::<PrefetchedChunk>(PREFETCH_BUFFER_SIZE);
+    let (stop_tx, stop_rx) = watch::channel(false);
+    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
+    let buffer_state = Arc::new(BufferState::new());
+
+    // Draining consumer: pull chunks as fast as they arrive so the producer
+    // never blocks on the bounded channel.
+    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let producer = tokio::spawn(producer_task(
+        fetcher,
+        tx,
+        1,    // start_chunk_id
+        0,    // delivery_delay_ms (fast endpoints pass 0)
+        true, // is_fast → adaptive controller engaged
+        stop_rx,
+        stats.clone(),
+        "fast-ep".to_string(),
+        buffer_state,
+        None,
+    ));
+
+    // Drive virtual time. With 50ms/fetch latency, ~12s of advance lets the
+    // producer read > LAG_PROBE_INTERVAL_ITERS (30) chunks, fire the lag-probe
+    // once, jump forward by the ladder window (~8k chunks), and keep reading.
+    // It stays far below the 30_000 live edge so the trailing assertion holds
+    // deterministically (it cannot collapse onto the edge in this window).
+    for _ in 0..1200 {
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
+    }
+
+    let observed = max_fetched.load(Ordering::Relaxed);
+    assert!(
+        observed > 1,
+        "fast endpoint must JUMP forward toward live (skip backlog), got {observed}"
+    );
+    assert!(
+        observed < live_edge,
+        "fast endpoint must read BEHIND the live edge (built a buffer); \
+         observed read position {observed} reached the edge {live_edge}"
+    );
+
+    let _ = stop_tx.send(true);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), producer).await;
+    drain.abort();
+}
+
+#[tokio::test]
+async fn test_controller_grow_makes_lag_jump_trail_edge() {
+    // Focused integration of the two pieces the producer wires together:
+    // `FastDelayController` (read-delay) + `producer_lag::detect_lag_and_jump`
+    // (live-edge jump target). After the controller GROWS on starvation, the
+    // jump target must trail the live edge by the grown delay — proving the
+    // fast endpoint keeps a real buffer rather than re-pinning to the edge.
+    //
+    // This is the assertion the full-producer test above cannot make sharply:
+    // at the bare floor (~2 chunks) the inter-probe catch-up can momentarily
+    // reach the edge; only AFTER a grow is the gap unambiguous. Old behaviour
+    // (delivery_delay_chunks == 0) would jump to the absolute edge here.
+    let now = std::time::Instant::now();
+    let mut ctrl = crate::fast_delay::FastDelayController::new(now);
+
+    let current: i64 = 100;
+    // Edge chosen so BOTH the floor-delay and grown-delay probe ladders land
+    // their highest existing rung on exactly the same chunk (8292), isolating
+    // the delay's effect on the gap. The exponential ladder breaks at the
+    // first missing probe, so the block must be contiguous up to the edge.
+    //   floor (offset seed 4):  104,108,116,132,164,228,356,612,1124,2148,4196,8292 → last=8292 (12-rung cap)
+    //   grown (offset seed 64): 164,228,356,612,1124,2148,4196,8292,16484(miss)      → last=8292
+    let edge: i64 = 8292;
+    let chunks: Vec<(i64, Vec<u8>)> = (1..=edge).map(|i| (i, vec![0u8; 1])).collect();
+    let fetcher = TimedMockFetcher::new(chunks, edge); // 2000ms chunks
+
+    // Floor delay (5s / 2s chunks = 2 chunks): jump target trails the
+    // highest-found chunk (the live edge) by exactly 2.
+    let floor_chunks = ctrl.delay_chunks(2000);
+    assert_eq!(floor_chunks, 2, "floor 5s / 2s chunks = 2 chunks");
+    let floor_target = crate::producer_lag::detect_lag_and_jump(&fetcher, current, floor_chunks)
+        .await
+        .expect("chunks exist far ahead → a jump target");
+    assert_eq!(floor_target, edge - 2, "floor target trails the edge by 2");
+
+    // Starvation: a 60s deficit grows the controller to 65s (deficit + margin).
+    let grown = ctrl.on_starvation(60, now);
+    assert_eq!(grown, Some((5, 65)), "grow to deficit(60)+margin(5)=65s");
+    let grown_chunks = ctrl.delay_chunks(2000); // 65000 / 2000 = 32 chunks
+    assert_eq!(grown_chunks, 32);
+
+    let grown_target = crate::producer_lag::detect_lag_and_jump(&fetcher, current, grown_chunks)
+        .await
+        .expect("chunks exist far ahead → a jump target");
+    assert_eq!(
+        grown_target,
+        edge - 32,
+        "grown target trails the edge by 32"
+    );
+
+    // After growth the producer reads FURTHER behind the SAME detected edge
+    // chunk (8292) → a strictly larger buffer. Both delays found 8292, so the
+    // gap-behind-edge difference equals the chunk-delay difference (32-2=30):
+    // detect_lag_and_jump subtracts delivery_delay_chunks from the highest
+    // found chunk.
+    assert!(
+        grown_target < floor_target,
+        "grown delay must trail the edge further: grown_target={grown_target} \
+         floor_target={floor_target}"
+    );
+    assert!(
+        grown_target < edge,
+        "grown jump target must be behind the edge"
+    );
+    assert_eq!(
+        floor_target - grown_target,
+        grown_chunks - floor_chunks,
+        "extra buffer = extra read-delay chunks"
     );
 }

--- a/crates/rs-delivery/src/fast_delay.rs
+++ b/crates/rs-delivery/src/fast_delay.rs
@@ -1,0 +1,219 @@
+//! Adaptive read-delay controller for fast endpoints.
+// Items are used by other modules wired up in a later task.
+#![allow(dead_code)]
+//!
+//! A fast endpoint normally reads at the live edge (delay 0). That has zero
+//! tolerance for local S3-upload latency spikes: when the live-edge chunk is
+//! not yet in S3 the push starves and YouTube resets the idle connection.
+//!
+//! This controller makes the fast endpoint's read-delay ADAPTIVE: it grows
+//! when the producer starves (so the live-edge lag-probe jumps to
+//! `live_edge - delay` and leaves a buffer instead of yanking back to the
+//! edge) and shrinks slowly when healthy (chasing the lowest working
+//! latency). It NEVER speeds up the push — it only changes which chunk the
+//! producer reads next. See the design doc for the full rationale.
+
+use std::time::Instant;
+
+/// Lowest fast-stream read-delay when healthy (seconds).
+pub const FAST_DELAY_FLOOR_SECS: u64 = 5;
+/// Maximum read-delay (seconds) = same safety as the normal stream.
+pub const FAST_DELAY_CEILING_SECS: u64 = 120;
+/// Headroom added above the observed deficit when growing (seconds).
+pub const FAST_DELAY_MARGIN_SECS: u64 = 5;
+/// Step size when shrinking back toward the floor (seconds).
+pub const FAST_DELAY_SHRINK_STEP_SECS: u64 = 5;
+/// Healthy window (seconds) with no starvation before one shrink step.
+pub const FAST_HEALTHY_SHRINK_SECS: u64 = 180;
+
+#[derive(Debug, Clone)]
+pub struct FastDelayController {
+    target_secs: u64,
+    floor: u64,
+    ceiling: u64,
+    margin: u64,
+    shrink_step: u64,
+    healthy_shrink_secs: u64,
+    /// Wall-clock of the last grow OR shrink; gates the next shrink.
+    last_change: Instant,
+}
+
+impl FastDelayController {
+    /// Production constructor: floor/ceiling/margin/step from the consts above.
+    pub fn new(now: Instant) -> Self {
+        Self::with_params(
+            FAST_DELAY_FLOOR_SECS,
+            FAST_DELAY_CEILING_SECS,
+            FAST_DELAY_MARGIN_SECS,
+            FAST_DELAY_SHRINK_STEP_SECS,
+            FAST_HEALTHY_SHRINK_SECS,
+            now,
+        )
+    }
+
+    /// Test/explicit constructor.
+    pub fn with_params(
+        floor: u64,
+        ceiling: u64,
+        margin: u64,
+        shrink_step: u64,
+        healthy_shrink_secs: u64,
+        now: Instant,
+    ) -> Self {
+        Self {
+            target_secs: floor,
+            floor,
+            ceiling,
+            margin,
+            shrink_step,
+            healthy_shrink_secs,
+            last_change: now,
+        }
+    }
+
+    pub fn target_secs(&self) -> u64 {
+        self.target_secs
+    }
+
+    /// Producer starved: the chunk it needs is not in S3 yet. `deficit_secs`
+    /// is how far the needed chunk trails the newest chunk available in S3
+    /// (0 when unknown). Grows the target to `max(target, deficit + margin)`,
+    /// clamped to the ceiling. Returns `Some((from, to))` when the target
+    /// actually changed.
+    pub fn on_starvation(&mut self, deficit_secs: u64, now: Instant) -> Option<(u64, u64)> {
+        let want = deficit_secs
+            .saturating_add(self.margin)
+            .clamp(self.floor, self.ceiling);
+        let next = self.target_secs.max(want);
+        if next != self.target_secs {
+            let from = self.target_secs;
+            self.target_secs = next;
+            self.last_change = now;
+            Some((from, next))
+        } else {
+            None
+        }
+    }
+
+    /// Called while chunks are flowing normally. After `healthy_shrink_secs`
+    /// with no change, shrink one step toward the floor. Returns
+    /// `Some((from, to))` when the target changed.
+    pub fn on_healthy(&mut self, now: Instant) -> Option<(u64, u64)> {
+        if self.target_secs <= self.floor {
+            return None;
+        }
+        if now.duration_since(self.last_change).as_secs() < self.healthy_shrink_secs {
+            return None;
+        }
+        let from = self.target_secs;
+        let next = from.saturating_sub(self.shrink_step).max(self.floor);
+        self.target_secs = next;
+        self.last_change = now;
+        Some((from, next))
+    }
+
+    /// Current target expressed in chunks, for the live-edge lag-probe.
+    /// Always >= 1 so a fast endpoint never re-pins to the absolute edge.
+    pub fn delay_chunks(&self, typical_chunk_dur_ms: u64) -> i64 {
+        let dur = typical_chunk_dur_ms.max(1);
+        ((self.target_secs.saturating_mul(1000) / dur) as i64).max(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn ctrl(now: Instant) -> FastDelayController {
+        // floor 5, ceiling 120, margin 5, step 5, healthy-window 180
+        FastDelayController::with_params(5, 120, 5, 5, 180, now)
+    }
+
+    #[test]
+    fn starts_at_floor() {
+        let now = Instant::now();
+        assert_eq!(ctrl(now).target_secs(), 5);
+    }
+
+    #[test]
+    fn grows_to_deficit_plus_margin() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        // deficit 20s -> target 25s
+        assert_eq!(c.on_starvation(20, now), Some((5, 25)));
+        assert_eq!(c.target_secs(), 25);
+    }
+
+    #[test]
+    fn grow_is_monotonic_until_shrink() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        c.on_starvation(20, now); // -> 25
+        // smaller deficit does not lower the target
+        assert_eq!(c.on_starvation(5, now), None);
+        assert_eq!(c.target_secs(), 25);
+    }
+
+    #[test]
+    fn grow_clamps_to_ceiling() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        // deficit 200s + margin would be 205 -> clamp to 120
+        assert_eq!(c.on_starvation(200, now), Some((5, 120)));
+        assert_eq!(c.target_secs(), 120);
+    }
+
+    #[test]
+    fn unknown_deficit_grows_by_margin_floor() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        // deficit 0 -> want = max(floor, margin)=5 == floor -> no change at floor
+        assert_eq!(c.on_starvation(0, now), None);
+        // after a grow to 25, deficit-0 still cannot lower
+        c.on_starvation(20, now);
+        assert_eq!(c.on_starvation(0, now), None);
+        assert_eq!(c.target_secs(), 25);
+    }
+
+    #[test]
+    fn shrink_only_after_healthy_window() {
+        let base = Instant::now();
+        let mut c = ctrl(base);
+        c.on_starvation(40, base); // -> 45 at t=0
+        // before window: no shrink
+        assert_eq!(c.on_healthy(base + Duration::from_secs(179)), None);
+        // at window: one step down (45 -> 40)
+        assert_eq!(
+            c.on_healthy(base + Duration::from_secs(180)),
+            Some((45, 40))
+        );
+        assert_eq!(c.target_secs(), 40);
+    }
+
+    #[test]
+    fn shrink_floors_at_floor() {
+        let base = Instant::now();
+        let mut c = ctrl(base);
+        c.on_starvation(2, base); // deficit2+margin5=7 -> 7
+        assert_eq!(c.target_secs(), 7);
+        let t = base + Duration::from_secs(180);
+        assert_eq!(c.on_healthy(t), Some((7, 5))); // 7-5=2 -> max(floor)=5
+        // already at floor -> no further shrink
+        assert_eq!(c.on_healthy(t + Duration::from_secs(180)), None);
+    }
+
+    #[test]
+    fn delay_chunks_uses_chunk_duration() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        c.on_starvation(20, now); // 25s
+        // 2000ms chunks -> 25000/2000 = 12 chunks
+        assert_eq!(c.delay_chunks(2000), 12);
+        // 1000ms chunks -> 25 chunks
+        assert_eq!(c.delay_chunks(1000), 25);
+        // never below 1 even at floor with huge chunks
+        let edge = ctrl(now);
+        assert_eq!(edge.delay_chunks(60_000), 1);
+    }
+}

--- a/crates/rs-delivery/src/fast_delay.rs
+++ b/crates/rs-delivery/src/fast_delay.rs
@@ -1,5 +1,11 @@
 //! Adaptive read-delay controller for fast endpoints.
-// Items are used by other modules wired up in a later task.
+//!
+//! The sole consumer (`producer_task`) lives in the `rs-delivery` BINARY
+//! (`main.rs`), while this module is also declared `pub(crate)` in the
+//! library crate (`lib.rs`) for integration tests. In the library
+//! compilation unit there is no consumer, so every item reads as dead code;
+//! the module-level allow below suppresses that false positive. The bin
+//! build uses every item, so this does not hide a genuine dead-code bug.
 #![allow(dead_code)]
 //!
 //! A fast endpoint normally reads at the live edge (delay 0). That has zero

--- a/crates/rs-delivery/src/fast_delay_audit.rs
+++ b/crates/rs-delivery/src/fast_delay_audit.rs
@@ -1,0 +1,97 @@
+//! Audit emit helpers for the fast-endpoint self-healing path. Mirrors
+//! `rescue_audit.rs`: VPS-side events go through the `AuditRing`.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use rs_core::audit::{Action, Severity, Source};
+
+use crate::audit_ring::{AuditRing, RingRowParts};
+
+fn push(
+    audit_ring: &Option<Arc<AuditRing>>,
+    severity: Severity,
+    action: Action,
+    alias: &str,
+    detail: serde_json::Value,
+) {
+    if let Some(ring) = audit_ring {
+        ring.push_parts(RingRowParts {
+            severity,
+            source: Source::Vps,
+            endpoint: Some(alias.to_string()),
+            action,
+            detail,
+        });
+    }
+}
+
+pub fn emit_delay_grown(
+    audit_ring: &Option<Arc<AuditRing>>,
+    alias: &str,
+    from_secs: u64,
+    to_secs: u64,
+    deficit_secs: u64,
+) {
+    push(
+        audit_ring,
+        Severity::Warn,
+        Action::FastDelayGrown,
+        alias,
+        serde_json::json!({
+            "alias": alias,
+            "from_secs": from_secs,
+            "to_secs": to_secs,
+            "observed_deficit_secs": deficit_secs,
+        }),
+    );
+}
+
+pub fn emit_delay_shrank(
+    audit_ring: &Option<Arc<AuditRing>>,
+    alias: &str,
+    from_secs: u64,
+    to_secs: u64,
+) {
+    push(
+        audit_ring,
+        Severity::Info,
+        Action::FastDelayShrank,
+        alias,
+        serde_json::json!({ "alias": alias, "from_secs": from_secs, "to_secs": to_secs }),
+    );
+}
+
+pub fn emit_keepalive_started(audit_ring: &Option<Arc<AuditRing>>, alias: &str, mode: &str) {
+    push(
+        audit_ring,
+        Severity::Warn,
+        Action::FastKeepaliveStarted,
+        alias,
+        serde_json::json!({ "alias": alias, "mode": mode }),
+    );
+}
+
+pub fn emit_keepalive_ended(audit_ring: &Option<Arc<AuditRing>>, alias: &str, gap_secs: u64) {
+    push(
+        audit_ring,
+        Severity::Info,
+        Action::FastKeepaliveEnded,
+        alias,
+        serde_json::json!({ "alias": alias, "gap_secs": gap_secs }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_with_none_ring_is_noop() {
+        // Must not panic when there is no audit ring (e.g. tests / no DB).
+        emit_delay_grown(&None, "ep", 5, 25, 20);
+        emit_delay_shrank(&None, "ep", 25, 20);
+        emit_keepalive_started(&None, "ep", "freeze");
+        emit_keepalive_ended(&None, "ep", 12);
+    }
+}

--- a/crates/rs-delivery/src/fast_keepalive.rs
+++ b/crates/rs-delivery/src/fast_keepalive.rs
@@ -1,0 +1,75 @@
+//! Fast-endpoint keepalive: hold the EXISTING rtmp session alive during a
+//! short producer gap by re-pushing the last delivered chunk (freeze), then
+//! the default rescue loop after `FAST_KEEPALIVE_RESCUE_AFTER_SECS`. Re-using
+//! the same session means the RTMP connection is never closed by starvation
+//! — only a real socket error reconnects. `push_flv_bytes` re-anchors
+//! timestamps across the repeated blob internally.
+#![allow(dead_code)]
+use std::sync::Arc;
+
+/// Wait this long for a real chunk before starting keepalive frames. Far
+/// below the 8s full-stall rescue threshold so the trickle regime (chunks
+/// arriving late but often) is covered, not just total outages.
+pub const FAST_KEEPALIVE_TRIGGER_SECS: u64 = 2;
+/// After this much continuous gap, switch the keepalive content from the
+/// frozen last chunk to the default rescue loop.
+pub const FAST_KEEPALIVE_RESCUE_AFTER_SECS: u64 = 10;
+
+/// Which content the keepalive is currently pushing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeepaliveMode {
+    Freeze,
+    Rescue,
+}
+
+/// Pure decision: given how long the gap has lasted, what to push.
+pub fn keepalive_mode(gap_secs: u64, have_freeze: bool) -> KeepaliveMode {
+    if have_freeze && gap_secs < FAST_KEEPALIVE_RESCUE_AFTER_SECS {
+        KeepaliveMode::Freeze
+    } else {
+        KeepaliveMode::Rescue
+    }
+}
+
+/// Select the FLV bytes to push for a keepalive tick.
+pub fn keepalive_bytes<'a>(
+    mode: KeepaliveMode,
+    last_chunk: &'a Option<Arc<Vec<u8>>>,
+) -> std::borrow::Cow<'a, [u8]> {
+    match mode {
+        KeepaliveMode::Freeze => match last_chunk {
+            Some(b) => std::borrow::Cow::Borrowed(b.as_slice()),
+            None => std::borrow::Cow::Borrowed(crate::rescue_default::DEFAULT_RESCUE_FLV),
+        },
+        KeepaliveMode::Rescue => {
+            std::borrow::Cow::Borrowed(crate::rescue_default::DEFAULT_RESCUE_FLV)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn freeze_then_rescue_by_gap() {
+        assert_eq!(keepalive_mode(0, true), KeepaliveMode::Freeze);
+        assert_eq!(keepalive_mode(9, true), KeepaliveMode::Freeze);
+        assert_eq!(keepalive_mode(10, true), KeepaliveMode::Rescue);
+        assert_eq!(keepalive_mode(0, false), KeepaliveMode::Rescue);
+    }
+
+    #[test]
+    fn bytes_fall_back_to_default_when_no_freeze() {
+        let none: Option<Arc<Vec<u8>>> = None;
+        let b = keepalive_bytes(KeepaliveMode::Freeze, &none);
+        assert_eq!(&*b, crate::rescue_default::DEFAULT_RESCUE_FLV);
+    }
+
+    #[test]
+    fn freeze_uses_last_chunk_bytes() {
+        let last = Some(Arc::new(vec![1u8, 2, 3]));
+        let b = keepalive_bytes(KeepaliveMode::Freeze, &last);
+        assert_eq!(&*b, &[1u8, 2, 3]);
+    }
+}

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -1,0 +1,269 @@
+//! Fast-delay self-healing producer tests, split out of
+//! `endpoint_task_tests.rs` so both test files stay under the 1000-line CI
+//! cap. These exercise the producer's adaptive read-delay / live-edge
+//! lag-probe behaviour (#232) plus the buffer-fill stop/pacing paths.
+//!
+//! Shared mock helpers (`TimedMockFetcher`, `MockProcessFactory`,
+//! `test_ep_cfg`) live in the sibling `tests` module and are reused here via
+//! `super::tests::…`. This is a pure move of the tests — no assertion change.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use tokio::sync::{Mutex, mpsc, watch};
+
+use crate::buffer_state::BufferState;
+use crate::endpoint_producer::producer_task;
+use crate::endpoint_stats::{EndpointStats, Stats};
+use crate::endpoint_task::{PREFETCH_BUFFER_SIZE, PrefetchedChunk, endpoint_loop};
+
+use super::tests::{MockProcessFactory, TimedMockFetcher, test_ep_cfg};
+
+#[tokio::test]
+async fn test_chunk_gap_maintained_at_delay_target() {
+    // With delivery_delay_ms=20000, start_chunk_id=1, pre-load chunks 1-30 (2000ms each):
+    // After buffer fill (chunk 11 available), VPS starts consuming from chunk 1.
+    // Elapsed-aware pacing: 1000ms per chunk (non-fast).
+    tokio::time::pause();
+
+    let all_chunks: Vec<(i64, Vec<u8>)> = (1..=30).map(|i| (i, vec![i as u8; 100])).collect();
+    // All 30 chunks available immediately
+    let fetcher = TimedMockFetcher::new(all_chunks, 30);
+    let factory = MockProcessFactory::new();
+
+    let (stop_tx, stop_rx) = watch::channel(false);
+    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
+
+    let stats_clone = stats.clone();
+    let handle = tokio::spawn(async move {
+        endpoint_loop(
+            fetcher,
+            factory,
+            test_ep_cfg(),
+            1,     // start_chunk_id
+            20000, // delivery_delay_ms (10 chunks * 2000ms)
+            stop_rx,
+            stats_clone,
+            None,
+            Arc::new(BufferState::new()),
+            None,
+        )
+        .await;
+    });
+
+    // Buffer fill needs 10 chunks (20000ms / 2000ms) which are already
+    // available. Consumer pacing sleeps ~2000ms per chunk. 30 chunks require
+    // ~60s of wall-clock advancement for pacing. Each iteration advances
+    // 100ms, so we need at least 600 iterations; use 2000 for slack.
+    for _ in 0..2000 {
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+    }
+
+    let s = stats.lock().await;
+    assert_eq!(
+        s.chunks_processed, 30,
+        "Should have processed all 30 chunks, got {}",
+        s.chunks_processed
+    );
+    drop(s);
+
+    let _ = stop_tx.send(true);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
+}
+#[tokio::test]
+async fn test_buffer_fill_stops_on_signal() {
+    // If stop signal is sent during buffer fill, the loop should exit
+    // without processing any chunks.
+    tokio::time::pause();
+
+    let all_chunks: Vec<(i64, Vec<u8>)> = (1..=5).map(|i| (i, vec![i as u8; 100])).collect();
+    // Only chunk 1 available, target_chunk = 1 + 10 = 11 -- will never be available
+    let fetcher = TimedMockFetcher::new(all_chunks, 1);
+    let factory = MockProcessFactory::new();
+
+    let (stop_tx, stop_rx) = watch::channel(false);
+    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
+
+    let stats_clone = stats.clone();
+    let handle = tokio::spawn(async move {
+        endpoint_loop(
+            fetcher,
+            factory,
+            test_ep_cfg(),
+            1,
+            20000, // delivery_delay_ms (10 chunks * 2000ms)
+            stop_rx,
+            stats_clone,
+            None,
+            Arc::new(BufferState::new()),
+            None,
+        )
+        .await;
+    });
+
+    // Let it poll a few times during buffer fill
+    for _ in 0..3 {
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+        tokio::task::yield_now().await;
+    }
+
+    // Send stop signal
+    let _ = stop_tx.send(true);
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    assert!(
+        result.is_ok(),
+        "Task should have stopped during buffer fill"
+    );
+
+    let s = stats.lock().await;
+    assert_eq!(
+        s.chunks_processed, 0,
+        "Should not have processed any chunks, stopped during buffer fill"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_fast_endpoint_producer_trails_live_edge() {
+    // A FAST endpoint must build a buffer: even with the live edge far ahead
+    // and S3 fetches incurring latency (the upload-spike scenario), the
+    // adaptive controller keeps the read pointer BEHIND the edge. The
+    // live-edge lag-probe jumps to `edge - delay_chunks` with delay_chunks
+    // >= 1 (the controller floor), so the producer leaves a buffer instead of
+    // re-pinning to the absolute edge.
+    //
+    // Old behaviour (delivery_delay_ms == 0 → delivery_delay_chunks == 0)
+    // pinned the read pointer to the live edge, so any S3 latency spike
+    // instantly starved the push. This test drives `producer_task` directly
+    // and asserts the producer's highest requested chunk_id stays strictly
+    // below the live edge after the lag-probe fires (a buffer was built) and
+    // that it JUMPED forward (did not replay the whole backlog one-by-one).
+    let live_edge: i64 = 30_000;
+    // All chunks exist and are available from t=0; the producer is "behind"
+    // the live edge purely because it reads at 1x + the injected latency.
+    let chunks: Vec<(i64, Vec<u8>)> = (1..=live_edge).map(|i| (i, vec![0u8; 4])).collect();
+    // 50ms per fetch simulates real S3 GET/HEAD latency. Each fetch advances
+    // virtual time, so the producer reads at a bounded rate well below the
+    // far-ahead live edge.
+    let fetcher =
+        TimedMockFetcher::new(chunks, live_edge).with_latency(std::time::Duration::from_millis(50));
+    let max_fetched = fetcher.max_fetched_id();
+
+    let (tx, mut rx) = mpsc::channel::<PrefetchedChunk>(PREFETCH_BUFFER_SIZE);
+    let (stop_tx, stop_rx) = watch::channel(false);
+    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
+    let buffer_state = Arc::new(BufferState::new());
+
+    // Draining consumer: pull chunks as fast as they arrive so the producer
+    // never blocks on the bounded channel.
+    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let producer = tokio::spawn(producer_task(
+        fetcher,
+        tx,
+        1,    // start_chunk_id
+        0,    // delivery_delay_ms (fast endpoints pass 0)
+        true, // is_fast → adaptive controller engaged
+        stop_rx,
+        stats.clone(),
+        "fast-ep".to_string(),
+        buffer_state,
+        None,
+    ));
+
+    // Drive virtual time. With 50ms/fetch latency, ~12s of advance lets the
+    // producer read > LAG_PROBE_INTERVAL_ITERS (30) chunks, fire the lag-probe
+    // once, jump forward by the ladder window (~8k chunks), and keep reading.
+    // It stays far below the 30_000 live edge so the trailing assertion holds
+    // deterministically (it cannot collapse onto the edge in this window).
+    for _ in 0..1200 {
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
+    }
+
+    let observed = max_fetched.load(Ordering::Relaxed);
+    assert!(
+        observed > 1,
+        "fast endpoint must JUMP forward toward live (skip backlog), got {observed}"
+    );
+    assert!(
+        observed < live_edge,
+        "fast endpoint must read BEHIND the live edge (built a buffer); \
+         observed read position {observed} reached the edge {live_edge}"
+    );
+
+    let _ = stop_tx.send(true);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), producer).await;
+    drain.abort();
+}
+
+#[tokio::test]
+async fn test_controller_grow_makes_lag_jump_trail_edge() {
+    // Focused integration of the two pieces the producer wires together:
+    // `FastDelayController` (read-delay) + `producer_lag::detect_lag_and_jump`
+    // (live-edge jump target). After the controller GROWS on starvation, the
+    // jump target must trail the live edge by the grown delay — proving the
+    // fast endpoint keeps a real buffer rather than re-pinning to the edge.
+    //
+    // This is the assertion the full-producer test above cannot make sharply:
+    // at the bare floor (~2 chunks) the inter-probe catch-up can momentarily
+    // reach the edge; only AFTER a grow is the gap unambiguous. Old behaviour
+    // (delivery_delay_chunks == 0) would jump to the absolute edge here.
+    let now = std::time::Instant::now();
+    let mut ctrl = crate::fast_delay::FastDelayController::new(now);
+
+    let current: i64 = 100;
+    // Edge chosen so BOTH the floor-delay and grown-delay probe ladders land
+    // their highest existing rung on exactly the same chunk (8292), isolating
+    // the delay's effect on the gap. The exponential ladder breaks at the
+    // first missing probe, so the block must be contiguous up to the edge.
+    //   floor (offset seed 4):  104,108,116,132,164,228,356,612,1124,2148,4196,8292 → last=8292 (12-rung cap)
+    //   grown (offset seed 64): 164,228,356,612,1124,2148,4196,8292,16484(miss)      → last=8292
+    let edge: i64 = 8292;
+    let chunks: Vec<(i64, Vec<u8>)> = (1..=edge).map(|i| (i, vec![0u8; 1])).collect();
+    let fetcher = TimedMockFetcher::new(chunks, edge); // 2000ms chunks
+
+    // Floor delay (5s / 2s chunks = 2 chunks): jump target trails the
+    // highest-found chunk (the live edge) by exactly 2.
+    let floor_chunks = ctrl.delay_chunks(2000);
+    assert_eq!(floor_chunks, 2, "floor 5s / 2s chunks = 2 chunks");
+    let floor_target = crate::producer_lag::detect_lag_and_jump(&fetcher, current, floor_chunks)
+        .await
+        .expect("chunks exist far ahead → a jump target");
+    assert_eq!(floor_target, edge - 2, "floor target trails the edge by 2");
+
+    // Starvation: a 60s deficit grows the controller to 65s (deficit + margin).
+    let grown = ctrl.on_starvation(60, now);
+    assert_eq!(grown, Some((5, 65)), "grow to deficit(60)+margin(5)=65s");
+    let grown_chunks = ctrl.delay_chunks(2000); // 65000 / 2000 = 32 chunks
+    assert_eq!(grown_chunks, 32);
+
+    let grown_target = crate::producer_lag::detect_lag_and_jump(&fetcher, current, grown_chunks)
+        .await
+        .expect("chunks exist far ahead → a jump target");
+    assert_eq!(
+        grown_target,
+        edge - 32,
+        "grown target trails the edge by 32"
+    );
+
+    // After growth the producer reads FURTHER behind the SAME detected edge
+    // chunk (8292) → a strictly larger buffer. Both delays found 8292, so the
+    // gap-behind-edge difference equals the chunk-delay difference (32-2=30):
+    // detect_lag_and_jump subtracts delivery_delay_chunks from the highest
+    // found chunk.
+    assert!(
+        grown_target < floor_target,
+        "grown delay must trail the edge further: grown_target={grown_target} \
+         floor_target={floor_target}"
+    );
+    assert!(
+        grown_target < edge,
+        "grown jump target must be behind the edge"
+    );
+    assert_eq!(
+        floor_target - grown_target,
+        grown_chunks - floor_chunks,
+        "extra buffer = extra read-delay chunks"
+    );
+}

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -267,3 +267,190 @@ async fn test_controller_grow_makes_lag_jump_trail_edge() {
         "extra buffer = extra read-delay chunks"
     );
 }
+
+// ---------------------------------------------------------------------------
+// REGRESSION GATE (Task 6): fast endpoint survives an upload gap.
+//
+// The core guarantee that shipped CI-green with NO test: when a fast endpoint
+// starves (producer stops delivering chunks), the keepalive loop must
+//   1. NEVER close the connection (no teardown on starvation),
+//   2. keep pushing frames during the gap — first FREEZE (last chunk bytes),
+//      then RESCUE (default FLV) once the gap exceeds FAST_KEEPALIVE_RESCUE_
+//      AFTER_SECS (10s), and
+//   3. resume the real chunk the moment one arrives.
+//
+// This locks `keepalive_until_chunk`'s freeze->rescue transition and its
+// never-close contract against regression. Without this test, upload jitter
+// against a fast endpoint had zero coverage.
+// ---------------------------------------------------------------------------
+mod fast_upload_gap_regression {
+    // Reach `keepalive_until_chunk` (private fn in `endpoint_task`) and the
+    // `Pushable` trait (in `endpoint_task::consumer_helpers`). This module is
+    // nested as endpoint_task::test_root::fast_self_healing_tests::
+    // fast_upload_gap_regression, so:
+    //   super (fast_self_healing_tests) -> super (test_root) -> super (endpoint_task)
+    use super::super::super::consumer_helpers::Pushable;
+    use super::super::super::keepalive_until_chunk;
+
+    use crate::endpoint_task::PrefetchedChunk;
+    use crate::rescue_default::DEFAULT_RESCUE_FLV;
+    use rs_rtmp_push::PushError;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+    use tokio::sync::{mpsc, watch};
+
+    /// Test pusher that records every push's byte-length, models ~1x pacing
+    /// with a 200ms sleep, and NEVER returns an error (so any close() would be
+    /// caused by starvation logic, not by us injecting failures).
+    struct RecordingPusher {
+        pushes: Arc<Mutex<Vec<usize>>>,
+        closed: Arc<AtomicBool>,
+    }
+
+    impl Pushable for RecordingPusher {
+        async fn push_flv_bytes(&mut self, data: &[u8]) -> Result<(), PushError> {
+            self.pushes.lock().unwrap().push(data.len());
+            // Model the real pusher's ~1x self-pacing so each keepalive tick
+            // advances virtual time by a frame interval. Deterministic under
+            // `start_paused = true` — advanced explicitly below, never waited
+            // on the wall clock.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok(())
+        }
+
+        async fn close(&mut self) {
+            // Starvation must NEVER reach here. If it does, the assertion on
+            // `closed` below fails and the regression is caught.
+            self.closed.store(true, Ordering::SeqCst);
+        }
+
+        fn reconnect_count(&self) -> u32 {
+            0
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fast_endpoint_survives_upload_gap_without_closing() {
+        // Distinct freeze length (4242) so freeze pushes are identifiable and
+        // never collide with the rescue FLV length.
+        const FREEZE_LEN: usize = 4242;
+        assert_ne!(
+            FREEZE_LEN,
+            DEFAULT_RESCUE_FLV.len(),
+            "freeze length must differ from rescue length so the two are distinguishable"
+        );
+
+        let pushes = Arc::new(Mutex::new(Vec::<usize>::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let mut pusher = RecordingPusher {
+            pushes: Arc::clone(&pushes),
+            closed: Arc::clone(&closed),
+        };
+
+        // Producer gap: channel created, nothing sent yet.
+        let (tx, mut rx) = mpsc::channel::<PrefetchedChunk>(10);
+        let (_stop_tx, mut stop_rx) = watch::channel(false);
+
+        // A populated last-chunk → freeze is available for gap < 10s.
+        let last: Option<Arc<Vec<u8>>> = Some(Arc::new(vec![0u8; FREEZE_LEN]));
+        let audit_ring: Option<Arc<crate::audit_ring::AuditRing>> = None;
+
+        // Drive `keepalive_until_chunk` in a task so we can advance virtual
+        // time around it. The pusher (moved in) records into the `pushes` Arc,
+        // which the test still owns a clone of, so the recorded data stays
+        // readable throughout.
+        let task = tokio::spawn(async move {
+            keepalive_until_chunk(
+                &mut pusher,
+                &mut rx,
+                &last,
+                "fast-test",
+                &audit_ring,
+                &mut stop_rx,
+            )
+            .await
+        });
+
+        // Phase 1 — FREEZE window (gap < 10s). Advance ~3s in small steps,
+        // yielding between each so the spawned keepalive task makes progress
+        // (each push sleeps 200ms of virtual time). This keeps the timing
+        // deterministic with no wall-clock waits.
+        advance_in_steps(Duration::from_millis(200), 16).await; // ~3.2s
+
+        {
+            let recorded = pushes.lock().unwrap();
+            assert!(
+                !recorded.is_empty(),
+                "keepalive must emit frames during the gap; recorded none after ~3s"
+            );
+            assert!(
+                recorded.contains(&FREEZE_LEN),
+                "during the freeze window keepalive must push the last chunk bytes \
+                 (len {FREEZE_LEN}); recorded lengths: {recorded:?}"
+            );
+        }
+
+        // Phase 2 — cross the 10s rescue threshold. Advance another ~9s so the
+        // cumulative gap exceeds FAST_KEEPALIVE_RESCUE_AFTER_SECS (10s) and the
+        // content switches to the default rescue FLV.
+        advance_in_steps(Duration::from_millis(200), 50).await; // +~10s → ~13s total
+
+        {
+            let recorded = pushes.lock().unwrap();
+            let rescue_len = DEFAULT_RESCUE_FLV.len();
+            assert!(
+                recorded.contains(&rescue_len),
+                "after 10s gap keepalive must switch to the rescue FLV \
+                 (len {rescue_len}); recorded lengths: {recorded:?}"
+            );
+        }
+
+        // The connection must NEVER have been closed by starvation.
+        assert!(
+            !closed.load(Ordering::SeqCst),
+            "keepalive must NOT close the connection during a producer gap"
+        );
+
+        // Phase 3 — a real chunk arrives. keepalive must return it (resume).
+        tx.send(PrefetchedChunk {
+            chunk_id: 99,
+            data: vec![1, 2, 3],
+            duration_ms: 2000,
+        })
+        .await
+        .expect("send real chunk");
+        // Let the rx.recv() arm win.
+        advance_in_steps(Duration::from_millis(50), 4).await;
+
+        let returned = task.await.expect("keepalive task panicked");
+        let chunk = returned.expect("keepalive must return the resumed real chunk, got None");
+        assert_eq!(
+            chunk.chunk_id, 99,
+            "keepalive must resume the real chunk (id 99) once one arrives"
+        );
+
+        // Final guarantees recap:
+        // - never closed: asserted above.
+        // - frames emitted during gap: asserted above (non-empty).
+        // - freeze AND rescue both observed: asserted above.
+        // - real chunk resumed: chunk_id == 99 asserted above.
+        assert!(
+            !closed.load(Ordering::SeqCst),
+            "connection still must not be closed after the chunk resumed"
+        );
+    }
+
+    /// Advance virtual time in `count` steps of `step`, yielding to the
+    /// runtime between each so the spawned keepalive task is polled and its
+    /// internal 200ms sleeps fire deterministically. Avoids the "advance past
+    /// everything in one jump" pitfall where the task never gets scheduled
+    /// between ticks.
+    async fn advance_in_steps(step: Duration, count: u32) {
+        for _ in 0..count {
+            tokio::time::advance(step).await;
+            tokio::task::yield_now().await;
+        }
+    }
+}

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -361,6 +361,10 @@ mod fast_upload_gap_regression {
         // time around it. The pusher (moved in) records into the `pushes` Arc,
         // which the test still owns a clone of, so the recorded data stays
         // readable throughout.
+        let stats: crate::endpoint_stats::Stats = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::endpoint_stats::EndpointStats::default(),
+        ));
+        let stats_task = stats.clone();
         let task = tokio::spawn(async move {
             keepalive_until_chunk(
                 &mut pusher,
@@ -369,6 +373,7 @@ mod fast_upload_gap_regression {
                 "fast-test",
                 &audit_ring,
                 &mut stop_rx,
+                &stats_task,
             )
             .await
         });

--- a/crates/rs-delivery/src/lib.rs
+++ b/crates/rs-delivery/src/lib.rs
@@ -9,4 +9,5 @@
 pub mod audit_ring;
 pub mod chunk_lifecycle;
 pub mod clock_endpoint;
+pub(crate) mod fast_delay;
 pub mod ffmpeg_reason;

--- a/crates/rs-delivery/src/lib.rs
+++ b/crates/rs-delivery/src/lib.rs
@@ -10,4 +10,5 @@ pub mod audit_ring;
 pub mod chunk_lifecycle;
 pub mod clock_endpoint;
 pub(crate) mod fast_delay;
+pub(crate) mod fast_delay_audit;
 pub mod ffmpeg_reason;

--- a/crates/rs-delivery/src/lib.rs
+++ b/crates/rs-delivery/src/lib.rs
@@ -11,4 +11,8 @@ pub mod chunk_lifecycle;
 pub mod clock_endpoint;
 pub(crate) mod fast_delay;
 pub(crate) mod fast_delay_audit;
+pub(crate) mod fast_keepalive;
 pub mod ffmpeg_reason;
+// `fast_keepalive` references the embedded default rescue blob; expose the
+// const-only module in the library target too so the helper compiles there.
+pub mod rescue_default;

--- a/crates/rs-delivery/src/main.rs
+++ b/crates/rs-delivery/src/main.rs
@@ -19,6 +19,7 @@ mod disk_cache_fetcher;
 mod disk_cache_push_sample;
 pub mod endpoint_audit;
 mod endpoint_ffmpeg_impl;
+pub(crate) mod endpoint_producer;
 pub(crate) mod endpoint_rtmp_url;
 pub mod endpoint_stats;
 pub mod endpoint_task;

--- a/crates/rs-delivery/src/main.rs
+++ b/crates/rs-delivery/src/main.rs
@@ -25,6 +25,7 @@ pub mod endpoint_stats;
 pub mod endpoint_task;
 mod fast_delay;
 mod fast_delay_audit;
+mod fast_keepalive;
 mod ffmpeg_reason;
 mod producer_lag;
 pub mod rescue;

--- a/crates/rs-delivery/src/main.rs
+++ b/crates/rs-delivery/src/main.rs
@@ -22,6 +22,8 @@ mod endpoint_ffmpeg_impl;
 pub(crate) mod endpoint_rtmp_url;
 pub mod endpoint_stats;
 pub mod endpoint_task;
+mod fast_delay;
+mod fast_delay_audit;
 mod ffmpeg_reason;
 mod producer_lag;
 pub mod rescue;

--- a/crates/rs-endpoint/src/disk_pressure.rs
+++ b/crates/rs-endpoint/src/disk_pressure.rs
@@ -2,7 +2,7 @@
 //! buffered chunk (continuity guarantee). At critical, the endpoint
 //! lifecycle goes RED Attention (operator must act).
 
-use rs_core::audit::{Action, AuditRow, RateLimiter, Severity, Source};
+use rs_core::audit::{Action, AuditRow, Severity, Source};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -57,8 +57,13 @@ pub fn classify_disk_pressure(used_fraction: f64) -> DiskPressure {
     }
 }
 
+/// True when a new pressure reading should be logged (level changed).
+pub(crate) fn should_log_transition(prev: DiskPressure, now: DiskPressure) -> bool {
+    prev != now
+}
+
 /// Sample the volume containing `chunk_dir` every 10s; emit LocalDiskPressure
-/// (rate-limited 1/min per severity) on Warn/Critical. Returns when the
+/// on level transitions (Ok↔Warn↔Critical) only. Returns when the
 /// shutdown channel fires.
 ///
 /// `disk_critical`, when set, is updated every sample to reflect whether the
@@ -73,7 +78,7 @@ pub async fn run_disk_monitor(
     disk_level: Option<Arc<std::sync::atomic::AtomicU8>>,
     mut shutdown: broadcast::Receiver<()>,
 ) {
-    let rl = Arc::new(RateLimiter::new());
+    let mut last_pressure = DiskPressure::Ok;
     loop {
         tokio::select! {
             _ = shutdown.recv() => return,
@@ -101,13 +106,21 @@ pub async fn run_disk_monitor(
         if let Some(l) = &disk_level {
             l.store(pressure.as_u8(), std::sync::atomic::Ordering::Relaxed);
         }
-        let (sev, class) = match pressure {
-            DiskPressure::Ok => continue,
-            DiskPressure::Warn => (Severity::Warn, "warn"),
-            DiskPressure::Critical => (Severity::Critical, "critical"),
-        };
-        if let Some(tx) = &audit_tx {
-            if rl.allow(Action::LocalDiskPressure, class) {
+        // Emit an audit row only on a level transition (Ok↔Warn↔Critical).
+        // last_pressure is updated BEFORE the Ok-continue so that a subsequent
+        // Ok→Warn transition still logs.
+        let log_it = should_log_transition(last_pressure, pressure);
+        last_pressure = pressure;
+        if pressure == DiskPressure::Ok {
+            continue;
+        }
+        if log_it {
+            if let Some(tx) = &audit_tx {
+                let sev = match pressure {
+                    DiskPressure::Warn => Severity::Warn,
+                    DiskPressure::Critical => Severity::Critical,
+                    DiskPressure::Ok => unreachable!(),
+                };
                 rs_core::audit::record(
                     tx,
                     AuditRow {
@@ -156,6 +169,23 @@ fn volume_usage(path: &std::path::Path) -> Option<(u64, u64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn logs_only_on_transition() {
+        assert!(should_log_transition(DiskPressure::Ok, DiskPressure::Warn));
+        assert!(!should_log_transition(
+            DiskPressure::Warn,
+            DiskPressure::Warn
+        ));
+        assert!(should_log_transition(
+            DiskPressure::Warn,
+            DiskPressure::Critical
+        ));
+        assert!(should_log_transition(
+            DiskPressure::Critical,
+            DiskPressure::Warn
+        ));
+    }
 
     #[test]
     fn classify_boundaries() {

--- a/docs/superpowers/plans/2026-06-07-fast-stream-self-healing.md
+++ b/docs/superpowers/plans/2026-06-07-fast-stream-self-healing.md
@@ -1,0 +1,1039 @@
+# Self-Healing Fast Stream Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `is_fast` delivery endpoint survive local S3-upload latency spikes without ever crashing/looping — by adding an adaptive read-delay controller (grow on starvation, shrink on health, always 1× push) and a never-crash keepalive (freeze last chunk, then rescue loop) that holds the RTMP connection alive through gaps.
+
+**Architecture:** All new behaviour lives VPS-side in `crates/rs-delivery`. A new pure controller (`fast_delay.rs`) decides how far behind live the fast endpoint reads; the producer feeds that into the existing live-edge lag-probe so jumps leave a buffer instead of yanking to the edge. A new consumer keepalive layer (rust-pusher path only — the fast endpoint always uses the rust pusher) keeps the *existing* session fed with the last chunk (freeze) then `DEFAULT_RESCUE_FLV`, so a trickle/gap never leaves the socket idle long enough for YouTube to reset it. New audit events make grow/shrink/keepalive observable. A latency-injecting mock fetcher provides the regression gate that was missing.
+
+**Tech Stack:** Rust 2024, tokio, `rs-rtmp-push` (RtmpPusher), `tracing`, sqlx audit, `cargo test -p rs-delivery`. Tier-2 fast-iterate is ON (local builds + `cargo xwin` allowed); run the full local pre-push gate before any push.
+
+**Root-cause evidence:** see `docs/superpowers/specs/2026-06-07-fast-stream-self-healing-design.md`. Summary: fast endpoint reads at delay 0 (live edge); streampp upload lag spikes to 90 s (vs 2.2 s on stream.lan, same S3 bucket) → producer "no chunks found in probe range" → push idles → YouTube `connection reset` → restart loop; operator removed the endpoint and switched OBS direct.
+
+**Key facts the implementer must respect:**
+- RTMP push is **always strictly 1×** (never speed up to catch up — corrupts quality, YT/FB kill it). The controller only moves the READ pointer / sets keepalive, never the push rate. (memory: `feedback_rtmp_push_always_1x`)
+- The fast endpoint (`KS-PP-TEST`) uses `pusher = Rust` → keepalive is implemented on the **rust-pusher path only**.
+- `RtmpPusher::push_flv_bytes(&bytes)` re-anchors timestamps across repeated FLV blobs internally (per-track `*_base_ms` roll-forward + `MAX_TAG_TS_JUMP_MS=30_000` re-anchor). Re-pushing the same FLV blob = a working freeze/loop with advancing timestamps. Each S3 chunk is itself a complete, self-contained FLV.
+- The rs-delivery `EndpointConfig` (`crates/rs-delivery/src/api.rs`) is a SEPARATE struct from the rs-core one. Add `#[serde(default)]` fields so old/new binaries stay cross-compatible.
+- New audit `Action` variants serialize via `#[serde(rename_all="snake_case")]` automatically; no central match to update. VPS emits through `AuditRing::push_parts`.
+- File-size CI cap: **1000 lines per .rs file**. `endpoint_task.rs` is already large — put new logic in new modules/helpers, not inline.
+
+---
+
+## Task 0: Version bump (FIRST commit, before any code)
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `version`)
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/tauri.conf.json`
+- Modify: `leptos-ui/Cargo.toml`
+
+- [ ] **Step 1: Bump all four version fields `0.22.5` → `0.22.6`**
+
+Edit each file's `version = "0.22.5"` / `"version": "0.22.5"` to `0.22.6`. Confirm:
+
+```bash
+grep -rn '0\.22\.5' Cargo.toml src-tauri/Cargo.toml src-tauri/tauri.conf.json leptos-ui/Cargo.toml
+```
+Expected: no matches remain (all now `0.22.6`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Cargo.toml src-tauri/Cargo.toml src-tauri/tauri.conf.json leptos-ui/Cargo.toml
+git commit -m "chore: bump version 0.22.5 -> 0.22.6 (fast-stream self-healing)"
+```
+
+---
+
+## Task 1: Adaptive delay controller (pure logic + unit tests)
+
+**Files:**
+- Create: `crates/rs-delivery/src/fast_delay.rs`
+- Modify: `crates/rs-delivery/src/lib.rs` (add `mod fast_delay;` — find the existing `mod` list and add it alphabetically)
+
+This is pure logic with no I/O — fully unit-testable. `now: Instant` is passed in so tests are deterministic (no tokio time needed).
+
+- [ ] **Step 1: Write the failing tests** in `crates/rs-delivery/src/fast_delay.rs`
+
+```rust
+//! Adaptive read-delay controller for fast endpoints.
+//!
+//! A fast endpoint normally reads at the live edge (delay 0). That has zero
+//! tolerance for local S3-upload latency spikes: when the live-edge chunk is
+//! not yet in S3 the push starves and YouTube resets the idle connection.
+//!
+//! This controller makes the fast endpoint's read-delay ADAPTIVE: it grows
+//! when the producer starves (so the live-edge lag-probe jumps to
+//! `live_edge - delay` and leaves a buffer instead of yanking back to the
+//! edge) and shrinks slowly when healthy (chasing the lowest working
+//! latency). It NEVER speeds up the push — it only changes which chunk the
+//! producer reads next. See the design doc for the full rationale.
+
+use std::time::Instant;
+
+/// Lowest fast-stream read-delay when healthy (seconds).
+pub const FAST_DELAY_FLOOR_SECS: u64 = 5;
+/// Maximum read-delay (seconds) = same safety as the normal stream.
+pub const FAST_DELAY_CEILING_SECS: u64 = 120;
+/// Headroom added above the observed deficit when growing (seconds).
+pub const FAST_DELAY_MARGIN_SECS: u64 = 5;
+/// Step size when shrinking back toward the floor (seconds).
+pub const FAST_DELAY_SHRINK_STEP_SECS: u64 = 5;
+/// Healthy window (seconds) with no starvation before one shrink step.
+pub const FAST_HEALTHY_SHRINK_SECS: u64 = 180;
+
+#[derive(Debug, Clone)]
+pub struct FastDelayController {
+    target_secs: u64,
+    floor: u64,
+    ceiling: u64,
+    margin: u64,
+    shrink_step: u64,
+    healthy_shrink_secs: u64,
+    /// Wall-clock of the last grow OR shrink; gates the next shrink.
+    last_change: Instant,
+}
+
+impl FastDelayController {
+    /// Production constructor: floor/ceiling/margin/step from the consts above.
+    pub fn new(now: Instant) -> Self {
+        Self::with_params(
+            FAST_DELAY_FLOOR_SECS,
+            FAST_DELAY_CEILING_SECS,
+            FAST_DELAY_MARGIN_SECS,
+            FAST_DELAY_SHRINK_STEP_SECS,
+            FAST_HEALTHY_SHRINK_SECS,
+            now,
+        )
+    }
+
+    /// Test/explicit constructor.
+    pub fn with_params(
+        floor: u64,
+        ceiling: u64,
+        margin: u64,
+        shrink_step: u64,
+        healthy_shrink_secs: u64,
+        now: Instant,
+    ) -> Self {
+        Self {
+            target_secs: floor,
+            floor,
+            ceiling,
+            margin,
+            shrink_step,
+            healthy_shrink_secs,
+            last_change: now,
+        }
+    }
+
+    pub fn target_secs(&self) -> u64 {
+        self.target_secs
+    }
+
+    /// Producer starved: the chunk it needs is not in S3 yet. `deficit_secs`
+    /// is how far the needed chunk trails the newest chunk available in S3
+    /// (0 when unknown). Grows the target to `max(target, deficit + margin)`,
+    /// clamped to the ceiling. Returns `Some((from, to))` when the target
+    /// actually changed.
+    pub fn on_starvation(&mut self, deficit_secs: u64, now: Instant) -> Option<(u64, u64)> {
+        let want = deficit_secs
+            .saturating_add(self.margin)
+            .clamp(self.floor, self.ceiling);
+        let next = self.target_secs.max(want);
+        if next != self.target_secs {
+            let from = self.target_secs;
+            self.target_secs = next;
+            self.last_change = now;
+            Some((from, next))
+        } else {
+            None
+        }
+    }
+
+    /// Called while chunks are flowing normally. After `healthy_shrink_secs`
+    /// with no change, shrink one step toward the floor. Returns
+    /// `Some((from, to))` when the target changed.
+    pub fn on_healthy(&mut self, now: Instant) -> Option<(u64, u64)> {
+        if self.target_secs <= self.floor {
+            return None;
+        }
+        if now.duration_since(self.last_change).as_secs() < self.healthy_shrink_secs {
+            return None;
+        }
+        let from = self.target_secs;
+        let next = from.saturating_sub(self.shrink_step).max(self.floor);
+        self.target_secs = next;
+        self.last_change = now;
+        Some((from, next))
+    }
+
+    /// Current target expressed in chunks, for the live-edge lag-probe.
+    /// Always >= 1 so a fast endpoint never re-pins to the absolute edge.
+    pub fn delay_chunks(&self, typical_chunk_dur_ms: u64) -> i64 {
+        let dur = typical_chunk_dur_ms.max(1);
+        ((self.target_secs.saturating_mul(1000) / dur) as i64).max(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn ctrl(now: Instant) -> FastDelayController {
+        // floor 5, ceiling 120, margin 5, step 5, healthy-window 180
+        FastDelayController::with_params(5, 120, 5, 5, 180, now)
+    }
+
+    #[test]
+    fn starts_at_floor() {
+        let now = Instant::now();
+        assert_eq!(ctrl(now).target_secs(), 5);
+    }
+
+    #[test]
+    fn grows_to_deficit_plus_margin() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        // deficit 20s -> target 25s
+        assert_eq!(c.on_starvation(20, now), Some((5, 25)));
+        assert_eq!(c.target_secs(), 25);
+    }
+
+    #[test]
+    fn grow_is_monotonic_until_shrink() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        c.on_starvation(20, now); // -> 25
+        // smaller deficit does not lower the target
+        assert_eq!(c.on_starvation(5, now), None);
+        assert_eq!(c.target_secs(), 25);
+    }
+
+    #[test]
+    fn grow_clamps_to_ceiling() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        // deficit 200s + margin would be 205 -> clamp to 120
+        assert_eq!(c.on_starvation(200, now), Some((5, 120)));
+        assert_eq!(c.target_secs(), 120);
+    }
+
+    #[test]
+    fn unknown_deficit_grows_by_margin_floor() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        // deficit 0 -> want = max(floor, margin)=5 == floor -> no change at floor
+        assert_eq!(c.on_starvation(0, now), None);
+        // after a grow to 25, deficit-0 still cannot lower
+        c.on_starvation(20, now);
+        assert_eq!(c.on_starvation(0, now), None);
+        assert_eq!(c.target_secs(), 25);
+    }
+
+    #[test]
+    fn shrink_only_after_healthy_window() {
+        let base = Instant::now();
+        let mut c = ctrl(base);
+        c.on_starvation(40, base); // -> 45 at t=0
+        // before window: no shrink
+        assert_eq!(c.on_healthy(base + Duration::from_secs(179)), None);
+        // at window: one step down (45 -> 40)
+        assert_eq!(c.on_healthy(base + Duration::from_secs(180)), Some((45, 40)));
+        assert_eq!(c.target_secs(), 40);
+    }
+
+    #[test]
+    fn shrink_floors_at_floor() {
+        let base = Instant::now();
+        let mut c = ctrl(base);
+        c.on_starvation(2, base); // -> max(target, 5+? ) ; deficit2+margin5=7 -> 7
+        assert_eq!(c.target_secs(), 7);
+        let t = base + Duration::from_secs(180);
+        assert_eq!(c.on_healthy(t), Some((7, 5))); // 7-5=2 -> max(floor)=5
+        // already at floor -> no further shrink
+        assert_eq!(c.on_healthy(t + Duration::from_secs(180)), None);
+    }
+
+    #[test]
+    fn delay_chunks_uses_chunk_duration() {
+        let now = Instant::now();
+        let mut c = ctrl(now);
+        c.on_starvation(20, now); // 25s
+        // 2000ms chunks -> 25000/2000 = 12 chunks
+        assert_eq!(c.delay_chunks(2000), 12);
+        // 1000ms chunks -> 25 chunks
+        assert_eq!(c.delay_chunks(1000), 25);
+        // never below 1 even at floor with huge chunks
+        let edge = ctrl(now);
+        assert_eq!(edge.delay_chunks(60_000), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (module not yet wired)**
+
+Run: `cargo test -p rs-delivery fast_delay`
+Expected: FAIL — `fast_delay` not declared in `lib.rs` (compile error) until the implementation file + `mod fast_delay;` exist. (If you wrote the file in Step 1, the failure is the missing `mod` line.)
+
+- [ ] **Step 3: Declare the module**
+
+In `crates/rs-delivery/src/lib.rs`, add `mod fast_delay;` to the module list (keep alphabetical with the neighbouring `mod` lines). If other modules need it later, use `pub(crate) mod fast_delay;`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p rs-delivery fast_delay`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rs-delivery/src/fast_delay.rs crates/rs-delivery/src/lib.rs
+git commit -m "feat(delivery): adaptive read-delay controller for fast endpoints"
+```
+
+---
+
+## Task 2: New audit Action variants
+
+**Files:**
+- Modify: `crates/rs-core/src/audit.rs` (add variants + serde round-trip tests)
+
+- [ ] **Step 1: Write failing serde round-trip tests**
+
+In the `#[cfg(test)] mod tests` block of `crates/rs-core/src/audit.rs`, alongside the existing `action_*_serdes` tests, add:
+
+```rust
+#[test]
+fn action_fast_delay_grown_serdes() {
+    let a = Action::FastDelayGrown;
+    let s = serde_json::to_string(&a).unwrap();
+    assert_eq!(s, "\"fast_delay_grown\"");
+    assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+}
+
+#[test]
+fn action_fast_delay_shrank_serdes() {
+    let a = Action::FastDelayShrank;
+    let s = serde_json::to_string(&a).unwrap();
+    assert_eq!(s, "\"fast_delay_shrank\"");
+    assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+}
+
+#[test]
+fn action_fast_keepalive_started_serdes() {
+    let a = Action::FastKeepaliveStarted;
+    let s = serde_json::to_string(&a).unwrap();
+    assert_eq!(s, "\"fast_keepalive_started\"");
+    assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+}
+
+#[test]
+fn action_fast_keepalive_ended_serdes() {
+    let a = Action::FastKeepaliveEnded;
+    let s = serde_json::to_string(&a).unwrap();
+    assert_eq!(s, "\"fast_keepalive_ended\"");
+    assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p rs-core audit::tests::action_fast`
+Expected: FAIL — `no variant named FastDelayGrown` (compile error).
+
+- [ ] **Step 3: Add the variants**
+
+In the `Action` enum in `crates/rs-core/src/audit.rs`, add (next to `FastEndpointJumpedToLiveEdge, EndpointStartChunkUpdated,`):
+
+```rust
+    FastDelayGrown,
+    FastDelayShrank,
+    FastKeepaliveStarted,
+    FastKeepaliveEnded,
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p rs-core audit::tests::action_fast`
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rs-core/src/audit.rs
+git commit -m "feat(audit): fast-delay + fast-keepalive action variants"
+```
+
+---
+
+## Task 3: Audit emit helpers (VPS-side AuditRing)
+
+**Files:**
+- Create: `crates/rs-delivery/src/fast_delay_audit.rs`
+- Modify: `crates/rs-delivery/src/lib.rs` (add `mod fast_delay_audit;`)
+
+Mirror the pattern in `rescue_audit.rs` (which emits via `AuditRing::push_parts`).
+
+- [ ] **Step 1: Write the helper module with tests**
+
+```rust
+//! Audit emit helpers for the fast-endpoint self-healing path. Mirrors
+//! `rescue_audit.rs`: VPS-side events go through the `AuditRing`.
+use std::sync::Arc;
+
+use rs_core::audit::{Action, Severity, Source};
+
+use crate::audit_ring::{AuditRing, RingRowParts};
+
+fn push(
+    audit_ring: &Option<Arc<AuditRing>>,
+    severity: Severity,
+    action: Action,
+    alias: &str,
+    detail: serde_json::Value,
+) {
+    if let Some(ring) = audit_ring {
+        ring.push_parts(RingRowParts {
+            severity,
+            source: Source::Vps,
+            endpoint: Some(alias.to_string()),
+            action,
+            detail,
+        });
+    }
+}
+
+pub fn emit_delay_grown(
+    audit_ring: &Option<Arc<AuditRing>>,
+    alias: &str,
+    from_secs: u64,
+    to_secs: u64,
+    deficit_secs: u64,
+) {
+    push(
+        audit_ring,
+        Severity::Warn,
+        Action::FastDelayGrown,
+        alias,
+        serde_json::json!({
+            "alias": alias,
+            "from_secs": from_secs,
+            "to_secs": to_secs,
+            "observed_deficit_secs": deficit_secs,
+        }),
+    );
+}
+
+pub fn emit_delay_shrank(
+    audit_ring: &Option<Arc<AuditRing>>,
+    alias: &str,
+    from_secs: u64,
+    to_secs: u64,
+) {
+    push(
+        audit_ring,
+        Severity::Info,
+        Action::FastDelayShrank,
+        alias,
+        serde_json::json!({ "alias": alias, "from_secs": from_secs, "to_secs": to_secs }),
+    );
+}
+
+pub fn emit_keepalive_started(audit_ring: &Option<Arc<AuditRing>>, alias: &str, mode: &str) {
+    push(
+        audit_ring,
+        Severity::Warn,
+        Action::FastKeepaliveStarted,
+        alias,
+        serde_json::json!({ "alias": alias, "mode": mode }),
+    );
+}
+
+pub fn emit_keepalive_ended(audit_ring: &Option<Arc<AuditRing>>, alias: &str, gap_secs: u64) {
+    push(
+        audit_ring,
+        Severity::Info,
+        Action::FastKeepaliveEnded,
+        alias,
+        serde_json::json!({ "alias": alias, "gap_secs": gap_secs }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_with_none_ring_is_noop() {
+        // Must not panic when there is no audit ring (e.g. tests / no DB).
+        emit_delay_grown(&None, "ep", 5, 25, 20);
+        emit_delay_shrank(&None, "ep", 25, 20);
+        emit_keepalive_started(&None, "ep", "freeze");
+        emit_keepalive_ended(&None, "ep", 12);
+    }
+}
+```
+
+> NOTE for implementer: confirm `RingRowParts`' exact field set by reading `crates/rs-delivery/src/audit_ring.rs`. The canonical call site is `rescue.rs::run_warmup_loop` (`ring.push_parts(RingRowParts{ severity, source, endpoint, action, detail })`). Match field names exactly.
+
+- [ ] **Step 2: Declare module + run test (expect fail then pass)**
+
+Add `mod fast_delay_audit;` to `crates/rs-delivery/src/lib.rs`.
+Run: `cargo test -p rs-delivery fast_delay_audit`
+Expected: PASS (the no-op test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rs-delivery/src/fast_delay_audit.rs crates/rs-delivery/src/lib.rs
+git commit -m "feat(delivery): fast-delay/keepalive audit emit helpers"
+```
+
+---
+
+## Task 4: Wire the adaptive controller into the producer
+
+**Files:**
+- Modify: `crates/rs-delivery/src/endpoint_task.rs` (producer_task + EndpointHandle::spawn call site)
+- Test: `crates/rs-delivery/src/endpoint_task_tests.rs` (extend `TimedMockFetcher` with injected latency + a producer-grows test)
+
+The producer owns `chunk_id` and the miss loop — the controller lives here for fast endpoints. For non-fast endpoints behaviour is unchanged.
+
+- [ ] **Step 1: Extend `TimedMockFetcher` with injected per-fetch latency**
+
+In `crates/rs-delivery/src/endpoint_task_tests.rs`, add a latency field to `TimedMockFetcher` (currently fields `chunks`, `available_up_to: Arc<AtomicI64>`, `duration_ms_per_chunk: 2000`). Add:
+
+```rust
+    /// Optional artificial delay applied inside each fetch/HEAD, so tests
+    /// can simulate a slow live edge under `tokio::time::pause()`.
+    fetch_latency: std::time::Duration,
+```
+
+Set it to `Duration::ZERO` in the existing constructor, add a `with_latency(self, d: Duration) -> Self` builder, and at the top of both `fetch_chunk_with_meta` and `chunk_duration_ms` add:
+
+```rust
+        if !self.fetch_latency.is_zero() {
+            tokio::time::sleep(self.fetch_latency).await;
+        }
+```
+
+(Works deterministically under `tokio::time::pause()` + `tokio::time::advance()`.)
+
+- [ ] **Step 2: Write the failing producer test**
+
+Add to `endpoint_task_tests.rs`. It drives `producer_task` for a FAST endpoint where the live edge is briefly unavailable, and asserts the read pointer ends up BEHIND the live edge (a buffer was built), not pinned to it.
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn fast_producer_builds_buffer_after_starvation() {
+    use std::sync::atomic::Ordering;
+    // available_up_to starts low; chunks 0..=4 exist, edge will advance.
+    let fetcher = TimedMockFetcher::new(/* chunks 0..=4, dur 2000 */);
+    fetcher.set_available_up_to(4);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+    let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+    let stats = make_stats();
+    let buffer_state = std::sync::Arc::new(crate::buffer_state::BufferState::new());
+
+    let handle = tokio::spawn(producer_task_fast(
+        fetcher.clone(),
+        tx,
+        0,            // start_chunk_id
+        stop_rx,
+        stats.clone(),
+        "fast-ep".to_string(),
+        buffer_state.clone(),
+        None,         // audit_ring
+    ));
+
+    // Drain a few chunks; advance the live edge far ahead while the producer
+    // is busy, then induce a miss window so the controller grows the delay.
+    tokio::time::advance(std::time::Duration::from_secs(2)).await;
+    let _ = rx.recv().await;
+    fetcher.set_available_up_to(100);             // edge jumps far ahead
+    tokio::time::advance(std::time::Duration::from_secs(120)).await;
+
+    stop_tx.send(true).unwrap();
+    let _ = handle.await;
+
+    // After the lag-probe, a FAST endpoint must read at `edge - delay`, i.e.
+    // strictly behind 100, never AT 100. (delay_chunks >= floor/dur >= 1)
+    let read_pos = stats.lock().await.current_chunk_id;
+    assert!(read_pos < 100, "fast endpoint must keep a buffer, got {read_pos}");
+}
+```
+
+> NOTE: `producer_task` is currently private and not fast-aware. Step 3 introduces a thin fast-aware entry. If a `make_stats()` helper / `TimedMockFetcher::new` shape differs, match the existing test helpers in this file (read the top of `endpoint_task_tests.rs`).
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cargo test -p rs-delivery fast_producer_builds_buffer_after_starvation`
+Expected: FAIL — `producer_task_fast` not defined.
+
+- [ ] **Step 4: Make `producer_task` fast-aware**
+
+In `crates/rs-delivery/src/endpoint_task.rs`:
+
+1. Add `is_fast: bool` to the `producer_task` parameter list (thread it from `EndpointHandle::spawn`, which already has `ep_cfg.is_fast`). At the `EndpointHandle::spawn` producer-spawn call site, pass `ep_cfg.is_fast`.
+
+2. At the top of `producer_task`, construct the controller for fast endpoints:
+
+```rust
+    let mut fast_delay = if is_fast {
+        Some(crate::fast_delay::FastDelayController::new(tokio::time::Instant::now().into_std()))
+    } else {
+        None
+    };
+```
+
+   (Use `std::time::Instant::now()` directly if simpler — the controller takes `std::time::Instant`. Under `start_paused`, prefer `tokio::time::Instant::now().into_std()` so `advance()` is honoured; verify which compiles cleanly and is deterministic in the test.)
+
+3. Replace the fixed delay-chunks computation (current lines ~219-223):
+
+```rust
+                let delivery_delay_chunks: i64 = if delivery_delay_ms == 0 {
+                    0
+                } else {
+                    ((delivery_delay_ms / typical_chunk_dur_ms.max(1)) as i64).max(1)
+                };
+```
+
+   with a controller-aware version:
+
+```rust
+                let delivery_delay_chunks: i64 = match fast_delay.as_mut() {
+                    Some(ctrl) => {
+                        // Healthy fetch: opportunistically shrink toward the
+                        // floor after a sustained healthy window.
+                        if let Some((from, to)) =
+                            ctrl.on_healthy(std::time::Instant::now())
+                        {
+                            crate::fast_delay_audit::emit_delay_shrank(
+                                &audit_ring, &alias, from, to,
+                            );
+                        }
+                        ctrl.delay_chunks(typical_chunk_dur_ms)
+                    }
+                    None if delivery_delay_ms == 0 => 0,
+                    None => ((delivery_delay_ms / typical_chunk_dur_ms.max(1)) as i64).max(1),
+                };
+```
+
+4. In the `Ok(None)` arm, after the skip-ahead probe determines the gap, grow the controller. When `found_ahead` is true the gap is `probe_id - chunk_id_before`; when not found pass `0`. Add — inside the `if consecutive_chunk_misses >= MAX_CHUNK_MISS_COUNT` block, capture `let stuck_at = chunk_id;` before the probe loop, and after the block:
+
+```rust
+                    if let Some(ctrl) = fast_delay.as_mut() {
+                        let deficit_secs = if found_ahead {
+                            ((chunk_id - stuck_at).max(0) as u64)
+                                .saturating_mul(typical_chunk_dur_ms)
+                                / 1000
+                        } else {
+                            0
+                        };
+                        if let Some((from, to)) =
+                            ctrl.on_starvation(deficit_secs, std::time::Instant::now())
+                        {
+                            crate::fast_delay_audit::emit_delay_grown(
+                                &audit_ring, &alias, from, to, deficit_secs,
+                            );
+                        }
+                    }
+```
+
+   (`audit_ring` is already a `producer_task` param — confirm its exact type matches the helper signature `&Option<Arc<AuditRing>>`; pass `&audit_ring`.)
+
+5. The lag-probe already targets `live_edge - delivery_delay_chunks`; with the controller returning `>= 1` for fast endpoints, fast now keeps a buffer. No change needed in `producer_lag.rs`.
+
+- [ ] **Step 5: Run the producer test + the existing producer_lag/endpoint_task suites**
+
+Run: `cargo test -p rs-delivery`
+Expected: PASS — new test green; all existing `producer_lag`, `endpoint_task_tests`, `buffer_state` tests still green (non-fast path unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rs-delivery/src/endpoint_task.rs crates/rs-delivery/src/endpoint_task_tests.rs
+git commit -m "feat(delivery): drive fast-endpoint read-delay from adaptive controller"
+```
+
+---
+
+## Task 5: Keepalive — hold the connection through short gaps (freeze → rescue)
+
+**Files:**
+- Create: `crates/rs-delivery/src/fast_keepalive.rs`
+- Modify: `crates/rs-delivery/src/lib.rs` (add `mod fast_keepalive;`)
+- Modify: `crates/rs-delivery/src/endpoint_task.rs` (consumer rust-pusher path: capture last chunk; run keepalive instead of idling on a short gap)
+
+The fast endpoint always uses the rust pusher. The fix keeps that SAME pusher session fed during a gap, so YouTube never sees an idle socket. This is distinct from the heavyweight 8 s outage rescue (which drops+recreates the session) — keepalive is the light, fast (sub-second-trigger) gap filler.
+
+- [ ] **Step 1: Write the keepalive helper with a unit test**
+
+```rust
+//! Fast-endpoint keepalive: hold the EXISTING rtmp session alive during a
+//! short producer gap by re-pushing the last delivered chunk (freeze), then
+//! the default rescue loop after `FAST_KEEPALIVE_RESCUE_AFTER_SECS`. Re-using
+//! the same `Pushable` means the RTMP connection is never closed by
+//! starvation — only a real socket error reconnects. `push_flv_bytes`
+//! re-anchors timestamps across the repeated blob internally.
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Wait this long for a real chunk before starting keepalive frames. Far
+/// below the 8s full-stall rescue threshold so the trickle regime (chunks
+/// arriving late but often) is covered, not just total outages.
+pub const FAST_KEEPALIVE_TRIGGER_SECS: u64 = 2;
+/// After this much continuous gap, switch the keepalive content from the
+/// frozen last chunk to the default rescue loop.
+pub const FAST_KEEPALIVE_RESCUE_AFTER_SECS: u64 = 10;
+
+/// Which content the keepalive is currently pushing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeepaliveMode {
+    Freeze,
+    Rescue,
+}
+
+/// Pure decision: given how long the gap has lasted, what to push.
+pub fn keepalive_mode(gap_secs: u64, have_freeze: bool) -> KeepaliveMode {
+    if have_freeze && gap_secs < FAST_KEEPALIVE_RESCUE_AFTER_SECS {
+        KeepaliveMode::Freeze
+    } else {
+        KeepaliveMode::Rescue
+    }
+}
+
+/// Select the FLV bytes to push for a keepalive tick.
+pub fn keepalive_bytes<'a>(
+    mode: KeepaliveMode,
+    last_chunk: &'a Option<Arc<Vec<u8>>>,
+) -> std::borrow::Cow<'a, [u8]> {
+    match mode {
+        KeepaliveMode::Freeze => match last_chunk {
+            Some(b) => std::borrow::Cow::Borrowed(b.as_slice()),
+            None => std::borrow::Cow::Borrowed(crate::rescue_default::DEFAULT_RESCUE_FLV),
+        },
+        KeepaliveMode::Rescue => {
+            std::borrow::Cow::Borrowed(crate::rescue_default::DEFAULT_RESCUE_FLV)
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn elapsed_secs(since: Instant) -> u64 {
+    since.elapsed().as_secs()
+}
+
+/// Test seam: a duration-free "did we exceed the rescue switch?" check.
+#[allow(dead_code)]
+pub(crate) fn should_switch_to_rescue(gap: Duration) -> bool {
+    gap.as_secs() >= FAST_KEEPALIVE_RESCUE_AFTER_SECS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn freeze_then_rescue_by_gap() {
+        assert_eq!(keepalive_mode(0, true), KeepaliveMode::Freeze);
+        assert_eq!(keepalive_mode(9, true), KeepaliveMode::Freeze);
+        assert_eq!(keepalive_mode(10, true), KeepaliveMode::Rescue);
+        // No freeze bytes available -> straight to rescue.
+        assert_eq!(keepalive_mode(0, false), KeepaliveMode::Rescue);
+    }
+
+    #[test]
+    fn bytes_fall_back_to_default_when_no_freeze() {
+        let none: Option<Arc<Vec<u8>>> = None;
+        let b = keepalive_bytes(KeepaliveMode::Freeze, &none);
+        assert_eq!(&*b, crate::rescue_default::DEFAULT_RESCUE_FLV);
+    }
+
+    #[test]
+    fn freeze_uses_last_chunk_bytes() {
+        let last = Some(Arc::new(vec![1u8, 2, 3]));
+        let b = keepalive_bytes(KeepaliveMode::Freeze, &last);
+        assert_eq!(&*b, &[1u8, 2, 3]);
+    }
+}
+```
+
+- [ ] **Step 2: Declare module, run tests (expect pass)**
+
+Add `mod fast_keepalive;` to `lib.rs`.
+Run: `cargo test -p rs-delivery fast_keepalive`
+Expected: PASS — 3 unit tests green.
+
+- [ ] **Step 3: Capture the last delivered chunk in the consumer (rust path)**
+
+In `consumer_task` (`endpoint_task.rs`), add near the other `let mut` state (e.g. by `last_delivered_chunk_id`):
+
+```rust
+    // Last full FLV chunk pushed — replayed as a freeze during keepalive.
+    let mut last_chunk_bytes: Option<std::sync::Arc<Vec<u8>>> = None;
+```
+
+In the rust-pusher write branch, after `handle_rust_push` returns `RustPushAction::Continue`, set:
+
+```rust
+                if matches!(action, RustPushAction::Continue) {
+                    last_chunk_bytes = Some(std::sync::Arc::new(chunk.data.clone()));
+                    // ... existing emit_push_sample(...) call stays ...
+                }
+```
+
+(The `chunk.data` clone is one chunk (~few MB) held for freeze; acceptable.)
+
+- [ ] **Step 4: Run keepalive on a short gap instead of idling (rust path only)**
+
+Replace the consumer's chunk-pull `tokio::select!` so that, on the rust path, a short gap triggers keepalive on the existing pusher rather than waiting silently up to 8 s.
+
+Concretely, change the `_ = tokio::time::sleep(RESCUE_STALL_THRESHOLD_SECS) => { ... }` arm: for the rust path, lower the first reaction to `FAST_KEEPALIVE_TRIGGER_SECS` and, when fired, enter a keepalive loop that keeps the SAME `rust_pusher` fed until a real chunk arrives, then returns it. Implementation (new private async fn in `endpoint_task.rs`, kept short to respect the 1000-line cap — or place the loop body in `fast_keepalive.rs` taking `&mut impl Pushable`):
+
+```rust
+/// Keep the existing rust session alive during a producer gap. Returns the
+/// next real chunk when one arrives, or None on stop/closed channel.
+async fn keepalive_until_chunk(
+    pusher: &mut rs_rtmp_push::RtmpPusher,
+    rx: &mut tokio::sync::mpsc::Receiver<PrefetchedChunk>,
+    last_chunk_bytes: &Option<std::sync::Arc<Vec<u8>>>,
+    alias: &str,
+    audit_ring: &Option<std::sync::Arc<crate::audit_ring::AuditRing>>,
+    stop_rx: &mut tokio::sync::watch::Receiver<bool>,
+) -> Option<PrefetchedChunk> {
+    use crate::fast_keepalive::{keepalive_bytes, keepalive_mode};
+    let started = std::time::Instant::now();
+    crate::fast_delay_audit::emit_keepalive_started(audit_ring, alias, "freeze");
+    let mut last_mode = crate::fast_keepalive::KeepaliveMode::Freeze;
+    loop {
+        let gap = started.elapsed().as_secs();
+        let mode = keepalive_mode(gap, last_chunk_bytes.is_some());
+        if mode != last_mode {
+            crate::fast_delay_audit::emit_keepalive_started(
+                audit_ring, alias,
+                if mode == crate::fast_keepalive::KeepaliveMode::Rescue { "rescue" } else { "freeze" },
+            );
+            last_mode = mode;
+        }
+        let bytes = keepalive_bytes(mode, last_chunk_bytes).into_owned();
+        tokio::select! {
+            maybe = rx.recv() => {
+                crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+                return maybe; // Some(chunk) resumes; None -> caller handles teardown
+            }
+            res = pusher.push_flv_bytes(&bytes) => {
+                if let Err(e) = res {
+                    // A REAL socket error: log + short backoff, but DO NOT
+                    // tear down — the pusher lazy-reconnects on next push.
+                    tracing::warn!(alias = %alias, "keepalive push error: {e}; reconnecting");
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+                // push_flv_bytes self-paces ~1x; loop pushes the next tick.
+            }
+            _ = stop_rx.changed() => {
+                if *stop_rx.borrow() {
+                    crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+                    return None;
+                }
+            }
+        }
+    }
+}
+```
+
+Then in the consumer chunk-pull, on the rust path, gate entry into keepalive: when `rx.recv()` hasn't produced a chunk within `FAST_KEEPALIVE_TRIGGER_SECS`, call `keepalive_until_chunk` and treat its `Some(chunk)` return exactly like a normal `rx.recv()` chunk (process it), or `None` like the channel-closed/stop path (defensive teardown). Keep the existing 8 s `run_outage_rescue` path for the **non-rust** (ffmpeg) endpoints unchanged. Minimal restructure:
+
+```rust
+        // rust path: short-gap keepalive on the SAME session.
+        let chunk = if use_rust_pusher {
+            tokio::select! {
+                maybe = rx.recv() => match maybe {
+                    Some(c) => { /* update buffer_duration_ms, last_delivered_chunk_id */ c }
+                    None => { /* existing defensive-rescue None branch */ break }
+                },
+                _ = tokio::time::sleep(std::time::Duration::from_secs(
+                        crate::fast_keepalive::FAST_KEEPALIVE_TRIGGER_SECS)) => {
+                    if let Some(ref mut pusher) = rust_pusher {
+                        match keepalive_until_chunk(pusher, &mut rx, &last_chunk_bytes, &alias, &audit_ring, &mut stop_rx).await {
+                            Some(c) => { /* update buffer_duration_ms, last_delivered_chunk_id */ c }
+                            None => break,
+                        }
+                    } else { continue }
+                }
+                _ = stop_rx.changed() => { if *stop_rx.borrow() { break } else { continue } }
+            }
+        } else {
+            // EXISTING ffmpeg-path select! (rx.recv / RESCUE_STALL_THRESHOLD_SECS / stop) unchanged
+            tokio::select! { /* ...existing code... */ }
+        };
+```
+
+> IMPLEMENTER NOTE: this is the riskiest edit. Keep the buffer-duration bookkeeping (`buffer_state.buffer_duration_ms` decrement + `last_delivered_chunk_id = c.chunk_id`) identical to the current `Some(c)` branch in BOTH the direct-recv and post-keepalive paths. Do not remove the existing 8 s `run_outage_rescue` arm for the ffmpeg path. `rust_pusher` is `Option`; the `if let Some(ref mut pusher)` borrow must end before the chunk is processed in the write section below — restructure so the keepalive borrow is scoped to the select arm only (return the chunk value out of the arm, then process it after the `select!`). Iterate against the compiler (Tier-2 fast-iterate is ON).
+
+- [ ] **Step 5: Run the full rs-delivery suite**
+
+Run: `cargo test -p rs-delivery`
+Expected: PASS — keepalive unit tests + all existing tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rs-delivery/src/fast_keepalive.rs crates/rs-delivery/src/lib.rs crates/rs-delivery/src/endpoint_task.rs
+git commit -m "feat(delivery): never-crash keepalive (freeze->rescue) for fast endpoints"
+```
+
+---
+
+## Task 6: Integration regression test — jitter never crashes the fast stream
+
+**Files:**
+- Modify: `crates/rs-delivery/src/endpoint_task_tests.rs` (or a new `fast_self_healing_tests.rs` module — match how integration tests are organized; declare in `lib.rs` if new)
+
+This is the gate that was missing: a deterministic test proving a fast endpoint survives an injected upload-latency gap without the push ever erroring/closing, with keepalive frames emitted and the stream resuming.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Use a recording mock `Pushable` (push never errors; counts pushes + records byte-lengths) and the latency-extended `TimedMockFetcher`. Drive `consumer_task` (rust path) with a producer that stops supplying chunks for 30 s of simulated time, then resumes.
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn fast_endpoint_survives_upload_gap_without_dying() {
+    // A Pushable that NEVER errors and records each push.
+    #[derive(Clone, Default)]
+    struct RecordingPusher { pushes: std::sync::Arc<std::sync::atomic::AtomicU32>, closed: std::sync::Arc<std::sync::atomic::AtomicBool> }
+    impl crate::endpoint_consumer_helpers::Pushable for RecordingPusher {
+        async fn push_flv_bytes(&mut self, _d: &[u8]) -> Result<(), rs_rtmp_push::PushError> {
+            self.pushes.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await; // 1x-ish pacing
+            Ok(())
+        }
+        async fn close(&mut self) { self.closed.store(true, std::sync::atomic::Ordering::Relaxed); }
+        fn reconnect_count(&self) -> u32 { 0 }
+    }
+
+    // ... build consumer with: a channel that yields 3 chunks, then a 30s
+    // gap (no chunks), then 3 more chunks; last_chunk_bytes populated after
+    // the first real chunk; stop after resume.
+
+    // Assertions:
+    // 1. RecordingPusher.closed == false the whole time (connection never
+    //    torn down by starvation).
+    // 2. push count during the gap > 0 (keepalive frames were emitted).
+    // 3. after resume, real chunks were pushed again.
+    // 4. no panic / no early return.
+}
+```
+
+> IMPLEMENTER NOTE: `consumer_task` is generic over `OutputProcessFactory` and constructs `RtmpPusher` internally for the rust path — it does not currently accept an injected `Pushable`. To test deterministically, EITHER (a) refactor the keepalive + per-chunk push to go through a small `&mut impl Pushable` seam that the test can supply (preferred — also de-risks the consumer), OR (b) test `keepalive_until_chunk` directly with `RecordingPusher` + a hand-driven `mpsc` (lighter, still proves the never-close + keepalive-frames + resume guarantees). Choose (b) if the consumer refactor is too invasive for one task; it still locks the core guarantee. Use `tokio::time::advance` to cross the 30 s gap and the 10 s freeze→rescue switch, and assert the mode switched (freeze pushes then rescue pushes).
+
+- [ ] **Step 2: Run to verify failure, then implement the test seam, then pass**
+
+Run: `cargo test -p rs-delivery fast_endpoint_survives_upload_gap_without_dying`
+Expected: FAIL first (seam/test not present), PASS after wiring.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rs-delivery/src/endpoint_task_tests.rs crates/rs-delivery/src/lib.rs
+git commit -m "test(delivery): regression gate — fast endpoint survives upload jitter [red->green]"
+```
+
+---
+
+## Task 7: Disk-pressure logging — emit only on level transitions (small, secondary)
+
+**Files:**
+- Modify: `crates/rs-endpoint/src/disk_pressure.rs`
+
+Reduces the every-minute `LocalDiskPressure` warn while the disk sits at one level (203 rows in one event). Keeps the signal (transitions) and the `disk_critical`/`disk_level` atomics unchanged. This does NOT change retention (host keeps chunks until uploaded — continuity guarantee).
+
+- [ ] **Step 1: Write/adjust the test**
+
+In the `#[cfg(test)]` block of `disk_pressure.rs`, add a test asserting the transition predicate (extract a tiny pure helper):
+
+```rust
+/// True when a new pressure reading should be logged (level changed).
+pub(crate) fn should_log_transition(prev: DiskPressure, now: DiskPressure) -> bool {
+    prev != now
+}
+
+#[test]
+fn logs_only_on_transition() {
+    assert!(should_log_transition(DiskPressure::Ok, DiskPressure::Warn));
+    assert!(!should_log_transition(DiskPressure::Warn, DiskPressure::Warn));
+    assert!(should_log_transition(DiskPressure::Warn, DiskPressure::Critical));
+    assert!(should_log_transition(DiskPressure::Critical, DiskPressure::Warn));
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p rs-endpoint --features testing disk_pressure`
+Expected: FAIL — `should_log_transition` not defined.
+
+- [ ] **Step 3: Implement transition-only emit**
+
+In `run_disk_monitor`, add `let mut last_pressure = DiskPressure::Ok;` before the loop. Replace the `rl.allow(Action::LocalDiskPressure, class)` gate with `should_log_transition(last_pressure, pressure)`, and after the (possible) emit set `last_pressure = pressure;`. Keep emitting for `Ok` transitions too is unnecessary — but DO update `last_pressure` for every reading (including the `Ok => continue` path) so an Ok→Warn later still logs. Restructure: classify, store atomics, update `last_pressure` AFTER deciding to log; for `Ok` set `last_pressure = Ok` and `continue` (no audit row for Ok, matching today's behaviour). The `RateLimiter` can stay as a secondary guard or be removed (transition gate already bounds volume).
+
+- [ ] **Step 4: Run to verify pass + the rs-endpoint suite**
+
+Run: `cargo test -p rs-endpoint --features testing`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rs-endpoint/src/disk_pressure.rs
+git commit -m "feat(endpoint): log local disk pressure only on level transitions"
+```
+
+---
+
+## Task 8: Final review, full gate, push, CI, deploy verification
+
+- [ ] **Step 1: Run the full local pre-push gate (Tier-2)**
+
+```bash
+cargo fmt --all --check \
+ && cargo check --workspace \
+ && cargo clippy --workspace --all-targets -- -D warnings \
+ && cargo test --no-run --workspace
+```
+All must pass. Then run the changed-crate suites in full:
+
+```bash
+cargo test -p rs-delivery && cargo test -p rs-core audit && cargo test -p rs-endpoint --features testing
+```
+Do NOT mask exit codes with `tail`/`grep` (memory: `feedback_dont_mask_gate_exit_code`).
+
+- [ ] **Step 2: Self-review the diff** against the spec; run `/review` and `superpowers:requesting-code-review`; fix every 🔴/🟡/🔵.
+
+- [ ] **Step 3: Push once, monitor CI to all-green** (per `ci-monitoring`). Single push.
+
+- [ ] **Step 4: Open PR `dev` → `main`** titled `Fast-stream self-healing: adaptive read-delay + never-crash keepalive (fixes restart loop)`, body listing the root-cause evidence + the soak verification still owed. Ensure `mergeable: true` AND `mergeable_state: "clean"`.
+
+- [ ] **Step 5: Post-merge soak verification (owed before "done")** — on streampp, run a real event with the fast endpoint enabled; assert via the audit log: zero starvation-driven `endpoint_rtmp_push_died`, visible `fast_delay_grown`/`fast_keepalive_*` events during an induced disk-busy spike, and a continuous stream. "Working" = sustained soak, 0 deaths, 0 crashes (memory: `feedback_definition_of_working`).
+
+---
+
+## Self-Review (planner)
+
+**1. Spec coverage:**
+- Principle 1 (never crash on starvation) → Task 5 (keepalive holds the session; only real socket errors reconnect) + Task 6 (regression gate asserts no close).
+- Principle 2 (self-tuning delay) → Tasks 1, 4 (grow/shrink controller wired into the lag-probe).
+- Principle 3 (buffering-then-resume; freeze→rescue) → Task 5 (`keepalive_mode` freeze<10 s then rescue) + user-selected content.
+- Principle 4 (always 1×) → controller only moves the read pointer / keepalive uses self-pacing `push_flv_bytes`; no speed-up anywhere. Noted in Task header.
+- Component 3 (local jitter) → Task 7 (transition-only logging) + ops note (host retention intentionally uncapped — corrected from spec's "tighter retention").
+- Component 4 (regression test) → Task 6 + Task 1/5 unit tests.
+- Audit observability → Tasks 2, 3, wired in 4 & 5.
+
+**2. Placeholder scan:** Tasks 1–3, 7 have complete code. Tasks 4–6 carry exact insertion points + complete new functions, with explicit IMPLEMENTER NOTES where a borrow-scope/refactor judgment is required (these are integration judgments against verbatim current code, not vague TODOs). The integration test (Task 6) gives two concrete seam options and full assertions.
+
+**3. Type consistency:** `FastDelayController::{new, with_params, target_secs, on_starvation, on_healthy, delay_chunks}`, `KeepaliveMode::{Freeze,Rescue}`, `keepalive_mode/keepalive_bytes`, audit helpers `emit_delay_grown/emit_delay_shrank/emit_keepalive_started/emit_keepalive_ended`, and `Action::{FastDelayGrown,FastDelayShrank,FastKeepaliveStarted,FastKeepaliveEnded}` are used consistently across Tasks 1–6. `Pushable` matches the verbatim trait in `endpoint_consumer_helpers.rs`.
+
+**Decomposition note:** one feature = one PR (per `autonomous-batch-issue-development`). All tasks land on `dev` in one PR. Task 7 (disk logging) is <30 LoC same-area polish — included, not deferred.

--- a/docs/superpowers/specs/2026-06-07-fast-stream-self-healing-design.md
+++ b/docs/superpowers/specs/2026-06-07-fast-stream-self-healing-design.md
@@ -1,0 +1,209 @@
+# Self-Healing Fast Stream — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (brainstorming) — ready for implementation plan
+**Author:** CAWE
+
+## Problem
+
+The "fast" delivery endpoint restarts in a loop during production events and
+forces the operator to abandon restreamer and push from OBS directly. Reported
+on the last two PP-live events; worst case 39 consecutive restarts in one event.
+
+## Root cause (proven from streampp production data, 2026-06-07)
+
+The fast endpoint is the **only** endpoint with `is_fast = 1`
+(`endpoint_configs` id 22, `KS-PP-TEST`, `YT_RTMP`, rust pusher).
+
+`crates/rs-delivery/src/endpoint_task.rs:132`:
+
+```rust
+let effective_delay = if ep_cfg.is_fast { 0 } else { delivery_delay_ms };
+```
+
+- Normal endpoints read S3 **120 s behind live** (`delivery.delivery_delay_secs = 120`)
+  — a 2-minute buffer that absorbs any upload hiccup.
+- The fast endpoint reads at **delay 0 = the live edge** and re-pins to the
+  newest chunk. **Zero buffer.**
+
+S3 upload from the local machine has a long latency tail. Measured on the same
+S3 bucket (`restreamer-chunks`, nbg1), same event window:
+
+| capture→S3 lag | stream.lan | streampp |
+|---|---|---|
+| average | 0.5 s | 1.3 s |
+| **max** | **2.2 s** | **90.8 s** |
+| chunks > 5 s | 0 | 106 |
+| chunks > 20 s | 0 | 7 |
+| disk used | 63.6 % | **82.8 %** |
+
+Identical S3 backend, wildly different tails. **S3 / the Hetzner region move is
+fine** (stream.lan proves it). streampp's 90 s spikes track its near-full disk
+(82.8 %) plus per-minute cache eviction churning local I/O.
+
+The failure chain (each link confirmed in code + production logs):
+
+1. Fast endpoint pins to the live edge (0 buffer).
+2. A local upload spike (up to 90 s) leaves the next live-edge chunk not yet in S3.
+3. VPS producer logs `Producer: no chunks found in probe range`
+   (8× in today's `delivery-logs/1780828999-evt16-inst19.log`).
+   `delivery_endpoint_status` for the fast endpoint shows `current_chunk_id=1410`
+   vs `chunks_processed=1328` → 82 chunks never delivered.
+4. Fast endpoints **skip rescue by design** (`crates/rs-delivery/src/rescue.rs`),
+   so the RTMP push goes **idle** (bytes/sec → 0).
+5. YouTube resets the idle connection:
+   `endpoint_rtmp_push_died … "upstream closed connection mid-stream: connection reset"`,
+   `chunks_pushed=30 time_since_connect_ms=84990` (≈0.35× realtime — starved).
+6. Reconnect → re-pin to live edge → starve again → loop. Worst case:
+   `delivery_restart_log` shows 39 restarts, every one `lifetime_secs=0`, 15 s apart.
+
+Normal endpoints were healthy throughout (single mid-stream reset after ~1 h, or
+steady 1× pacing in the VPS log). The fast path is the only fragile one, and it
+failed exactly as designed under upload jitter. It shipped CI-green because no
+test simulates upload jitter against a fast endpoint.
+
+## Design principles (operator directive)
+
+1. **Starvation must NEVER crash or end the fast stream.** A missing chunk is a
+   wait, never a fatal error. The RTMP connection is torn down only on a real
+   socket error — never because the producer is behind.
+2. **Restreamer self-tunes the delay to a working value.** The fast endpoint's
+   delay grows when starving and shrinks when healthy — chasing the lowest
+   *working* latency automatically, not a hand-set constant.
+3. **The viewer sees buffering-then-resume, like an OBS freeze** — never a dead
+   stream. (Freeze last frame, then rescue loop for long gaps.)
+4. **Push is always strictly 1×.** Recovery is never via speed-up/burst
+   (corrupts quality; YouTube/FB kill sped-up streams). Grow = hold and let the
+   buffer rebuild; shrink = an occasional controlled keyframe skip.
+
+## Architecture
+
+All new behaviour lives on the VPS delivery side (`crates/rs-delivery`), where
+the producer sees chunk misses and the consumer controls the RTMP push. The
+one-time live-edge jump in `rs-api` (`delivery_live_edge.rs`) is subsumed by the
+adaptive controller's initial state. State is per-endpoint, in-memory on the VPS.
+
+### Component 1 — Adaptive delay controller (`fast_delay.rs`, new)
+
+Per fast endpoint, the producer keeps a dynamic `target_delay_chunks`.
+
+- **Init:** floor (`FAST_DELAY_FLOOR_SECS`, default 5 s).
+- **Grow (on starvation):** when the producer cannot supply the next chunk and
+  the consumer buffer is at/near empty, raise the target to
+  `max(target, observed_deficit + FAST_DELAY_MARGIN_SECS)`, capped at
+  `FAST_DELAY_CEILING_SECS` (default 120 s = same safety as the normal stream).
+  `observed_deficit` = (newest chunk available in S3) − (chunk we needed),
+  expressed in seconds. The read position does not move; the consumer holds
+  (keepalive) until the buffer has rebuilt to `target_delay`, then resumes at 1×.
+  Net effect: the steady-state read position is now `target_delay` behind live.
+- **Shrink (on sustained health):** after `FAST_HEALTHY_SHRINK_SECS` (default
+  180 s) with zero misses, lower the target by one step
+  (`FAST_DELAY_SHRINK_STEP_SECS`, default 5 s) toward the floor, executed as a
+  single controlled skip-ahead at the next keyframe (drop a few chunks; one
+  small, infrequent glitch — acceptable for a low-latency stream). Never by
+  speeding up the push.
+- Emits audit events (with values): `fast_delay_grown`, `fast_delay_shrank`,
+  carrying `from_secs`, `to_secs`, `observed_deficit_secs`.
+
+The controller is pure logic over (current buffer, newest-available chunk,
+miss history) and is unit-testable in isolation.
+
+### Component 2 — Never-crash keepalive (extend `rescue.rs` / consumer)
+
+When the consumer buffer empties and the producer is behind (starvation), the
+consumer enters **keepalive** instead of going idle or returning a terminal
+error:
+
+- **Freeze last frame:** cache the last AVC sequence header + last IDR keyframe
+  (GOP) seen on the wire; re-emit it with advancing timestamps + silent AAC,
+  reusing the existing rust pusher timestamp-continuity machinery
+  (`rust_rescue_push`). Glass looks frozen, exactly like an OBS hiccup.
+- **Long-gap fallback:** if the gap exceeds `FAST_KEEPALIVE_RESCUE_AFTER_SECS`
+  (default 10 s), switch to the existing rescue loop FLV (fast endpoints are
+  enabled for rescue as the long-gap fallback; they currently skip it).
+- **Resume:** when the buffer has rebuilt to `target_delay`, resume real chunks
+  seamlessly via `FlvStreamNormalizer::new()` (the existing reset path that
+  guarantees monotonic timestamps across a rescue→live transition).
+- **Connection lifecycle:** starvation NEVER closes the RTMP connection. Only a
+  genuine socket error triggers reconnect (existing backoff). On reconnect, the
+  endpoint re-enters keepalive if still starved — it can never enter a
+  starvation-driven death loop.
+- Emits `fast_keepalive_started` / `fast_keepalive_ended` with `mode`
+  (`freeze` | `rescue`) and `gap_secs`.
+
+### Component 3 — Reduce local jitter (`rs-endpoint` uploader / `rs-core` disk)
+
+Secondary mitigation — shrink the jitter source so the controller rarely has to
+grow:
+
+- **Tighter local cache retention:** lower the local chunk-cache cap so the disk
+  stays well below the pressure threshold, reducing the per-minute eviction
+  churn that fattens the upload-latency tail. (Exact cap decided in the plan
+  against current retention code.)
+- **Quiet the disk-pressure log spam:** `local_disk_pressure` currently logs
+  every 60 s (565 rows). Change to log only on **level transitions**
+  (ok→warn→critical), per the comprehensive-logging "log state transitions"
+  rule — keeps the signal, drops the noise.
+- **Ops note (not code):** streampp's disk is 82.8 % full. Freeing disk space is
+  an operator action (no automatic remote deletion without approval).
+
+### Component 4 — Regression test (`rs-delivery` integration + unit)
+
+The CI gap that let this ship green. Add:
+
+- **Unit:** `fast_delay` controller grow/shrink law — given a miss with deficit
+  D, target grows to D + margin (capped); after a healthy window, shrinks one
+  step; never below floor, never above ceiling.
+- **Integration:** a `ChunkFetcher` mock that injects a 30–90 s availability gap
+  for a fast endpoint. Assert: (a) the pusher never returns a terminal error /
+  the connection is never closed by starvation; (b) keepalive frames are emitted
+  during the gap (freeze, then rescue after 10 s); (c) on chunk availability the
+  stream resumes with monotonic timestamps; (d) `target_delay` grew during the
+  gap and shrinks back after the healthy window.
+
+## Data flow
+
+```
+OBS ─RTMP→ local inpoint ─chunk→ local disk ─uploader→ S3
+                                                 │  (latency tail: 0.5–90 s)
+                                                 ▼
+VPS producer: fetch chunk_id from S3
+   ├─ present → push to buffer; health++; maybe shrink target
+   └─ missing → grow target; signal consumer
+VPS consumer: pull from buffer ─1×→ rust pusher ─RTMP→ YouTube
+   └─ buffer empty + producer behind → KEEPALIVE (freeze→rescue), connection held
+                                       resume when buffer ≥ target_delay
+```
+
+## Error handling
+
+- Missing chunk → grow + keepalive. Never fatal.
+- Real socket error → existing reconnect/backoff; re-enter keepalive if starved.
+- Rescue asset unavailable → fall back to freeze-frame (already in hand).
+- Controller target is clamped to `[floor, ceiling]`; ceiling = normal-stream
+  safety, so the worst case degrades to "as safe as the main stream," never dies.
+
+## Constants (defaults — tunable in the plan)
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `FAST_DELAY_FLOOR_SECS` | 5 | Lowest fast-stream latency when healthy |
+| `FAST_DELAY_CEILING_SECS` | 120 | Max delay (= normal stream) |
+| `FAST_DELAY_MARGIN_SECS` | 5 | Headroom added above observed deficit on grow |
+| `FAST_DELAY_SHRINK_STEP_SECS` | 5 | Step size when shrinking |
+| `FAST_HEALTHY_SHRINK_SECS` | 180 | Healthy window before a shrink step |
+| `FAST_KEEPALIVE_RESCUE_AFTER_SECS` | 10 | Freeze→rescue switch threshold |
+
+## Out of scope
+
+- Changing normal-endpoint behaviour (120 s buffer stays).
+- Speed-up/burst recovery (banned — push is always 1×).
+- Automatic remote disk deletion (operator action).
+
+## Verification
+
+- CI: new unit + integration tests above (deterministic, no real VPS).
+- Post-merge soak on streampp: a full event with the fast endpoint enabled,
+  asserting zero `endpoint_rtmp_push_died` from starvation, visible
+  grow/shrink audit events, and a continuous stream through an induced disk-busy
+  spike. "Working" = sustained soak, 0 deaths, 0 crashes (per project DoD).

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.22.4"
+version = "0.22.5"
 edition = "2024"
 license = "MIT"
 

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.22.5"
+version = "0.22.6"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.22.4"
+version = "0.22.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.22.5"
+version = "0.22.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why

On the last two PP-live events the **fast stream (`KS-PP-TEST`, the only `is_fast` endpoint)** restart-looped and the operator had to abandon restreamer and push OBS direct. Root-caused from streampp production data (`docs/superpowers/specs/2026-06-07-fast-stream-self-healing-design.md`):

- The fast endpoint read at the **live edge (delay 0)** with zero buffer.
- streampp local S3-upload lag spikes to **90s** (vs 2.2s on stream.lan, **same S3 bucket** — so it's local, not Hetzner; the region move held). Tracks streampp's 82.8%-full disk + per-minute eviction churn.
- Missing live-edge chunk → producer "no chunks found in probe range" → push idles → YouTube `connection reset` → restart → re-pin to edge → starve again → loop.
- Fast endpoints skip rescue, and the lag-probe kept yanking the read pointer back to the edge, so it could never build a buffer.

## What changed (fast endpoint only — normal YT/FB streams byte-for-byte unchanged)

1. **Adaptive read-delay controller** (`fast_delay.rs`) — grows the read-delay on starvation (so the lag-probe leaves a buffer instead of pinning to the edge), shrinks it back toward a 5s floor when healthy. Always 1× push — only moves the read pointer, never the push rate. Ceiling 120s (worst case = as safe as the main stream, never dies).
2. **Never-crash keepalive** (`fast_keepalive.rs` + `keepalive_until_chunk`) — on a gap, holds the **existing** RTMP session alive by re-pushing the last chunk (freeze), then the default rescue loop after 10s. Starvation never tears down the connection; YouTube shows buffering then resumes. Connection only reconnects on a real socket error.
3. **New audit events** — `fast_delay_grown/shrank`, `fast_keepalive_started/ended`; keepalive now reflected in dashboard `delivery_mode`.
4. **Disk-pressure logging** now emits only on level transitions (was 203 near-identical rows in one event).
5. **Regression gate** — deterministic test proving a fast endpoint survives an injected upload gap without ever closing the connection (freeze→rescue→resume), RED→GREEN verified.

## Tests / gates (local, Tier-2)
- `cargo test -p rs-delivery`: 255 pass · rs-core audit: 27 · rs-endpoint: green
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace`, `cargo test --no-run --workspace`: all clean
- File-size 1000-line cap satisfied (producer + tests extracted to own modules)

## Still owed before "done" (not in this PR)
Post-merge soak on streampp with the fast endpoint enabled: assert zero starvation-driven `endpoint_rtmp_push_died`, visible `fast_delay_grown`/`fast_keepalive_*` during an induced disk-busy spike, continuous stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)