### PR TITLE
Fix #2 for fast-stream failures: delivery-binary version lockstep + trickle-grow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,17 @@ jobs:
             --endpoint-url https://fsn1.your-objectstorage.com \
             --region fsn1 \
             --acl public-read
+          # Version sidecar for the binary-lockstep pre-create check
+          # (2026-06-10 incident). The orchestrator reads this to decide
+          # whether the bucket binary is current before creating a VPS.
+          VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+          echo -n "$VERSION" > rs-delivery.version
+          aws s3 cp rs-delivery.version \
+            s3://restreamer-chunks-fsn1/rs-delivery.version \
+            --endpoint-url https://fsn1.your-objectstorage.com \
+            --region fsn1 \
+            --acl public-read \
+            --content-type text/plain
 
   file-size:
     name: File size check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,8 +223,6 @@ Operational guides for common tasks:
 
 ## Local Build Policy
 
-<!-- airuleset:local-builds=fast-iterate -->
-
-**Fast-iterate mode (Tier 2) ENABLED.** Iterate locally; push to CI only when the feature works end-to-end.
-Reason: PR #194 had 9 CI roundtrips for compile/lint/test errors that `cargo check --workspace` + `cargo clippy --workspace -- -D warnings` would have caught in seconds. Cold-compile CI is 20+ min per cycle; local check is ~90s cold / ~15s warm.
-Activated: 2026-05-12. Revert with `/fast-iterate off` once #194 ships and dev is stable for ≥1 day.
+Tier 0 (default): NO local builds or test runs — dev1 has 7.5 GB RAM and rustc
+workspace builds OOM it (operator directive 2026-06-10). Lint/fmt only locally;
+compilation, clippy, and tests run on CI. Purge `target/` whenever found.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.22.6"
+version = "0.22.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-api/src/delivery.rs
+++ b/crates/rs-api/src/delivery.rs
@@ -326,6 +326,16 @@ impl DeliveryOrchestrator {
             self.config.s3.endpoint, self.config.s3.bucket,
         );
 
+        // Binary lockstep (2026-06-10 incident): never create a VPS that would
+        // download a stale rs-delivery. FAILS LOUDLY on unfixable drift.
+        crate::delivery_binary::ensure_bucket_binary_or_abort(
+            &self.config,
+            self.audit_tx.as_ref(),
+            event_id,
+            &binary_url,
+        )
+        .await?;
+
         let mut labels = HashMap::new();
         labels.insert("app".to_string(), "restreamer".to_string());
         labels.insert("event_id".to_string(), event_id.to_string());
@@ -512,9 +522,34 @@ impl DeliveryOrchestrator {
                         attempt,
                         "rs-delivery health check passed on {}", instance.ipv4
                     );
-                    // rs-delivery is healthy. Move to "initializing" phase
-                    // while we wait for buffer-fill and call /api/init —
-                    // operator can see this is normal startup, not a hang.
+
+                    // Post-boot version gate (2026-06-10 incident): parse the
+                    // health body BEFORE auditing VpsReady. `resp.json()` /
+                    // `resp.text()` consumes resp, so this must run in-arm.
+                    let body = resp.text().await.unwrap_or_default();
+                    let vps_version = crate::delivery_binary::parse_health_version(&body);
+                    let client_version = env!("CARGO_PKG_VERSION");
+                    if !crate::delivery_binary::versions_match(
+                        vps_version.as_deref(),
+                        client_version,
+                    ) {
+                        return Err(crate::delivery_binary::abort_on_version_mismatch(
+                            &self.hetzner,
+                            &self.pool,
+                            self.audit_tx.as_ref(),
+                            event_id,
+                            instance_id,
+                            hetzner_id,
+                            vps_version.as_deref(),
+                            client_version,
+                        )
+                        .await);
+                    }
+
+                    // rs-delivery is healthy AND version-matched. Move to
+                    // "initializing" phase while we wait for buffer-fill and
+                    // call /api/init — operator can see this is normal startup,
+                    // not a hang.
                     db::update_delivery_instance_status(&self.pool, instance_id, "initializing")
                         .await?;
                     // Audit: VPS booted + rs-delivery answered health check.
@@ -532,6 +567,7 @@ impl DeliveryOrchestrator {
                                     "hetzner_id": hetzner_id,
                                     "ipv4": instance.ipv4,
                                     "boot_secs": boot_start.elapsed().as_secs(),
+                                    "delivery_version": vps_version,
                                 }),
                                 ts_override: None,
                             },

--- a/crates/rs-api/src/delivery_binary.rs
+++ b/crates/rs-api/src/delivery_binary.rs
@@ -1,0 +1,582 @@
+//! Delivery binary version lockstep (2026-06-10 incident).
+//!
+//! The delivery VPS downloads its `rs-delivery` binary from the CLIENT'S OWN
+//! S3 bucket (`{s3.endpoint}/{s3.bucket}/rs-delivery`). CI only refreshes one
+//! client's bucket, so a production client whose bucket was never updated can
+//! silently boot a stale binary and stream a broken event — exactly what
+//! happened on streampp (a 12-day-old rs-delivery ran during a live event and
+//! nothing detected the drift).
+//!
+//! This module enforces lockstep at two points:
+//!
+//! 1. **Pre-create** ([`ensure_bucket_binary`]): a cheap sidecar version check
+//!    before every VPS create. On drift it downloads the matching GitHub
+//!    release asset for the client's OWN version, sha256-verifies it, and
+//!    uploads binary + sidecar with public-read ACL so cloud-init fetches the
+//!    correct bytes. Hard error (abort delivery) when no matching release
+//!    exists — a loud failure at start beats a silent broken event.
+//! 2. **Post-boot** ([`versions_match`]): the orchestrator parses the VPS
+//!    `/api/health` `version` field and aborts (delete VPS + Critical audit)
+//!    when it differs from the client version.
+//!
+//! Pure decision logic ([`decide_binary_action`], [`versions_match`],
+//! [`parse_sha256_file`]) is separated from the async I/O so it is unit-tested
+//! without network access.
+
+use std::time::Duration;
+
+use anyhow::{Context, anyhow};
+use rs_cloud::hetzner::HetznerClient;
+use rs_core::audit::{Action, AuditRow, Severity, Source};
+use rs_core::db;
+use sha2::{Digest, Sha256};
+use sqlx::SqlitePool;
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+
+/// GitHub repo that hosts the `rs-delivery` release assets.
+const RELEASE_BASE: &str =
+    "https://github.com/zbynekdrlik/restreamer/releases/download/restreamer-v";
+/// S3 object key for the rs-delivery binary the VPS cloud-init downloads.
+const BINARY_KEY: &str = "rs-delivery";
+/// S3 object key for the plain-text sidecar carrying the binary's version.
+const SIDECAR_KEY: &str = "rs-delivery.version";
+
+/// What to do about the bucket's rs-delivery binary before creating a VPS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinaryAction {
+    /// Sidecar matches the client version — bucket binary is current.
+    Proceed,
+    /// Sidecar missing or different — fetch the client-version release
+    /// asset and upload it (then proceed).
+    Ensure,
+}
+
+/// Decide, from the sidecar contents and the client's own version, whether the
+/// bucket binary is already current ([`BinaryAction::Proceed`]) or must be
+/// re-uploaded ([`BinaryAction::Ensure`]).
+///
+/// A missing sidecar (`None`) or any non-matching value forces `Ensure`.
+/// Trailing whitespace/newlines in the sidecar are tolerated.
+pub fn decide_binary_action(sidecar: Option<&str>, client_version: &str) -> BinaryAction {
+    match sidecar {
+        Some(s) if s.trim() == client_version => BinaryAction::Proceed,
+        _ => BinaryAction::Ensure,
+    }
+}
+
+/// Post-boot gate: does the VPS-reported version match the client's?
+///
+/// `None` (old binary with no `version` field in `/api/health`) is a mismatch
+/// by design — the gate must abort rather than assume.
+pub fn versions_match(vps_version: Option<&str>, client_version: &str) -> bool {
+    matches!(vps_version, Some(v) if v == client_version)
+}
+
+/// Extract the optional `version` field from an rs-delivery `/api/health`
+/// JSON body. Old binaries that predate the field deserialize to `None`
+/// (mismatch by design). Malformed JSON also yields `None`.
+pub fn parse_health_version(body: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct HealthBody {
+        #[serde(default)]
+        version: Option<String>,
+    }
+    serde_json::from_str::<HealthBody>(body)
+        .ok()
+        .and_then(|h| h.version)
+}
+
+/// Parse a `sha256sum`-format file (`<hex sha256>  <filename>`) into the
+/// lowercased hex digest. Returns `None` if the first token is not exactly
+/// 64 hex characters.
+pub fn parse_sha256_file(content: &str) -> Option<String> {
+    let token = content.split_whitespace().next()?;
+    if token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(token.to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+/// Compute the lowercase hex sha256 of `bytes`.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode(&hasher.finalize())
+}
+
+/// Lowercase hex encoding (avoids pulling a `hex` crate dep).
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Ensure the client bucket's rs-delivery binary matches `client_version`.
+///
+/// Cheap when current (one anonymous GET of the sidecar). On mismatch,
+/// downloads the GitHub release asset for the client's OWN version, verifies
+/// sha256, uploads binary + sidecar with public-read ACL.
+///
+/// Returns `Ok(Some(sha256))` if an upload happened (the verified digest of
+/// the uploaded binary), `Ok(None)` if the bucket was already current.
+/// `Err` means delivery start MUST abort — the caller surfaces and audits.
+pub async fn ensure_bucket_binary(
+    config: &rs_core::config::Config,
+    client_version: &str,
+) -> anyhow::Result<Option<String>> {
+    let sidecar = fetch_sidecar(config).await;
+    match decide_binary_action(sidecar.as_deref(), client_version) {
+        BinaryAction::Proceed => {
+            info!(
+                version = client_version,
+                "delivery binary lockstep: bucket sidecar current, proceeding"
+            );
+            Ok(None)
+        }
+        BinaryAction::Ensure => {
+            warn!(
+                client_version,
+                sidecar = ?sidecar,
+                "delivery binary lockstep: bucket binary stale/unknown, re-uploading from release"
+            );
+            let sha = upload_release_binary(config, client_version).await?;
+            Ok(Some(sha))
+        }
+    }
+}
+
+/// Anonymous GET of `{endpoint}/{bucket}/rs-delivery.version`. Any error or
+/// non-200 is treated as "no sidecar" (`None`) which forces an Ensure.
+async fn fetch_sidecar(config: &rs_core::config::Config) -> Option<String> {
+    let url = format!(
+        "{}/{}/{}",
+        config.s3.endpoint, config.s3.bucket, SIDECAR_KEY
+    );
+    let client = reqwest::Client::new();
+    match client
+        .get(&url)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => match resp.text().await {
+            Ok(body) => Some(body),
+            Err(e) => {
+                warn!(%url, "sidecar body read failed (treating as missing): {e}");
+                None
+            }
+        },
+        Ok(resp) => {
+            info!(%url, status = %resp.status(), "sidecar not present (treating as missing)");
+            None
+        }
+        Err(e) => {
+            warn!(%url, "sidecar GET failed (treating as missing): {e}");
+            None
+        }
+    }
+}
+
+/// Download the release asset for `client_version`, sha256-verify it against
+/// the `.sha256` sidecar, and upload binary + version sidecar to the client
+/// bucket with public-read ACL. Returns the verified sha256.
+async fn upload_release_binary(
+    config: &rs_core::config::Config,
+    client_version: &str,
+) -> anyhow::Result<String> {
+    let asset = format!("rs-delivery-{client_version}-linux-amd64");
+    let bin_url = format!("{RELEASE_BASE}{client_version}/{asset}");
+    let sha_url = format!("{bin_url}.sha256");
+    let client = reqwest::Client::new();
+
+    // Binary
+    let bin_resp = client
+        .get(&bin_url)
+        .timeout(Duration::from_secs(60))
+        .send()
+        .await
+        .with_context(|| format!("GET release asset {bin_url}"))?;
+    if bin_resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(anyhow!(
+            "no release asset for v{client_version} and bucket binary is stale/unknown \
+             — cannot guarantee VPS binary version"
+        ));
+    }
+    if !bin_resp.status().is_success() {
+        return Err(anyhow!(
+            "release asset {bin_url} returned {}",
+            bin_resp.status()
+        ));
+    }
+    let bin_bytes = bin_resp
+        .bytes()
+        .await
+        .with_context(|| format!("read release asset body {bin_url}"))?;
+    info!(
+        version = client_version,
+        bytes = bin_bytes.len(),
+        "delivery binary lockstep: downloaded release asset"
+    );
+
+    // Expected sha256
+    let sha_resp = client
+        .get(&sha_url)
+        .timeout(Duration::from_secs(60))
+        .send()
+        .await
+        .with_context(|| format!("GET release sha256 {sha_url}"))?;
+    if !sha_resp.status().is_success() {
+        return Err(anyhow!(
+            "release sha256 {sha_url} returned {}",
+            sha_resp.status()
+        ));
+    }
+    let sha_body = sha_resp
+        .text()
+        .await
+        .with_context(|| format!("read sha256 body {sha_url}"))?;
+    let expected = parse_sha256_file(&sha_body)
+        .ok_or_else(|| anyhow!("unparseable sha256 file for v{client_version}: {sha_body:?}"))?;
+
+    // Verify
+    let actual = sha256_hex(&bin_bytes);
+    if actual != expected {
+        return Err(anyhow!(
+            "sha256 mismatch for v{client_version}: expected {expected}, got {actual} \
+             — refusing to upload an unverified binary"
+        ));
+    }
+    info!(
+        version = client_version,
+        sha256 = %actual,
+        "delivery binary lockstep: sha256 verified"
+    );
+
+    // Upload binary + sidecar (public-read so cloud-init fetches anonymously).
+    let s3 = rs_endpoint::s3::S3Client::new(&config.s3)
+        .map_err(|e| anyhow!("S3Client::new for binary upload: {e}"))?;
+    s3.upload_public_object(BINARY_KEY, &bin_bytes, "application/octet-stream")
+        .await
+        .map_err(|e| anyhow!("upload rs-delivery binary: {e}"))?;
+    s3.upload_public_object(SIDECAR_KEY, client_version.as_bytes(), "text/plain")
+        .await
+        .map_err(|e| anyhow!("upload rs-delivery.version sidecar: {e}"))?;
+    info!(
+        version = client_version,
+        sha256 = %actual,
+        "delivery binary lockstep: uploaded binary + sidecar (public-read)"
+    );
+
+    Ok(actual)
+}
+
+/// Pre-create lockstep (2026-06-10 incident): ensure the client bucket's
+/// rs-delivery binary matches the client version before a VPS is created.
+/// Cheap sidecar check; uploads the matching release asset on drift; hard
+/// error (audit Critical + abort) when impossible (no release asset / sha
+/// mismatch / upload failure) so the event start fails loudly instead of
+/// silently streaming a wrong-version binary.
+pub async fn ensure_bucket_binary_or_abort(
+    config: &rs_core::config::Config,
+    audit_tx: Option<&mpsc::Sender<AuditRow>>,
+    event_id: i64,
+    binary_url: &str,
+) -> anyhow::Result<()> {
+    let client_version = env!("CARGO_PKG_VERSION");
+    match ensure_bucket_binary(config, client_version).await {
+        Ok(Some(sha256)) => {
+            if let Some(tx) = audit_tx {
+                rs_core::audit::record(tx, ensured_audit(event_id, client_version, &sha256));
+            }
+            Ok(())
+        }
+        Ok(None) => Ok(()),
+        Err(e) => {
+            if let Some(tx) = audit_tx {
+                rs_core::audit::record(
+                    tx,
+                    pre_create_mismatch_audit(event_id, client_version, binary_url, &e.to_string()),
+                );
+            }
+            Err(e)
+        }
+    }
+}
+
+/// Post-boot lockstep abort (2026-06-10 incident): the booted VPS reported a
+/// different rs-delivery version than the client. Audit Critical, delete the
+/// VPS (cause fully known — no post-mortem value), mark the instance failed,
+/// and return a loud error so delivery start fails visibly instead of
+/// silently streaming a wrong-version binary.
+#[allow(clippy::too_many_arguments)]
+pub async fn abort_on_version_mismatch(
+    hetzner: &HetznerClient,
+    pool: &SqlitePool,
+    audit_tx: Option<&mpsc::Sender<AuditRow>>,
+    event_id: i64,
+    instance_id: i64,
+    hetzner_id: i64,
+    vps_version: Option<&str>,
+    client_version: &str,
+) -> anyhow::Error {
+    warn!(
+        hetzner_id,
+        instance_id,
+        ?vps_version,
+        client_version,
+        "rs-delivery VERSION MISMATCH — aborting delivery, deleting VPS"
+    );
+    if let Some(tx) = audit_tx {
+        rs_core::audit::record(
+            tx,
+            post_boot_mismatch_audit(event_id, instance_id, vps_version, client_version),
+        );
+    }
+    if let Err(e) = hetzner.delete_server(hetzner_id).await {
+        error!(hetzner_id, "version-mismatch VPS delete failed: {e}");
+    }
+    if let Err(e) = db::update_delivery_instance_status(pool, instance_id, "failed").await {
+        error!(instance_id, "version-mismatch status update failed: {e}");
+    }
+    anyhow!(
+        "rs-delivery version mismatch: VPS reports {vps_version:?}, \
+         client is {client_version} — delivery aborted"
+    )
+}
+
+/// Info audit row: the bucket binary was re-uploaded to match the client
+/// version before VPS creation. Keeps the `start_delivery` call site to one
+/// `record()` line (delivery.rs is at its 1000-line cap).
+pub fn ensured_audit(event_id: i64, version: &str, sha256: &str) -> AuditRow {
+    AuditRow {
+        severity: Severity::Info,
+        source: Source::Delivery,
+        event_id: Some(event_id),
+        instance_id: None,
+        endpoint: None,
+        action: Action::DeliveryBinaryEnsured,
+        detail: serde_json::json!({ "version": version, "sha256": sha256 }),
+        ts_override: None,
+    }
+}
+
+/// Critical audit row for a pre-create lockstep failure (no release asset,
+/// sha mismatch, or upload failure) — the delivery start is aborted before a
+/// VPS is ever created.
+pub fn pre_create_mismatch_audit(
+    event_id: i64,
+    client_version: &str,
+    binary_url: &str,
+    error: &str,
+) -> AuditRow {
+    AuditRow {
+        severity: Severity::Critical,
+        source: Source::Delivery,
+        event_id: Some(event_id),
+        instance_id: None,
+        endpoint: None,
+        action: Action::DeliveryBinaryVersionMismatch,
+        detail: serde_json::json!({
+            "vps_version": serde_json::Value::Null,
+            "client_version": client_version,
+            "binary_url": binary_url,
+            "phase": "pre_create",
+            "error": error,
+        }),
+        ts_override: None,
+    }
+}
+
+/// Critical audit row for a post-boot lockstep failure: the booted VPS
+/// reported a different rs-delivery version than the client.
+pub fn post_boot_mismatch_audit(
+    event_id: i64,
+    instance_id: i64,
+    vps_version: Option<&str>,
+    client_version: &str,
+) -> AuditRow {
+    AuditRow {
+        severity: Severity::Critical,
+        source: Source::Delivery,
+        event_id: Some(event_id),
+        instance_id: Some(instance_id),
+        endpoint: None,
+        action: Action::DeliveryBinaryVersionMismatch,
+        detail: serde_json::json!({
+            "vps_version": vps_version,
+            "client_version": client_version,
+            "phase": "post_boot",
+        }),
+        ts_override: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decide_proceed_on_exact_match() {
+        assert_eq!(
+            decide_binary_action(Some("0.22.7"), "0.22.7"),
+            BinaryAction::Proceed
+        );
+    }
+
+    #[test]
+    fn decide_proceed_tolerates_trailing_newline() {
+        assert_eq!(
+            decide_binary_action(Some("0.22.7\n"), "0.22.7"),
+            BinaryAction::Proceed
+        );
+        assert_eq!(
+            decide_binary_action(Some("  0.22.7  \n"), "0.22.7"),
+            BinaryAction::Proceed
+        );
+    }
+
+    #[test]
+    fn decide_ensure_on_missing_sidecar() {
+        assert_eq!(decide_binary_action(None, "0.22.7"), BinaryAction::Ensure);
+    }
+
+    #[test]
+    fn decide_ensure_on_mismatch() {
+        assert_eq!(
+            decide_binary_action(Some("0.22.6"), "0.22.7"),
+            BinaryAction::Ensure
+        );
+        assert_eq!(
+            decide_binary_action(Some(""), "0.22.7"),
+            BinaryAction::Ensure
+        );
+    }
+
+    #[test]
+    fn versions_match_none_is_mismatch() {
+        assert!(!versions_match(None, "0.22.7"));
+    }
+
+    #[test]
+    fn versions_match_empty_is_mismatch() {
+        assert!(!versions_match(Some(""), "0.22.7"));
+    }
+
+    #[test]
+    fn versions_match_wrong_is_mismatch() {
+        assert!(!versions_match(Some("0.22.6"), "0.22.7"));
+    }
+
+    #[test]
+    fn versions_match_exact_is_match() {
+        assert!(versions_match(Some("0.22.7"), "0.22.7"));
+    }
+
+    #[test]
+    fn parse_health_version_extracts_field() {
+        assert_eq!(
+            parse_health_version(r#"{"status":"ok","version":"0.22.7"}"#).as_deref(),
+            Some("0.22.7")
+        );
+    }
+
+    #[test]
+    fn parse_health_version_missing_field_is_none() {
+        // Old binary: no version field.
+        assert_eq!(parse_health_version(r#"{"status":"ok"}"#), None);
+    }
+
+    #[test]
+    fn parse_health_version_garbage_is_none() {
+        assert_eq!(parse_health_version("not json"), None);
+        assert_eq!(parse_health_version(""), None);
+    }
+
+    #[test]
+    fn parse_sha256_valid() {
+        let line = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789  rs-delivery-0.22.7-linux-amd64";
+        assert_eq!(
+            parse_sha256_file(line).as_deref(),
+            Some("abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+        );
+    }
+
+    #[test]
+    fn parse_sha256_uppercase_is_lowercased() {
+        // 64 uppercase hex chars (16 * "ABCD").
+        let line = "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD  file";
+        assert_eq!(line.split_whitespace().next().unwrap().len(), 64);
+        assert_eq!(
+            parse_sha256_file(line).as_deref(),
+            Some("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd")
+        );
+    }
+
+    #[test]
+    fn parse_sha256_rejects_short() {
+        assert_eq!(parse_sha256_file("deadbeef  file"), None);
+    }
+
+    #[test]
+    fn parse_sha256_rejects_garbage() {
+        assert_eq!(parse_sha256_file("not a hash"), None);
+        assert_eq!(parse_sha256_file(""), None);
+        // 64 chars but with a non-hex char.
+        let bad = "g123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0  file";
+        assert_eq!(parse_sha256_file(bad), None);
+    }
+
+    #[test]
+    fn sha256_hex_known_vector() {
+        // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        // sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn ensured_audit_shape() {
+        let row = ensured_audit(7, "0.22.7", "deadbeef");
+        assert_eq!(row.severity, Severity::Info);
+        assert_eq!(row.source, Source::Delivery);
+        assert_eq!(row.action, Action::DeliveryBinaryEnsured);
+        assert_eq!(row.event_id, Some(7));
+        assert_eq!(row.detail["version"], "0.22.7");
+        assert_eq!(row.detail["sha256"], "deadbeef");
+    }
+
+    #[test]
+    fn pre_create_mismatch_audit_shape() {
+        let row = pre_create_mismatch_audit(7, "0.22.7", "https://s3/x/rs-delivery", "boom");
+        assert_eq!(row.severity, Severity::Critical);
+        assert_eq!(row.action, Action::DeliveryBinaryVersionMismatch);
+        assert_eq!(row.detail["vps_version"], serde_json::Value::Null);
+        assert_eq!(row.detail["client_version"], "0.22.7");
+        assert_eq!(row.detail["phase"], "pre_create");
+        assert_eq!(row.detail["error"], "boom");
+    }
+
+    #[test]
+    fn post_boot_mismatch_audit_shape() {
+        let row = post_boot_mismatch_audit(7, 20, Some("0.22.6"), "0.22.7");
+        assert_eq!(row.severity, Severity::Critical);
+        assert_eq!(row.action, Action::DeliveryBinaryVersionMismatch);
+        assert_eq!(row.instance_id, Some(20));
+        assert_eq!(row.detail["vps_version"], "0.22.6");
+        assert_eq!(row.detail["client_version"], "0.22.7");
+        assert_eq!(row.detail["phase"], "post_boot");
+        // None vps_version must serialize to JSON null.
+        let none_row = post_boot_mismatch_audit(7, 20, None, "0.22.7");
+        assert_eq!(none_row.detail["vps_version"], serde_json::Value::Null);
+    }
+}

--- a/crates/rs-api/src/lib.rs
+++ b/crates/rs-api/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audit_handlers;
 pub mod clock_skew_probe;
 pub mod delivery;
 pub(crate) mod delivery_audit_mirror;
+pub mod delivery_binary;
 pub mod delivery_endpoints;
 pub mod delivery_handlers;
 pub(crate) mod delivery_helpers;

--- a/crates/rs-core/src/audit.rs
+++ b/crates/rs-core/src/audit.rs
@@ -174,6 +174,16 @@ pub enum Action {
     /// Operator successfully completed an OAuth 2.0 Device Code Flow grant
     /// for a YouTube channel. Detail JSON: `{label, channel_id, scopes}`.
     OAuthGranted,
+
+    /// Host-side: the client's S3 bucket rs-delivery binary did not match the
+    /// client version; the matching GitHub release asset was downloaded,
+    /// sha256-verified and uploaded (public-read) before VPS creation.
+    /// Detail JSON: {version, sha256}.
+    DeliveryBinaryEnsured,
+    /// Host-side CRITICAL: the booted VPS reported a different rs-delivery
+    /// version than the client (or none). Delivery start is aborted and the
+    /// VPS deleted. Detail JSON: {vps_version, client_version, binary_url}.
+    DeliveryBinaryVersionMismatch,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -421,6 +431,22 @@ mod tests {
         let a = Action::FastKeepaliveEnded;
         let s = serde_json::to_string(&a).unwrap();
         assert_eq!(s, "\"fast_keepalive_ended\"");
+        assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+    }
+
+    #[test]
+    fn action_delivery_binary_ensured_serdes() {
+        let a = Action::DeliveryBinaryEnsured;
+        let s = serde_json::to_string(&a).unwrap();
+        assert_eq!(s, "\"delivery_binary_ensured\"");
+        assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
+    }
+
+    #[test]
+    fn action_delivery_binary_version_mismatch_serdes() {
+        let a = Action::DeliveryBinaryVersionMismatch;
+        let s = serde_json::to_string(&a).unwrap();
+        assert_eq!(s, "\"delivery_binary_version_mismatch\"");
         assert_eq!(serde_json::from_str::<Action>(&s).unwrap(), a);
     }
 }

--- a/crates/rs-delivery/src/buffer_state.rs
+++ b/crates/rs-delivery/src/buffer_state.rs
@@ -10,6 +10,10 @@ pub struct BufferState {
     pub buffer_duration_ms: AtomicU64,
     /// Whether the producer is actively finding new chunks (vs stalled).
     pub producer_active: AtomicBool,
+    /// Largest starvation gap (ms) observed by the consumer's keepalive since
+    /// the producer last consumed it. Written with fetch_max on keepalive end,
+    /// swapped to 0 by the producer, which grows the adaptive read-delay by it.
+    pub starvation_gap_ms: AtomicU64,
 }
 
 impl BufferState {
@@ -17,6 +21,7 @@ impl BufferState {
         Self {
             buffer_duration_ms: AtomicU64::new(0),
             producer_active: AtomicBool::new(true),
+            starvation_gap_ms: AtomicU64::new(0),
         }
     }
 }

--- a/crates/rs-delivery/src/endpoint_consumer_helpers.rs
+++ b/crates/rs-delivery/src/endpoint_consumer_helpers.rs
@@ -14,6 +14,24 @@ use super::{
 use crate::audit_ring::AuditRing;
 use crate::{endpoint_audit, ffmpeg_reason};
 
+/// Record the consumer-measured starvation gap into shared `BufferState` so
+/// the producer's adaptive read-delay controller grows by it (trickle-grow
+/// fix). `fetch_max` keeps the largest gap seen since the producer last
+/// consumed it. Returns the elapsed gap so the caller can reuse it for the
+/// keepalive audit without re-reading the clock. Call ONLY on the
+/// chunk-resume path — never the stop path (the endpoint is shutting down).
+pub(super) fn record_starvation_gap(
+    buffer_state: &Arc<crate::buffer_state::BufferState>,
+    started: tokio::time::Instant,
+) -> tokio::time::Duration {
+    let elapsed = started.elapsed();
+    buffer_state.starvation_gap_ms.fetch_max(
+        elapsed.as_millis() as u64,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    elapsed
+}
+
 /// Return value from `handle_rust_push` telling the consumer loop whether
 /// to continue normally or break the loop.
 pub(super) enum RustPushAction {

--- a/crates/rs-delivery/src/endpoint_producer.rs
+++ b/crates/rs-delivery/src/endpoint_producer.rs
@@ -111,6 +111,29 @@ pub(crate) async fn producer_task<F: ChunkFetcher>(
                 // stays strictly 1× — this only moves the READ pointer.
                 let delivery_delay_chunks: i64 = match fast_delay.as_mut() {
                     Some(ctrl) => {
+                        // Consumer-measured starvation gap (keepalive) — the
+                        // trickle-regime grow signal. The probe-cycle grow
+                        // below only fires after ~80s of uninterrupted misses;
+                        // this one fires after ANY real keepalive gap, so the
+                        // first freeze of an event grows the buffer and the
+                        // next spike of that size is absorbed silently.
+                        let gap_ms = buffer_state
+                            .starvation_gap_ms
+                            .swap(0, AtomicOrdering::Relaxed);
+                        if gap_ms > 0 {
+                            let gap_secs = gap_ms.div_ceil(1000);
+                            if let Some((from, to)) =
+                                ctrl.on_starvation(gap_secs, std::time::Instant::now())
+                            {
+                                crate::fast_delay_audit::emit_delay_grown(
+                                    &audit_ring,
+                                    &alias,
+                                    from,
+                                    to,
+                                    gap_secs,
+                                );
+                            }
+                        }
                         if let Some((from, to)) = ctrl.on_healthy(std::time::Instant::now()) {
                             crate::fast_delay_audit::emit_delay_shrank(
                                 &audit_ring,

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -483,6 +483,7 @@ async fn consumer_task<P: OutputProcessFactory>(
                             &audit_ring,
                             &mut stop_rx,
                             &stats,
+                            &buffer_state,
                         )
                         .await
                         {
@@ -794,14 +795,13 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
     audit_ring: &Option<std::sync::Arc<crate::audit_ring::AuditRing>>,
     stop_rx: &mut tokio::sync::watch::Receiver<bool>,
     stats: &Stats,
+    buffer_state: &std::sync::Arc<crate::buffer_state::BufferState>,
 ) -> Option<PrefetchedChunk> {
     use crate::fast_keepalive::{KeepaliveMode, keepalive_bytes, keepalive_mode};
-    // `tokio::time::Instant` (not `std::time::Instant`) so the gap clock tracks
-    // the same time source as the `tokio::time::sleep` pacing in this loop.
-    // In production it reads the real clock identically to `std::Instant`; under
-    // `tokio::time::pause()`/`start_paused` (the Task-6 regression gate) it
-    // advances with `tokio::time::advance`, making the freeze→rescue transition
-    // deterministically testable without real wall-clock waits.
+    // `tokio::time::Instant` (not `std::time::Instant`) so the gap clock shares
+    // the loop's `tokio::time::sleep` time source: identical to the real clock
+    // in prod, but advances under `start_paused` so the freeze→rescue transition
+    // is deterministically testable without wall-clock waits.
     let started = tokio::time::Instant::now();
     let mut current_mode = keepalive_mode(0, last_chunk_bytes.is_some());
     crate::fast_delay_audit::emit_keepalive_started(
@@ -841,9 +841,11 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
         let bytes = keepalive_bytes(mode, last_chunk_bytes);
         tokio::select! {
             maybe = rx.recv() => {
-                crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
-                // Reset delivery_mode before returning so the dashboard
-                // reflects normal delivery as soon as the real chunk resumes.
+                // Trickle-grow: feed the TRUE measured gap to the producer's
+                // adaptive controller (consumed via BufferState on its next fetch).
+                let elapsed = consumer_helpers::record_starvation_gap(buffer_state, started);
+                crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, elapsed.as_secs());
+                // Reset delivery_mode so the dashboard reflects normal delivery.
                 {
                     let mut s = stats.lock().await;
                     s.delivery_mode = "normal".to_string();

--- a/crates/rs-delivery/src/endpoint_task_tests.rs
+++ b/crates/rs-delivery/src/endpoint_task_tests.rs
@@ -790,6 +790,13 @@ pub(crate) struct TimedMockFetcher {
     // observe the producer's READ position without a real consumer. Starts at
     // i64::MIN; updated monotonically. ZERO impact when unread.
     max_fetched_id: Arc<AtomicI64>,
+    // Independent ceiling for HEAD probes (chunk_duration_ms / the lag-probe
+    // ladder). `None` (default) → HEAD uses `available_up_to`, identical to
+    // before. `Some(h)` lets the ladder discover the live edge at `h` while
+    // GET stalls at `available_up_to` — modelling "HEAD sees the edge, GET
+    // trails behind it" so a test can pin the producer's read position to
+    // the lag-probe's jump target without it catching up.
+    head_available_up_to: Option<Arc<AtomicI64>>,
 }
 
 impl TimedMockFetcher {
@@ -800,7 +807,17 @@ impl TimedMockFetcher {
             duration_ms_per_chunk: 2000,
             fetch_latency: std::time::Duration::ZERO,
             max_fetched_id: Arc::new(AtomicI64::new(i64::MIN)),
+            head_available_up_to: None,
         }
+    }
+
+    /// Let HEAD probes (the lag-probe ladder) reach `head_edge` while GET
+    /// fetches still stall at `available_up_to`. Models the producer
+    /// discovering the live edge via HEAD but reading behind it. ZERO impact
+    /// on callers that don't set it (HEAD falls back to `available_up_to`).
+    pub(crate) fn with_head_edge(mut self, head_edge: i64) -> Self {
+        self.head_available_up_to = Some(Arc::new(AtomicI64::new(head_edge)));
+        self
     }
 
     pub(crate) fn with_latency(mut self, d: std::time::Duration) -> Self {
@@ -846,7 +863,11 @@ impl ChunkFetcher for TimedMockFetcher {
         if !self.fetch_latency.is_zero() {
             tokio::time::sleep(self.fetch_latency).await;
         }
-        let available = self.available_up_to.load(Ordering::Relaxed);
+        // HEAD ceiling: the dedicated head edge when set, else GET's edge.
+        let available = match &self.head_available_up_to {
+            Some(h) => h.load(Ordering::Relaxed),
+            None => self.available_up_to.load(Ordering::Relaxed),
+        };
         if chunk_id > available {
             return Ok(None);
         }

--- a/crates/rs-delivery/src/endpoint_task_tests.rs
+++ b/crates/rs-delivery/src/endpoint_task_tests.rs
@@ -808,6 +808,15 @@ impl TimedMockFetcher {
         self
     }
 
+    /// Override the per-chunk media duration the fetcher reports (default
+    /// 2000ms). Lets a test pin `typical_chunk_dur_ms` so chunk-count maths
+    /// against the adaptive read-delay are deterministic. ZERO impact on
+    /// callers that don't use it.
+    pub(crate) fn with_chunk_duration(mut self, ms: i64) -> Self {
+        self.duration_ms_per_chunk = ms;
+        self
+    }
+
     pub(crate) fn available_up_to(&self) -> Arc<AtomicI64> {
         self.available_up_to.clone()
     }

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -197,6 +197,98 @@ async fn test_fast_endpoint_producer_trails_live_edge() {
     drain.abort();
 }
 
+#[tokio::test(start_paused = true)]
+async fn trickle_starvation_grows_fast_read_delay() {
+    // Simulate the consumer having measured a 30s keepalive gap (trickle
+    // starvation: chunks arrive late-but-arrive, so the producer's 40-miss
+    // probe cycle NEVER fires). The producer must consume that gap on its
+    // next successful fetch and GROW the adaptive read-delay by it, so the
+    // live-edge lag-probe target trails the edge by ~gap+margin (35 chunks at
+    // 1000ms chunks) instead of the 5s/5-chunk floor.
+    //
+    // RED without the fix: the producer ignores `starvation_gap_ms`, the
+    // controller stays at the floor, the lag-probe jumps to `edge - 5`, and
+    // the read position sits only ~5 chunks behind the edge → the
+    // `edge - read_pos >= 30` assertion fails. GREEN with the fix: the gap
+    // grows the controller to 35 chunks, the jump trails the edge by 35, and
+    // the read position stays >= 30 chunks behind.
+    //
+    // The edge (20_511) is the exact highest existing rung of the FLOOR-delay
+    // (5-chunk) probe ladder from current=31, so without the fix the jump
+    // lands at edge-5 (clear FAIL of `>= 30`). With the fix the GROWN-delay
+    // (35-chunk) ladder tops out at chunk 17_951 → jump target 17_916 → the
+    // read pointer trails the edge by ~2_595 (clear PASS).
+    let edge: i64 = 20_511;
+    let chunks: Vec<(i64, Vec<u8>)> = (1..=edge).map(|i| (i, vec![0u8; 1])).collect();
+    // 1000ms chunks so `typical_chunk_dur_ms` stays at 1000 (EWMA seed) and
+    // the delay→chunks maths is 1:1 (35s = 35 chunks, 5s = 5 chunks). 5ms
+    // per fetch keeps the producer reading at a bounded rate under paused time.
+    let fetcher = TimedMockFetcher::new(chunks, edge)
+        .with_chunk_duration(1000)
+        .with_latency(std::time::Duration::from_millis(5));
+    let max_fetched = fetcher.max_fetched_id();
+
+    let (tx, mut rx) = mpsc::channel::<PrefetchedChunk>(PREFETCH_BUFFER_SIZE);
+    let (stop_tx, stop_rx) = watch::channel(false);
+    let stats: Stats = Arc::new(Mutex::new(EndpointStats::default()));
+    let buffer_state = Arc::new(BufferState::new());
+
+    // The consumer-side keepalive measured a 30s starvation gap (trickle).
+    buffer_state
+        .starvation_gap_ms
+        .store(30_000, Ordering::Relaxed);
+
+    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let bs = buffer_state.clone();
+    let producer = tokio::spawn(producer_task(
+        fetcher,
+        tx,
+        1,    // start_chunk_id
+        0,    // delivery_delay_ms (fast endpoints pass 0)
+        true, // is_fast → adaptive controller engaged
+        stop_rx,
+        stats.clone(),
+        "fast-ep".to_string(),
+        bs,
+        None,
+    ));
+
+    // Drive virtual time: ~30 reads at 5ms latency fire the lag-probe once,
+    // which jumps the read pointer to `edge - delay_chunks`. Stop shortly
+    // after so `max_fetched_id` reflects the post-jump position (it climbs
+    // ~1/fetch; the floor-vs-grown gap of 30 chunks is decisive long before
+    // it could close).
+    for _ in 0..400 {
+        tokio::time::advance(std::time::Duration::from_millis(5)).await;
+        tokio::task::yield_now().await;
+    }
+
+    let observed = max_fetched.load(Ordering::Relaxed);
+    // The producer must have consumed the gap (swapped to 0) on its first
+    // successful fetch.
+    assert_eq!(
+        buffer_state.starvation_gap_ms.load(Ordering::Relaxed),
+        0,
+        "producer must consume the keepalive starvation gap (swap to 0)"
+    );
+    assert!(
+        observed < edge,
+        "read pointer must trail the live edge, got {observed} vs edge {edge}"
+    );
+    assert!(
+        edge - observed >= 30,
+        "trickle gap (30s) must grow the read-delay so the producer trails the \
+         live edge by >= 30 chunks; got trail {} (read_pos {observed}, edge {edge}). \
+         Floor-only behaviour trails by ~5 → this is the RED assertion.",
+        edge - observed
+    );
+
+    let _ = stop_tx.send(true);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), producer).await;
+    drain.abort();
+}
+
 #[tokio::test]
 async fn test_controller_grow_makes_lag_jump_trail_edge() {
     // Focused integration of the two pieces the producer wires together:

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -203,27 +203,34 @@ async fn trickle_starvation_grows_fast_read_delay() {
     // starvation: chunks arrive late-but-arrive, so the producer's 40-miss
     // probe cycle NEVER fires). The producer must consume that gap on its
     // next successful fetch and GROW the adaptive read-delay by it, so the
-    // live-edge lag-probe target trails the edge by ~gap+margin (35 chunks at
+    // live-edge lag-probe jump trails the edge by ~gap+margin (35 chunks at
     // 1000ms chunks) instead of the 5s/5-chunk floor.
     //
-    // RED without the fix: the producer ignores `starvation_gap_ms`, the
-    // controller stays at the floor, the lag-probe jumps to `edge - 5`, and
-    // the read position sits only ~5 chunks behind the edge → the
-    // `edge - read_pos >= 30` assertion fails. GREEN with the fix: the gap
-    // grows the controller to 35 chunks, the jump trails the edge by 35, and
-    // the read position stays >= 30 chunks behind.
+    // Determinism — separating HEAD (lag-probe) from GET (read) ceilings:
+    //   * `head_edge` (HEAD) = 20_511: the live edge the lag-probe ladder
+    //     discovers. From current=31 the FLOOR-delay (5-chunk) ladder tops out
+    //     at exactly this rung; the GROWN-delay (35-chunk) ladder tops out at
+    //     chunk 17_951.
+    //   * `available_up_to` (GET) = 17_916: GET stalls here, so once the
+    //     producer jumps it CANNOT catch up and the read position freezes at
+    //     the jump target (the value under test).
     //
-    // The edge (20_511) is the exact highest existing rung of the FLOOR-delay
-    // (5-chunk) probe ladder from current=31, so without the fix the jump
-    // lands at edge-5 (clear FAIL of `>= 30`). With the fix the GROWN-delay
-    // (35-chunk) ladder tops out at chunk 17_951 → jump target 17_916 → the
-    // read pointer trails the edge by ~2_595 (clear PASS).
-    let edge: i64 = 20_511;
-    let chunks: Vec<(i64, Vec<u8>)> = (1..=edge).map(|i| (i, vec![0u8; 1])).collect();
+    // Without the fix the controller stays at the floor → jump target
+    //   17_951... no: floor ladder tops at 20_511 → jump to 20_511 - 5 = 20_506.
+    //   GET 20_506 > 17_916 → None, but `max_fetched_id` still records 20_506,
+    //   so the read pointer trails the edge by only 5 → FAILS `>= 30` (RED).
+    // With the fix the 30s gap grows the controller to 35 chunks → grown ladder
+    //   tops at 17_951 → jump to 17_951 - 35 = 17_916 → GET 17_916 succeeds,
+    //   17_917 > avail → None, `max_fetched_id` = 17_917 → trail
+    //   20_511 - 17_917 = 2_594 (>= 30) → PASS (GREEN).
+    const HEAD_EDGE: i64 = 20_511;
+    const GET_EDGE: i64 = 17_916; // grown jump target — pins the read position
+    let chunks: Vec<(i64, Vec<u8>)> = (1..=HEAD_EDGE).map(|i| (i, vec![0u8; 1])).collect();
     // 1000ms chunks so `typical_chunk_dur_ms` stays at 1000 (EWMA seed) and
     // the delay→chunks maths is 1:1 (35s = 35 chunks, 5s = 5 chunks). 5ms
     // per fetch keeps the producer reading at a bounded rate under paused time.
-    let fetcher = TimedMockFetcher::new(chunks, edge)
+    let fetcher = TimedMockFetcher::new(chunks, GET_EDGE)
+        .with_head_edge(HEAD_EDGE)
         .with_chunk_duration(1000)
         .with_latency(std::time::Duration::from_millis(5));
     let max_fetched = fetcher.max_fetched_id();
@@ -255,10 +262,9 @@ async fn trickle_starvation_grows_fast_read_delay() {
     ));
 
     // Drive virtual time: ~30 reads at 5ms latency fire the lag-probe once,
-    // which jumps the read pointer to `edge - delay_chunks`. Stop shortly
-    // after so `max_fetched_id` reflects the post-jump position (it climbs
-    // ~1/fetch; the floor-vs-grown gap of 30 chunks is decisive long before
-    // it could close).
+    // which jumps the read pointer to `head_edge - delay_chunks`. GET then
+    // stalls at GET_EDGE so the position freezes — the floor-vs-grown gap is
+    // decisive and stable for the rest of the window.
     for _ in 0..400 {
         tokio::time::advance(std::time::Duration::from_millis(5)).await;
         tokio::task::yield_now().await;
@@ -273,15 +279,15 @@ async fn trickle_starvation_grows_fast_read_delay() {
         "producer must consume the keepalive starvation gap (swap to 0)"
     );
     assert!(
-        observed < edge,
-        "read pointer must trail the live edge, got {observed} vs edge {edge}"
+        observed < HEAD_EDGE,
+        "read pointer must trail the live edge, got {observed} vs edge {HEAD_EDGE}"
     );
     assert!(
-        edge - observed >= 30,
+        HEAD_EDGE - observed >= 30,
         "trickle gap (30s) must grow the read-delay so the producer trails the \
-         live edge by >= 30 chunks; got trail {} (read_pos {observed}, edge {edge}). \
+         live edge by >= 30 chunks; got trail {} (read_pos {observed}, edge {HEAD_EDGE}). \
          Floor-only behaviour trails by ~5 → this is the RED assertion.",
-        edge - observed
+        HEAD_EDGE - observed
     );
 
     let _ = stop_tx.send(true);
@@ -457,6 +463,10 @@ mod fast_upload_gap_regression {
             crate::endpoint_stats::EndpointStats::default(),
         ));
         let stats_task = stats.clone();
+        // Shared buffer state so keepalive can record the measured starvation
+        // gap for the producer's adaptive delay controller (trickle-grow fix).
+        let buffer_state = Arc::new(crate::buffer_state::BufferState::new());
+        let buffer_state_task = buffer_state.clone();
         let task = tokio::spawn(async move {
             keepalive_until_chunk(
                 &mut pusher,
@@ -466,6 +476,7 @@ mod fast_upload_gap_regression {
                 &audit_ring,
                 &mut stop_rx,
                 &stats_task,
+                &buffer_state_task,
             )
             .await
         });
@@ -526,6 +537,17 @@ mod fast_upload_gap_regression {
         assert_eq!(
             chunk.chunk_id, 99,
             "keepalive must resume the real chunk (id 99) once one arrives"
+        );
+
+        // Trickle-grow fix: on chunk resume keepalive must record the TRUE
+        // starvation gap (~13s here) into BufferState so the producer's
+        // adaptive read-delay controller grows by it. The gap is in ms and
+        // the window above advanced well past 10s before the chunk arrived.
+        assert!(
+            buffer_state.starvation_gap_ms.load(Ordering::SeqCst) >= 10_000,
+            "keepalive must record the measured starvation gap (>= 10s) for the \
+             producer's delay controller; got {}ms",
+            buffer_state.starvation_gap_ms.load(Ordering::SeqCst)
         );
 
         // Final guarantees recap:

--- a/crates/rs-delivery/src/main.rs
+++ b/crates/rs-delivery/src/main.rs
@@ -141,6 +141,10 @@ async fn main() {
         .with(fmt_layer)
         .init();
 
+    // First meaningful log line — a stale-binary incident (2026-06-10) is now
+    // one `grep` away from diagnosis.
+    tracing::info!(version = env!("CARGO_PKG_VERSION"), "rs-delivery starting");
+
     let app = api::router(state);
 
     let addr = "0.0.0.0:8000";

--- a/docs/superpowers/specs/2026-06-10-delivery-binary-lockstep-design.md
+++ b/docs/superpowers/specs/2026-06-10-delivery-binary-lockstep-design.md
@@ -1,0 +1,128 @@
+# Delivery Binary Version Lockstep + Trickle-Grow — Design
+
+**Date:** 2026-06-10
+**Status:** Approved (operator directive: "hardening needs be implemented")
+**Author:** CAWE
+
+## Problem — the 2026-06-10 recurrence
+
+Event PP-live-2026-06-10 failed exactly like the pre-fix events (fast endpoint
+KS-PP-TEST reset by YouTube at 18:01 + 18:07 local, operator removed it at
+18:14 and switched to OBS direct) — **despite the v0.22.6 fix being installed
+on streampp**. Proven from streampp's audit DB + today's VPS log
+(`delivery-logs/1781112184-evt17-inst20.log`):
+
+- The VPS log contains **zero** `keepalive` / `fast_delay` lines but 20×
+  "no chunks found in probe range" → the VPS ran a **pre-fix rs-delivery**.
+- The VPS downloads rs-delivery from **the client's own S3 bucket**
+  (`crates/rs-api/src/delivery.rs:324`:
+  `binary_url = {s3.endpoint}/{s3.bucket}/rs-delivery`).
+- **CI only updates stream.lan's bucket** (`ci.yml`:
+  `aws s3 cp … s3://restreamer-chunks-fsn1/rs-delivery`). streampp's nbg1
+  object was last modified **May 29** — pre-fix. Nothing ever updated it.
+- Conclusion: installing the Windows app does NOT update the VPS-side binary.
+  The 06-07 "deploy to streampp" was incomplete, and nothing in the system
+  detected or reported the version drift.
+
+Immediate ops fix applied 2026-06-10: release `rs-delivery-0.22.6` PUT to
+`nbg1…/restreamer-chunks/rs-delivery` with `x-amz-acl: public-read`
+(cloud-init fetches the binary anonymously — a PUT without that ACL produces
+403 and breaks VPS boot; verified live), sha256-verified byte-for-byte.
+
+## Goals
+
+1. **Version lockstep is enforced, never assumed.** A VPS running a different
+   rs-delivery version than the client must be impossible to miss and (when
+   remediable) impossible to happen.
+2. **The latent trickle flaw is fixed.** The adaptive delay currently grows
+   only after ~80 s of *uninterrupted* misses (`MAX_CHUNK_MISS_COUNT=40` probe
+   cycle); streampp's real jitter is a trickle (chunks 5–30 s late with
+   successes in between) which resets the miss counter — so the delay never
+   grows and viewers see a freeze/rescue blip on every spike.
+
+## Design
+
+### Component 1 — rs-delivery reports its version
+
+- `main()` logs `rs-delivery v{CARGO_PKG_VERSION}` as the FIRST log line
+  (today's incident would have been one `grep` to diagnose).
+- `/api/health` response gains `version: String`
+  (`env!("CARGO_PKG_VERSION")`). `#[serde(default)]` on the orchestrator's
+  deserialize side so old VPS binaries (no field) read as `""` = mismatch.
+
+### Component 2 — post-boot version gate (orchestrator, rs-api)
+
+In `start_delivery`'s health-poll loop (`delivery.rs` ~505): when health
+passes, compare `health.version` to the client's own `CARGO_PKG_VERSION`
+(single workspace version → identical strings when in lockstep).
+
+- Match → audit Info `delivery_binary_version` `{vps_version, client_version}`
+  and proceed.
+- Mismatch (or missing field = old binary) → audit **Critical**
+  `delivery_binary_version_mismatch` `{vps_version, client_version,
+  binary_url}`, **abort the delivery start** (delete the VPS, return error to
+  the operator's dashboard). Never silently stream on a wrong binary — a hard
+  visible failure at start beats a silent broken event (exactly today's
+  failure made loud).
+
+### Component 3 — pre-create ensure (orchestrator, rs-api)
+
+Before creating the VPS, ensure the bucket binary matches the client version
+using a sidecar object `rs-delivery.version` (plain text, e.g. `0.22.6`):
+
+1. GET sidecar. If sidecar == client version → proceed (cheap, every start).
+2. Else: download the GitHub release asset for the client's own version
+   (`…/releases/download/restreamer-v{ver}/rs-delivery-{ver}-linux-amd64`
+   + `.sha256`), verify sha256, PUT binary to `{bucket}/rs-delivery` **with
+   `x-amz-acl: public-read`**, PUT sidecar (same ACL). Audit Info
+   `delivery_binary_ensured` `{version, sha256}`. Proceed.
+3. No release asset for this version (dev build) AND sidecar mismatch → fail
+   delivery start with explicit error (audit Critical, same action as the
+   gate). On stream.lan this cannot happen: CI uploads the fresh dev binary +
+   sidecar on every deploy (Component 4).
+
+Pure decision logic (`decide_binary_action(sidecar, client_version,
+asset_available) → Proceed | EnsureFromRelease | Fail`) is separated from I/O
+and unit-tested.
+
+### Component 4 — CI writes the sidecar
+
+Extend the existing `Upload rs-delivery to S3` step in `ci.yml` to also write
+`rs-delivery.version` (the workspace version of the build) next to the binary.
+
+### Component 5 — trickle-grow (the latent flaw)
+
+The consumer's keepalive already measures the true starvation gap
+(`gap_secs` in `fast_keepalive_ended`). Feed it back to the producer's delay
+controller:
+
+- `BufferState` gains `starvation_gap_ms: AtomicU64` (max-accumulate: store
+  `max(current, gap_ms)`).
+- Consumer: on keepalive end, store the measured gap.
+- Producer hot loop: on each successful fetch, `swap(0)` the atomic; if
+  non-zero → `ctrl.on_starvation(gap_secs, now)` → emits `fast_delay_grown`.
+  The existing probe-cycle grow stays (covers total outages).
+- Result: the FIRST freeze of an event grows the read-delay to cover the
+  observed spike; subsequent spikes of that size are absorbed silently from
+  the buffer. RED test: a trickle pattern (late-but-arriving chunks, never 40
+  consecutive misses) must grow the delay — the regression the soak missed.
+
+## New audit actions
+
+`DeliveryBinaryVersion` (Info), `DeliveryBinaryVersionMismatch` (Critical),
+`DeliveryBinaryEnsured` (Info). snake_case via existing serde rename.
+
+## Out of scope
+
+- Presigned binary URLs (anonymous + public-read ACL kept — matches the
+  working cloud-init; revisit only if the bucket must go private).
+- Multi-client fleet management; each client self-ensures its own bucket.
+
+## Verification
+
+- Unit: decide_binary_action matrix; version-compare gate; trickle-grow RED→GREEN.
+- CI E2E: existing delivery E2E now implicitly exercises the gate (CI uploads
+  fresh binary+sidecar → versions match → delivery proceeds).
+- Post-merge: next streampp event — audit log must show
+  `delivery_binary_version` match row; if the bucket is ever stale again the
+  event start FAILS LOUDLY instead of silently streaming a broken fast stream.

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.22.6"
+version = "0.22.7"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.22.6"
+version = "0.22.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why — the 2026-06-10 recurrence

PP-live-2026-06-10 failed exactly like the pre-#243 events (fast endpoint reset by YouTube 18:01/18:07 local, operator removed it 18:14, switched OBS direct) **despite the local app being v0.22.6**. Evidence (streampp audit DB + VPS log `1781112184-evt17-inst20.log`):

- VPS log: 20× "no chunks found in probe range", **zero** keepalive/fast_delay lines → the VPS ran a **pre-fix rs-delivery**.
- The VPS downloads rs-delivery from **the client's own S3 bucket** (`delivery.rs` `binary_url`); **CI only refreshes stream.lan's bucket** — streampp's nbg1 object was from **May 29**. Installing the Windows app never updates the VPS binary, and nothing detected the drift.
- Immediate ops fix already applied: release rs-delivery-0.22.6 PUT to streampp's bucket (sha256-verified, `x-amz-acl: public-read` — cloud-init fetches anonymously).

Spec: `docs/superpowers/specs/2026-06-10-delivery-binary-lockstep-design.md`

## What changed

1. **Binary version lockstep** (`rs-api/src/delivery_binary.rs`):
   - Pre-create ensure: sidecar `rs-delivery.version` checked before every VPS create; on drift the matching GitHub release asset is downloaded, sha256-verified, and uploaded (public-read) to the client's bucket. Self-heals any client's bucket.
   - Post-boot gate: the booted VPS's `/api/health` version must equal the client version; mismatch → **Critical audit + VPS deleted + delivery start aborted loudly**. Never silently stream on a wrong binary again.
   - CI writes the sidecar next to the binary; `build-delivery → rust-ci-gate → deploy → E2E` needs-chain guarantees bootstrap ordering for dev versions.
   - rs-delivery logs its version as the first startup line.
2. **Trickle-grow** (`rs-delivery`) — latent flaw in #243: the adaptive delay grew only after ~80 s of *uninterrupted* misses; real jitter is a trickle (late-but-arriving chunks) which never triggered growth → a freeze blip on every spike. Now the consumer's keepalive feeds its measured gap back to the delay controller (`BufferState.starvation_gap_ms`), so the **first** freeze grows the buffer and subsequent spikes are absorbed silently. RED→GREEN: `11cc2bbb` (failing test) → `1dd2ee10` (fix).
3. fast-iterate (Tier 2) disabled in CLAUDE.md — no local builds on dev1 (8 GB RAM, OOM).

## Follow-up filed
- #244: orphaned Hetzner VPS on `poll_and_init` failure (pre-existing; the new mismatch abort deletes its VPS explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)