### PR TITLE
Race elimination (versioned keys + CI serialization) + freeze-only keepalive (green-video fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -925,12 +925,14 @@ jobs:
     # run can never interleave deploys or E2E on the shared machine
     # (2026-06-11 incident: concurrent main 0.22.7 + dev 0.22.8 runs raced
     # deploys and the shared S3 binary key -- BOTH runs failed, hours lost).
-    # cancel-in-progress:false => later run QUEUES instead of racing. NB:
-    # GitHub keeps only ONE pending job per group; a 3rd stacked run would
-    # cancel the 2nd's pending job (visible red, rerun) -- still better
-    # than a silent race.
+    # queue:max + cancel-in-progress:false => later jobs QUEUE (FIFO, up to
+    # 100) instead of racing. queue:max is REQUIRED: the default queue:single
+    # keeps only ONE pending job per group and CANCELS the older pending one
+    # -- with deploy fanning out to two parallel E2E siblings, a second run's
+    # queued deploy would cancel this run's pending E2E job (red run).
     concurrency:
       group: stream-lan-box
+      queue: max
       cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     steps:
@@ -1349,6 +1351,7 @@ jobs:
     # See deploy-stream-lan: cross-run serialization on the shared box.
     concurrency:
       group: stream-lan-box
+      queue: max
       cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     timeout-minutes: 20
@@ -1877,6 +1880,7 @@ jobs:
     # See deploy-stream-lan: cross-run serialization on the shared box.
     concurrency:
       group: stream-lan-box
+      queue: max
       cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     timeout-minutes: 60
@@ -5177,6 +5181,7 @@ jobs:
     # See deploy-stream-lan: cross-run serialization on the shared box.
     concurrency:
       group: stream-lan-box
+      queue: max
       cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -920,6 +920,18 @@ jobs:
     name: Deploy to stream.lan
     needs: [rust-ci-gate, build-tauri]
     if: always() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.rust-ci-gate.result == 'success' && needs.build-tauri.result == 'success'
+    # Cross-RUN serialization: every job that touches the single stream.lan
+    # box / YouTube test stream shares this group, so a main run and a dev
+    # run can never interleave deploys or E2E on the shared machine
+    # (2026-06-11 incident: concurrent main 0.22.7 + dev 0.22.8 runs raced
+    # deploys and the shared S3 binary key -- BOTH runs failed, hours lost).
+    # cancel-in-progress:false => later run QUEUES instead of racing. NB:
+    # GitHub keeps only ONE pending job per group; a 3rd stacked run would
+    # cancel the 2nd's pending job (visible red, rerun) -- still better
+    # than a silent race.
+    concurrency:
+      group: stream-lan-box
+      cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     steps:
       - name: Clean old artifacts
@@ -1334,6 +1346,10 @@ jobs:
     name: E2E Streaming Test
     needs: [deploy-stream-lan]
     if: always() && needs.deploy-stream-lan.result != 'failure' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # See deploy-stream-lan: cross-run serialization on the shared box.
+    concurrency:
+      group: stream-lan-box
+      cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     timeout-minutes: 20
     steps:
@@ -1858,6 +1874,10 @@ jobs:
     name: E2E OBS-to-YouTube Test
     needs: [deploy-stream-lan]
     if: always() && needs.deploy-stream-lan.result != 'failure' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # See deploy-stream-lan: cross-run serialization on the shared box.
+    concurrency:
+      group: stream-lan-box
+      cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     timeout-minutes: 60
     env:
@@ -5154,6 +5174,10 @@ jobs:
     # break the sustained YT health gate (CI run 26085993055 regression).
     needs: [deploy-stream-lan, e2e-streaming-test, e2e-obs-youtube-test]
     if: always() && needs.deploy-stream-lan.result != 'failure' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # See deploy-stream-lan: cross-run serialization on the shared box.
+    concurrency:
+      group: stream-lan-box
+      cancel-in-progress: false
     runs-on: [self-hosted, windows, stream-lan]
     timeout-minutes: 60
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,15 +446,23 @@ jobs:
           # reducing the available write limitations for some existing
           # buckets on NBG1" announcement.
           pip install awscli
+          VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+          # Versioned immutable key — the ONLY source the client of this
+          # build will request. Key name pins the version: concurrent runs
+          # of different versions can never race (2026-06-11 incident).
+          aws s3 cp target/release/rs-delivery \
+            "s3://restreamer-chunks-fsn1/rs-delivery-${VERSION}" \
+            --endpoint-url https://fsn1.your-objectstorage.com \
+            --region fsn1 \
+            --acl public-read
+          # Legacy mutable key for clients <=0.22.7 still deployed during
+          # the transition (they read `rs-delivery` + sidecar). Remove once
+          # all boxes run >=0.22.8 — tracked in #246.
           aws s3 cp target/release/rs-delivery \
             s3://restreamer-chunks-fsn1/rs-delivery \
             --endpoint-url https://fsn1.your-objectstorage.com \
             --region fsn1 \
             --acl public-read
-          # Version sidecar for the binary-lockstep pre-create check
-          # (2026-06-10 incident). The orchestrator reads this to decide
-          # whether the bucket binary is current before creating a VPS.
-          VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
           echo -n "$VERSION" > rs-delivery.version
           aws s3 cp rs-delivery.version \
             s3://restreamer-chunks-fsn1/rs-delivery.version \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,9 +233,12 @@ NEVER push to dev while a main run (or the release workflow) is in flight, and
 never stack a second dev push on a running dev E2E. All E2E shares ONE
 self-hosted runner, ONE stream.lan box and ONE YouTube test stream — concurrent
 runs race deploys and shared state, and historically BOTH fail (2026-06-07,
-2026-06-11). The `stream-lan-box` concurrency group in ci.yml now serializes
-those jobs platform-side, but queued runs still waste hours: hold the
-post-merge version-bump push until main + release reach terminal state.
+2026-06-11). The `stream-lan-box` concurrency group (`queue: max`,
+`cancel-in-progress: false`) in ci.yml serializes those jobs platform-side
+(FIFO queue — `queue: max` is required; the default single-pending-slot
+semantics would cancel an older run's pending E2E sibling). Queued runs still
+waste hours: hold the post-merge version-bump push until main + release reach
+terminal state.
 
 **If two runs ARE ever in flight together: STOP one immediately — never let
 both proceed.** Cancel the lower-value run (usually the version-bump/dev run;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,3 +226,13 @@ Operational guides for common tasks:
 Tier 0 (default): NO local builds or test runs — dev1 has 7.5 GB RAM and rustc
 workspace builds OOM it (operator directive 2026-06-10). Lint/fmt only locally;
 compilation, clippy, and tests run on CI. Purge `target/` whenever found.
+
+## Push Discipline — ONE in-flight CI run at a time
+
+NEVER push to dev while a main run (or the release workflow) is in flight, and
+never stack a second dev push on a running dev E2E. All E2E shares ONE
+self-hosted runner, ONE stream.lan box and ONE YouTube test stream — concurrent
+runs race deploys and shared state, and historically BOTH fail (2026-06-07,
+2026-06-11). The `stream-lan-box` concurrency group in ci.yml now serializes
+those jobs platform-side, but queued runs still waste hours: hold the
+post-merge version-bump push until main + release reach terminal state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,3 +236,12 @@ runs race deploys and shared state, and historically BOTH fail (2026-06-07,
 2026-06-11). The `stream-lan-box` concurrency group in ci.yml now serializes
 those jobs platform-side, but queued runs still waste hours: hold the
 post-merge version-bump push until main + release reach terminal state.
+
+**If two runs ARE ever in flight together: STOP one immediately — never let
+both proceed.** Cancel the lower-value run (usually the version-bump/dev run;
+keep the release-bound main run), clean shared state if its E2E was mid-test
+(deactivate/detach the E2E event via the API, delete any orphan VPS), then let
+the surviving run continue. A deliberate cancel + 5-minute cleanup always
+beats letting two runs race (2026-06-11: letting both run cost ~3 h and
+failed BOTH). This is one decisive cancel — not the banned cancel-thrashing
+of stuck runs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.22.7"
+version = "0.22.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-api/src/delivery.rs
+++ b/crates/rs-api/src/delivery.rs
@@ -321,10 +321,10 @@ impl DeliveryOrchestrator {
         let server_type = rs_cloud::select_server_type(endpoints.len());
 
         let name = format!("rs-delivery-evt{event_id}");
-        let binary_url = format!(
-            "{}/{}/rs-delivery",
-            self.config.s3.endpoint, self.config.s3.bucket,
-        );
+        // Versioned immutable key — the VPS downloads EXACTLY this build's
+        // object so concurrent CI runs never race (2026-06-11 incident).
+        let client_version = env!("CARGO_PKG_VERSION");
+        let binary_url = crate::delivery_binary::binary_url(&self.config, client_version);
 
         // Binary lockstep (2026-06-10 incident): never create a VPS that would
         // download a stale rs-delivery. FAILS LOUDLY on unfixable drift.

--- a/crates/rs-api/src/delivery_binary.rs
+++ b/crates/rs-api/src/delivery_binary.rs
@@ -1,27 +1,38 @@
-//! Delivery binary version lockstep (2026-06-10 incident).
+//! Delivery binary version lockstep — versioned immutable S3 keys
+//! (2026-06-10 lockstep + 2026-06-11 race fix).
 //!
 //! The delivery VPS downloads its `rs-delivery` binary from the CLIENT'S OWN
-//! S3 bucket (`{s3.endpoint}/{s3.bucket}/rs-delivery`). CI only refreshes one
-//! client's bucket, so a production client whose bucket was never updated can
-//! silently boot a stale binary and stream a broken event — exactly what
-//! happened on streampp (a 12-day-old rs-delivery ran during a live event and
-//! nothing detected the drift).
+//! S3 bucket. The original lockstep design (PR #245) used ONE mutable key
+//! (`rs-delivery`) plus a plain-text sidecar (`rs-delivery.version`); the
+//! client compared the sidecar to its own version and re-uploaded on drift.
+//!
+//! That shared mutable object can never be made race-safe. On 2026-06-11 two
+//! concurrent CI runs — `main` building 0.22.7 and `dev` building 0.22.8 —
+//! raced on the single key: last writer won, the deployed 0.22.7 client then
+//! saw sidecar=0.22.8, tried to fetch a GitHub release that did not yet exist,
+//! and delivery start failed.
+//!
+//! The fix is to put the version IN THE KEY NAME. Each build uploads its own
+//! immutable object `rs-delivery-{version}` ([`binary_key`]); the client of
+//! that build requests EXACTLY `rs-delivery-{client_version}`. Concurrent
+//! builds/versions write disjoint keys and can never interfere. There is no
+//! sidecar, no comparison, no re-upload of a shared object.
 //!
 //! This module enforces lockstep at two points:
 //!
-//! 1. **Pre-create** ([`ensure_bucket_binary`]): a cheap sidecar version check
-//!    before every VPS create. On drift it downloads the matching GitHub
-//!    release asset for the client's OWN version, sha256-verifies it, and
-//!    uploads binary + sidecar with public-read ACL so cloud-init fetches the
-//!    correct bytes. Hard error (abort delivery) when no matching release
-//!    exists — a loud failure at start beats a silent broken event.
+//! 1. **Pre-create** ([`ensure_bucket_binary`]): an anonymous HEAD of the
+//!    versioned key. Present → nothing to do. Missing → download the matching
+//!    GitHub release asset for the client's OWN version, sha256-verify it, and
+//!    upload it under the versioned key with public-read ACL so cloud-init
+//!    fetches the correct bytes. Hard error (abort delivery) when no matching
+//!    release exists — a loud failure at start beats a silent broken event.
 //! 2. **Post-boot** ([`versions_match`]): the orchestrator parses the VPS
 //!    `/api/health` `version` field and aborts (delete VPS + Critical audit)
 //!    when it differs from the client version.
 //!
-//! Pure decision logic ([`decide_binary_action`], [`versions_match`],
-//! [`parse_sha256_file`]) is separated from the async I/O so it is unit-tested
-//! without network access.
+//! Pure logic ([`binary_key`], [`versions_match`], [`parse_sha256_file`],
+//! [`parse_health_version`]) is separated from the async I/O so it is
+//! unit-tested without network access.
 
 use std::time::Duration;
 
@@ -37,32 +48,25 @@ use tracing::{error, info, warn};
 /// GitHub repo that hosts the `rs-delivery` release assets.
 const RELEASE_BASE: &str =
     "https://github.com/zbynekdrlik/restreamer/releases/download/restreamer-v";
-/// S3 object key for the rs-delivery binary the VPS cloud-init downloads.
-const BINARY_KEY: &str = "rs-delivery";
-/// S3 object key for the plain-text sidecar carrying the binary's version.
-const SIDECAR_KEY: &str = "rs-delivery.version";
 
-/// What to do about the bucket's rs-delivery binary before creating a VPS.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BinaryAction {
-    /// Sidecar matches the client version — bucket binary is current.
-    Proceed,
-    /// Sidecar missing or different — fetch the client-version release
-    /// asset and upload it (then proceed).
-    Ensure,
+/// Versioned, immutable S3 object key for the rs-delivery binary. The key
+/// name pins the version, so concurrent builds/versions can never race on
+/// a shared mutable object (2026-06-11 incident: main 0.22.7 and dev 0.22.8
+/// CI runs overwrote each other's `rs-delivery` + sidecar).
+pub fn binary_key(version: &str) -> String {
+    format!("rs-delivery-{version}")
 }
 
-/// Decide, from the sidecar contents and the client's own version, whether the
-/// bucket binary is already current ([`BinaryAction::Proceed`]) or must be
-/// re-uploaded ([`BinaryAction::Ensure`]).
-///
-/// A missing sidecar (`None`) or any non-matching value forces `Ensure`.
-/// Trailing whitespace/newlines in the sidecar are tolerated.
-pub fn decide_binary_action(sidecar: Option<&str>, client_version: &str) -> BinaryAction {
-    match sidecar {
-        Some(s) if s.trim() == client_version => BinaryAction::Proceed,
-        _ => BinaryAction::Ensure,
-    }
+/// Public anonymous URL of this client's versioned rs-delivery object, used by
+/// cloud-init to download the binary. Keeps the `start_delivery` call site to
+/// one line (delivery.rs is at its 1000-line cap).
+pub fn binary_url(config: &rs_core::config::Config, client_version: &str) -> String {
+    format!(
+        "{}/{}/{}",
+        config.s3.endpoint,
+        config.s3.bucket,
+        binary_key(client_version)
+    )
 }
 
 /// Post-boot gate: does the VPS-reported version match the client's?
@@ -115,75 +119,68 @@ fn hex_encode(bytes: &[u8]) -> String {
     s
 }
 
-/// Ensure the client bucket's rs-delivery binary matches `client_version`.
+/// Ensure the client bucket holds the immutable `rs-delivery-{client_version}`
+/// object.
 ///
-/// Cheap when current (one anonymous GET of the sidecar). On mismatch,
-/// downloads the GitHub release asset for the client's OWN version, verifies
-/// sha256, uploads binary + sidecar with public-read ACL.
+/// Cheap when present (one anonymous HEAD). When absent, downloads the GitHub
+/// release asset for the client's OWN version, verifies sha256, and uploads it
+/// under the versioned key with public-read ACL.
 ///
 /// Returns `Ok(Some(sha256))` if an upload happened (the verified digest of
-/// the uploaded binary), `Ok(None)` if the bucket was already current.
-/// `Err` means delivery start MUST abort — the caller surfaces and audits.
+/// the uploaded binary), `Ok(None)` if the versioned object was already
+/// present. `Err` means delivery start MUST abort — the caller surfaces and
+/// audits.
 pub async fn ensure_bucket_binary(
     config: &rs_core::config::Config,
     client_version: &str,
 ) -> anyhow::Result<Option<String>> {
-    let sidecar = fetch_sidecar(config).await;
-    match decide_binary_action(sidecar.as_deref(), client_version) {
-        BinaryAction::Proceed => {
-            info!(
-                version = client_version,
-                "delivery binary lockstep: bucket sidecar current, proceeding"
-            );
-            Ok(None)
-        }
-        BinaryAction::Ensure => {
-            warn!(
-                client_version,
-                sidecar = ?sidecar,
-                "delivery binary lockstep: bucket binary stale/unknown, re-uploading from release"
-            );
-            let sha = upload_release_binary(config, client_version).await?;
-            Ok(Some(sha))
-        }
+    if versioned_object_present(config, client_version).await {
+        info!(
+            version = client_version,
+            "delivery binary lockstep: rs-delivery-{client_version} present in bucket, proceeding"
+        );
+        return Ok(None);
     }
+    warn!(
+        client_version,
+        "delivery binary lockstep: rs-delivery-{client_version} absent, uploading from release"
+    );
+    let sha = upload_release_binary(config, client_version).await?;
+    Ok(Some(sha))
 }
 
-/// Anonymous GET of `{endpoint}/{bucket}/rs-delivery.version`. Any error or
-/// non-200 is treated as "no sidecar" (`None`) which forces an Ensure.
-async fn fetch_sidecar(config: &rs_core::config::Config) -> Option<String> {
+/// Anonymous HEAD of `{endpoint}/{bucket}/rs-delivery-{client_version}`.
+/// HTTP 200 → the immutable object is present (`true`). Any non-200 or
+/// network error → treat as absent (`false`), which forces an upload.
+async fn versioned_object_present(config: &rs_core::config::Config, client_version: &str) -> bool {
     let url = format!(
         "{}/{}/{}",
-        config.s3.endpoint, config.s3.bucket, SIDECAR_KEY
+        config.s3.endpoint,
+        config.s3.bucket,
+        binary_key(client_version)
     );
     let client = reqwest::Client::new();
     match client
-        .get(&url)
+        .head(&url)
         .timeout(Duration::from_secs(10))
         .send()
         .await
     {
-        Ok(resp) if resp.status().is_success() => match resp.text().await {
-            Ok(body) => Some(body),
-            Err(e) => {
-                warn!(%url, "sidecar body read failed (treating as missing): {e}");
-                None
-            }
-        },
+        Ok(resp) if resp.status().is_success() => true,
         Ok(resp) => {
-            info!(%url, status = %resp.status(), "sidecar not present (treating as missing)");
-            None
+            info!(%url, status = %resp.status(), "versioned binary not present (will upload)");
+            false
         }
         Err(e) => {
-            warn!(%url, "sidecar GET failed (treating as missing): {e}");
-            None
+            warn!(%url, "versioned binary HEAD failed (will upload): {e}");
+            false
         }
     }
 }
 
 /// Download the release asset for `client_version`, sha256-verify it against
-/// the `.sha256` sidecar, and upload binary + version sidecar to the client
-/// bucket with public-read ACL. Returns the verified sha256.
+/// the `.sha256` sidecar, and upload it to the client bucket under the
+/// versioned immutable key with public-read ACL. Returns the verified sha256.
 async fn upload_release_binary(
     config: &rs_core::config::Config,
     client_version: &str,
@@ -202,8 +199,8 @@ async fn upload_release_binary(
         .with_context(|| format!("GET release asset {bin_url}"))?;
     if bin_resp.status() == reqwest::StatusCode::NOT_FOUND {
         return Err(anyhow!(
-            "no release asset for v{client_version} and bucket binary is stale/unknown \
-             — cannot guarantee VPS binary version"
+            "no release asset for v{client_version} and bucket has no \
+             rs-delivery-{client_version} — cannot guarantee VPS binary version"
         ));
     }
     if !bin_resp.status().is_success() {
@@ -256,30 +253,30 @@ async fn upload_release_binary(
         "delivery binary lockstep: sha256 verified"
     );
 
-    // Upload binary + sidecar (public-read so cloud-init fetches anonymously).
+    // Upload under the versioned immutable key (public-read so cloud-init
+    // fetches anonymously).
+    let key = binary_key(client_version);
     let s3 = rs_endpoint::s3::S3Client::new(&config.s3)
         .map_err(|e| anyhow!("S3Client::new for binary upload: {e}"))?;
-    s3.upload_public_object(BINARY_KEY, &bin_bytes, "application/octet-stream")
+    s3.upload_public_object(&key, &bin_bytes, "application/octet-stream")
         .await
-        .map_err(|e| anyhow!("upload rs-delivery binary: {e}"))?;
-    s3.upload_public_object(SIDECAR_KEY, client_version.as_bytes(), "text/plain")
-        .await
-        .map_err(|e| anyhow!("upload rs-delivery.version sidecar: {e}"))?;
+        .map_err(|e| anyhow!("upload {key}: {e}"))?;
     info!(
         version = client_version,
         sha256 = %actual,
-        "delivery binary lockstep: uploaded binary + sidecar (public-read)"
+        key = %key,
+        "delivery binary lockstep: uploaded versioned binary (public-read)"
     );
 
     Ok(actual)
 }
 
-/// Pre-create lockstep (2026-06-10 incident): ensure the client bucket's
-/// rs-delivery binary matches the client version before a VPS is created.
-/// Cheap sidecar check; uploads the matching release asset on drift; hard
-/// error (audit Critical + abort) when impossible (no release asset / sha
-/// mismatch / upload failure) so the event start fails loudly instead of
-/// silently streaming a wrong-version binary.
+/// Pre-create lockstep (2026-06-10 incident, 2026-06-11 race fix): ensure the
+/// client bucket holds the immutable `rs-delivery-{client_version}` object
+/// before a VPS is created. Cheap HEAD; uploads the matching release asset
+/// when absent; hard error (audit Critical + abort) when impossible (no
+/// release asset / sha mismatch / upload failure) so the event start fails
+/// loudly instead of silently streaming a wrong-version binary.
 pub async fn ensure_bucket_binary_or_abort(
     config: &rs_core::config::Config,
     audit_tx: Option<&mpsc::Sender<AuditRow>>,
@@ -348,7 +345,7 @@ pub async fn abort_on_version_mismatch(
     )
 }
 
-/// Info audit row: the bucket binary was re-uploaded to match the client
+/// Info audit row: the versioned binary was uploaded to match the client
 /// version before VPS creation. Keeps the `start_delivery` call site to one
 /// `record()` line (delivery.rs is at its 1000-line cap).
 pub fn ensured_audit(event_id: i64, version: &str, sha256: &str) -> AuditRow {
@@ -420,39 +417,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn decide_proceed_on_exact_match() {
-        assert_eq!(
-            decide_binary_action(Some("0.22.7"), "0.22.7"),
-            BinaryAction::Proceed
-        );
+    fn binary_key_pins_version() {
+        assert_eq!(binary_key("0.22.8"), "rs-delivery-0.22.8");
+        assert_eq!(binary_key("0.22.7"), "rs-delivery-0.22.7");
     }
 
     #[test]
-    fn decide_proceed_tolerates_trailing_newline() {
-        assert_eq!(
-            decide_binary_action(Some("0.22.7\n"), "0.22.7"),
-            BinaryAction::Proceed
-        );
-        assert_eq!(
-            decide_binary_action(Some("  0.22.7  \n"), "0.22.7"),
-            BinaryAction::Proceed
-        );
+    fn binary_key_distinct_per_version() {
+        // The whole point of the 2026-06-11 race fix: different versions
+        // produce different keys, so concurrent builds never collide.
+        assert_ne!(binary_key("0.22.7"), binary_key("0.22.8"));
     }
 
     #[test]
-    fn decide_ensure_on_missing_sidecar() {
-        assert_eq!(decide_binary_action(None, "0.22.7"), BinaryAction::Ensure);
-    }
-
-    #[test]
-    fn decide_ensure_on_mismatch() {
+    fn binary_url_joins_endpoint_bucket_versioned_key() {
+        // Config::default() → endpoint http://localhost:9000, bucket test-bucket.
+        let cfg = rs_core::config::Config::default();
         assert_eq!(
-            decide_binary_action(Some("0.22.6"), "0.22.7"),
-            BinaryAction::Ensure
-        );
-        assert_eq!(
-            decide_binary_action(Some(""), "0.22.7"),
-            BinaryAction::Ensure
+            binary_url(&cfg, "0.22.8"),
+            "http://localhost:9000/test-bucket/rs-delivery-0.22.8"
         );
     }
 
@@ -557,11 +540,12 @@ mod tests {
 
     #[test]
     fn pre_create_mismatch_audit_shape() {
-        let row = pre_create_mismatch_audit(7, "0.22.7", "https://s3/x/rs-delivery", "boom");
+        let row = pre_create_mismatch_audit(7, "0.22.7", "https://s3/x/rs-delivery-0.22.7", "boom");
         assert_eq!(row.severity, Severity::Critical);
         assert_eq!(row.action, Action::DeliveryBinaryVersionMismatch);
         assert_eq!(row.detail["vps_version"], serde_json::Value::Null);
         assert_eq!(row.detail["client_version"], "0.22.7");
+        assert_eq!(row.detail["binary_url"], "https://s3/x/rs-delivery-0.22.7");
         assert_eq!(row.detail["phase"], "pre_create");
         assert_eq!(row.detail["error"], "boom");
     }

--- a/crates/rs-api/src/delivery_binary.rs
+++ b/crates/rs-api/src/delivery_binary.rs
@@ -431,8 +431,12 @@ mod tests {
 
     #[test]
     fn binary_url_joins_endpoint_bucket_versioned_key() {
-        // Config::default() → endpoint http://localhost:9000, bucket test-bucket.
-        let cfg = rs_core::config::Config::default();
+        // Set the S3 fields explicitly — asserting Config::default() values
+        // couples the test to unrelated config defaults (broke on CI when
+        // the real defaults differed from the assumption).
+        let mut cfg = rs_core::config::Config::default();
+        cfg.s3.endpoint = "http://localhost:9000".to_string();
+        cfg.s3.bucket = "test-bucket".to_string();
         assert_eq!(
             binary_url(&cfg, "0.22.8"),
             "http://localhost:9000/test-bucket/rs-delivery-0.22.8"

--- a/crates/rs-delivery/src/endpoint_task.rs
+++ b/crates/rs-delivery/src/endpoint_task.rs
@@ -783,6 +783,16 @@ async fn consumer_task<P: OutputProcessFactory>(
 /// channel. NEVER closes the connection on starvation — a push error just
 /// backs off briefly and the pusher lazy-reconnects on the next push.
 ///
+/// FREEZE-ONLY: a keepalive tick may push ONLY the last delivered chunk
+/// (same codec as the live stream). It must NEVER push the rescue clip —
+/// the RTMP pusher de-duplicates AVC sequence headers per session, so a
+/// codec-foreign rescue blob on a LIVE session makes YouTube decode the
+/// real stream with the wrong SPS/PPS (solid green video, 2026-06-11
+/// streampp KS-PP-TEST). If no chunk has been delivered yet there is
+/// nothing codec-safe to push: this function just WAITS for the first
+/// chunk (no pushes), identical to the pre-keepalive behaviour at session
+/// start.
+///
 /// Sets `stats.delivery_mode = "rescue"` on entry and resets it to
 /// `"normal"` on both exit paths so the dashboard correctly reflects the
 /// keepalive gap instead of showing stale `"normal"` state.
@@ -797,21 +807,19 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
     stats: &Stats,
     buffer_state: &std::sync::Arc<crate::buffer_state::BufferState>,
 ) -> Option<PrefetchedChunk> {
-    use crate::fast_keepalive::{KeepaliveMode, keepalive_bytes, keepalive_mode};
+    // ONLY codec-homogeneous bytes (the last real chunk). `None` => no chunk
+    // delivered yet => pure-wait, never push. Borrows `last_chunk_bytes` (an
+    // immutable `&` param) for the whole fn; nothing mutates it here.
+    let freeze: Option<&[u8]> = crate::fast_keepalive::keepalive_bytes(last_chunk_bytes);
     // `tokio::time::Instant` (not `std::time::Instant`) so the gap clock shares
     // the loop's `tokio::time::sleep` time source: identical to the real clock
-    // in prod, but advances under `start_paused` so the freeze→rescue transition
-    // is deterministically testable without wall-clock waits.
+    // in prod, but advances under `start_paused` so the gap is deterministically
+    // testable without wall-clock waits.
     let started = tokio::time::Instant::now();
-    let mut current_mode = keepalive_mode(0, last_chunk_bytes.is_some());
     crate::fast_delay_audit::emit_keepalive_started(
         audit_ring,
         alias,
-        if current_mode == KeepaliveMode::Rescue {
-            "rescue"
-        } else {
-            "freeze"
-        },
+        if freeze.is_some() { "freeze" } else { "wait" },
     );
     // Surface keepalive gap on the dashboard: set delivery_mode to "rescue"
     // so the UI doesn't falsely show "normal" during the starvation window.
@@ -820,57 +828,47 @@ async fn keepalive_until_chunk<P: consumer_helpers::Pushable>(
         let mut s = stats.lock().await;
         s.delivery_mode = "rescue".to_string();
     }
-    loop {
-        let gap = started.elapsed().as_secs();
-        let mode = keepalive_mode(gap, last_chunk_bytes.is_some());
-        if mode != current_mode {
-            current_mode = mode;
-            crate::fast_delay_audit::emit_keepalive_started(
-                audit_ring,
-                alias,
-                if mode == KeepaliveMode::Rescue {
-                    "rescue"
-                } else {
-                    "freeze"
-                },
-            );
-        }
-        // Finding 2: keep the Cow (borrowing last_chunk_bytes) instead of
-        // cloning with .into_owned() — avoids a multi-MB heap allocation on
-        // every keepalive tick for the freeze window.
-        let bytes = keepalive_bytes(mode, last_chunk_bytes);
-        tokio::select! {
-            maybe = rx.recv() => {
-                // Trickle-grow: feed the TRUE measured gap to the producer's
-                // adaptive controller (consumed via BufferState on its next fetch).
-                let elapsed = consumer_helpers::record_starvation_gap(buffer_state, started);
-                crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, elapsed.as_secs());
-                // Reset delivery_mode so the dashboard reflects normal delivery.
-                {
-                    let mut s = stats.lock().await;
-                    s.delivery_mode = "normal".to_string();
-                }
-                return maybe;
-            }
-            res = pusher.push_flv_bytes(&bytes) => {
-                if let Err(e) = res {
-                    tracing::warn!(alias = %alias, "keepalive push error: {e}; will reconnect on next push");
-                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                }
-                // push_flv_bytes self-paces ~1x; loop to push the next tick.
-            }
-            _ = stop_rx.changed() => {
-                if *stop_rx.borrow() {
-                    crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
-                    // Reset delivery_mode before returning None (stop path).
-                    {
-                        let mut s = stats.lock().await;
-                        s.delivery_mode = "normal".to_string();
+    // Shared exit bookkeeping. `resume` => record the TRUE gap for the
+    // producer's adaptive controller and return the chunk; otherwise (stop) =>
+    // return None. Both emit keepalive-ended and reset delivery_mode.
+    macro_rules! finish {
+        (resume $maybe:expr) => {{
+            consumer_helpers::record_starvation_gap(buffer_state, started);
+            finish!(@end);
+            return $maybe;
+        }};
+        (stop) => {{
+            finish!(@end);
+            return None;
+        }};
+        (@end) => {{
+            crate::fast_delay_audit::emit_keepalive_ended(audit_ring, alias, started.elapsed().as_secs());
+            let mut s = stats.lock().await;
+            s.delivery_mode = "normal".to_string();
+        }};
+    }
+    match freeze {
+        Some(bytes) => loop {
+            tokio::select! {
+                maybe = rx.recv() => finish!(resume maybe),
+                res = pusher.push_flv_bytes(bytes) => {
+                    if let Err(e) = res {
+                        tracing::warn!(alias = %alias, "keepalive push error: {e}; will reconnect on next push");
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     }
-                    return None;
+                    // push_flv_bytes self-paces ~1x; loop to push the next tick.
                 }
+                _ = stop_rx.changed() => { if *stop_rx.borrow() { finish!(stop); } }
             }
-        }
+        },
+        // No chunk delivered yet: nothing codec-safe to push. Pure wait for the
+        // first real chunk (or stop) — no push arm, so no codec-foreign bytes.
+        None => loop {
+            tokio::select! {
+                maybe = rx.recv() => finish!(resume maybe),
+                _ = stop_rx.changed() => { if *stop_rx.borrow() { finish!(stop); } }
+            }
+        },
     }
 }
 

--- a/crates/rs-delivery/src/fast_keepalive.rs
+++ b/crates/rs-delivery/src/fast_keepalive.rs
@@ -1,9 +1,18 @@
 //! Fast-endpoint keepalive: hold the EXISTING rtmp session alive during a
-//! short producer gap by re-pushing the last delivered chunk (freeze), then
-//! the default rescue loop after `FAST_KEEPALIVE_RESCUE_AFTER_SECS`. Re-using
-//! the same session means the RTMP connection is never closed by starvation
-//! — only a real socket error reconnects. `push_flv_bytes` re-anchors
-//! timestamps across the repeated blob internally.
+//! short producer gap by re-pushing the LAST DELIVERED CHUNK (freeze frame).
+//!
+//! FREEZE-ONLY, codec-homogeneous: the keepalive must never push any bytes
+//! that were not produced by the live encoder. The RTMP pusher de-duplicates
+//! AVC sequence headers per session, so pushing the rescue clip (different
+//! SPS/PPS) onto a live session makes YouTube decode the real stream with
+//! the wrong codec config -> solid green video for the entire session
+//! (2026-06-11 streampp incident, KS-PP-TEST). If no chunk has been
+//! delivered yet there is NOTHING codec-safe to push: the consumer waits
+//! for the first real chunk instead of entering keepalive.
+//!
+//! Re-using the same session means the RTMP connection is never closed by
+//! starvation — only a real socket error reconnects. `push_flv_bytes`
+//! re-anchors timestamps across the repeated blob internally.
 #![allow(dead_code)]
 use std::sync::Arc;
 
@@ -11,40 +20,12 @@ use std::sync::Arc;
 /// below the 8s full-stall rescue threshold so the trickle regime (chunks
 /// arriving late but often) is covered, not just total outages.
 pub const FAST_KEEPALIVE_TRIGGER_SECS: u64 = 2;
-/// After this much continuous gap, switch the keepalive content from the
-/// frozen last chunk to the default rescue loop.
-pub const FAST_KEEPALIVE_RESCUE_AFTER_SECS: u64 = 10;
 
-/// Which content the keepalive is currently pushing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KeepaliveMode {
-    Freeze,
-    Rescue,
-}
-
-/// Pure decision: given how long the gap has lasted, what to push.
-pub fn keepalive_mode(gap_secs: u64, have_freeze: bool) -> KeepaliveMode {
-    if have_freeze && gap_secs < FAST_KEEPALIVE_RESCUE_AFTER_SECS {
-        KeepaliveMode::Freeze
-    } else {
-        KeepaliveMode::Rescue
-    }
-}
-
-/// Select the FLV bytes to push for a keepalive tick.
-pub fn keepalive_bytes<'a>(
-    mode: KeepaliveMode,
-    last_chunk: &'a Option<Arc<Vec<u8>>>,
-) -> std::borrow::Cow<'a, [u8]> {
-    match mode {
-        KeepaliveMode::Freeze => match last_chunk {
-            Some(b) => std::borrow::Cow::Borrowed(b.as_slice()),
-            None => std::borrow::Cow::Borrowed(crate::rescue_default::DEFAULT_RESCUE_FLV),
-        },
-        KeepaliveMode::Rescue => {
-            std::borrow::Cow::Borrowed(crate::rescue_default::DEFAULT_RESCUE_FLV)
-        }
-    }
+/// The bytes a keepalive tick may push: ONLY the last delivered chunk
+/// (same codec as the live stream). `None` when no chunk has been delivered
+/// yet on this session — the caller must NOT push anything in that case.
+pub fn keepalive_bytes(last_chunk: &Option<Arc<Vec<u8>>>) -> Option<&[u8]> {
+    last_chunk.as_ref().map(|a| a.as_slice())
 }
 
 #[cfg(test)]
@@ -52,24 +33,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn freeze_then_rescue_by_gap() {
-        assert_eq!(keepalive_mode(0, true), KeepaliveMode::Freeze);
-        assert_eq!(keepalive_mode(9, true), KeepaliveMode::Freeze);
-        assert_eq!(keepalive_mode(10, true), KeepaliveMode::Rescue);
-        assert_eq!(keepalive_mode(0, false), KeepaliveMode::Rescue);
-    }
-
-    #[test]
-    fn bytes_fall_back_to_default_when_no_freeze() {
+    fn bytes_none_when_no_chunk_delivered() {
         let none: Option<Arc<Vec<u8>>> = None;
-        let b = keepalive_bytes(KeepaliveMode::Freeze, &none);
-        assert_eq!(&*b, crate::rescue_default::DEFAULT_RESCUE_FLV);
+        assert!(
+            keepalive_bytes(&none).is_none(),
+            "no codec-safe bytes exist before the first chunk"
+        );
     }
 
     #[test]
-    fn freeze_uses_last_chunk_bytes() {
+    fn bytes_are_the_last_chunk() {
         let last = Some(Arc::new(vec![1u8, 2, 3]));
-        let b = keepalive_bytes(KeepaliveMode::Freeze, &last);
-        assert_eq!(&*b, &[1u8, 2, 3]);
+        assert_eq!(
+            keepalive_bytes(&last),
+            Some(&[1u8, 2, 3][..]),
+            "keepalive must push the last delivered chunk verbatim"
+        );
     }
 }

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -633,8 +633,8 @@ mod fast_upload_gap_regression {
 
         {
             let recorded = pushes.lock().unwrap();
-            // RED on current code: with last_chunk_bytes == None the old
-            // keepalive_mode returns Rescue from gap 0 and pushes
+            // RED on pre-fix code: with last_chunk_bytes == None the old
+            // mode logic selected rescue from gap 0 and pushed
             // DEFAULT_RESCUE_FLV repeatedly. Freeze-only forbids any push here.
             assert!(
                 recorded.is_empty(),

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -367,17 +367,26 @@ async fn test_controller_grow_makes_lag_jump_trail_edge() {
 }
 
 // ---------------------------------------------------------------------------
-// REGRESSION GATE (Task 6): fast endpoint survives an upload gap.
+// REGRESSION GATE: fast-endpoint keepalive is FREEZE-ONLY (codec-homogeneous).
 //
-// The core guarantee that shipped CI-green with NO test: when a fast endpoint
-// starves (producer stops delivering chunks), the keepalive loop must
+// The core guarantee: when a fast endpoint starves (producer stops delivering
+// chunks), the keepalive loop must
 //   1. NEVER close the connection (no teardown on starvation),
-//   2. keep pushing frames during the gap — first FREEZE (last chunk bytes),
-//      then RESCUE (default FLV) once the gap exceeds FAST_KEEPALIVE_RESCUE_
-//      AFTER_SECS (10s), and
+//   2. keep pushing frames during the gap — but ONLY the last delivered chunk
+//      (freeze frame), NEVER the default rescue FLV, no matter how long the
+//      gap lasts, and
 //   3. resume the real chunk the moment one arrives.
 //
-// This locks `keepalive_until_chunk`'s freeze->rescue transition and its
+// Why freeze-only: the RTMP pusher de-duplicates AVC sequence headers per
+// session. Pushing the rescue clip (different SPS/PPS) onto a LIVE session
+// makes YouTube decode the real stream with the wrong codec config -> solid
+// green video for the entire session (2026-06-11 streampp incident,
+// KS-PP-TEST). The keepalive must therefore push ONLY codec-homogeneous bytes
+// (the last real chunk). If no chunk has been delivered yet there is nothing
+// codec-safe to push: keepalive must push NOTHING and just wait (covered by
+// `keepalive_without_first_chunk_pushes_nothing` below).
+//
+// This locks `keepalive_until_chunk`'s freeze-only contract and its
 // never-close contract against regression. Without this test, upload jitter
 // against a fast endpoint had zero coverage.
 // ---------------------------------------------------------------------------
@@ -495,23 +504,39 @@ mod fast_upload_gap_regression {
             );
             assert!(
                 recorded.contains(&FREEZE_LEN),
-                "during the freeze window keepalive must push the last chunk bytes \
+                "during the gap keepalive must push the last chunk bytes \
                  (len {FREEZE_LEN}); recorded lengths: {recorded:?}"
+            );
+            // FREEZE-ONLY invariant: every push so far is the freeze chunk.
+            assert!(
+                recorded.iter().all(|&l| l == FREEZE_LEN),
+                "keepalive must push ONLY the freeze chunk (len {FREEZE_LEN}); \
+                 found foreign byte-lengths (codec-corruption regression: green \
+                 video): {recorded:?}"
             );
         }
 
-        // Phase 2 — cross the 10s rescue threshold. Advance another ~9s so the
-        // cumulative gap exceeds FAST_KEEPALIVE_RESCUE_AFTER_SECS (10s) and the
-        // content switches to the default rescue FLV.
+        // Phase 2 — keep the gap open WELL past the old 10s rescue threshold.
+        // The keepalive must STILL push only the freeze chunk: a long gap is a
+        // frozen picture, never the codec-foreign rescue clip.
         advance_in_steps(Duration::from_millis(200), 50).await; // +~10s → ~13s total
 
         {
             let recorded = pushes.lock().unwrap();
             let rescue_len = DEFAULT_RESCUE_FLV.len();
+            // RED on current code: after 10s the freeze→rescue switch pushes
+            // DEFAULT_RESCUE_FLV (rescue_len) onto the live session. Freeze-only
+            // forbids any codec-foreign bytes for the WHOLE gap.
             assert!(
-                recorded.contains(&rescue_len),
-                "after 10s gap keepalive must switch to the rescue FLV \
-                 (len {rescue_len}); recorded lengths: {recorded:?}"
+                !recorded.contains(&rescue_len),
+                "keepalive must NEVER push the rescue FLV (len {rescue_len}) on a \
+                 live session — it corrupts the codec config (green video). \
+                 recorded lengths: {recorded:?}"
+            );
+            assert!(
+                recorded.iter().all(|&l| l == FREEZE_LEN),
+                "keepalive must push ONLY the freeze chunk (len {FREEZE_LEN}) for \
+                 the entire gap, no matter how long; recorded lengths: {recorded:?}"
             );
         }
 
@@ -553,11 +578,99 @@ mod fast_upload_gap_regression {
         // Final guarantees recap:
         // - never closed: asserted above.
         // - frames emitted during gap: asserted above (non-empty).
-        // - freeze AND rescue both observed: asserted above.
+        // - ONLY freeze observed, never rescue: asserted above.
         // - real chunk resumed: chunk_id == 99 asserted above.
         assert!(
             !closed.load(Ordering::SeqCst),
             "connection still must not be closed after the chunk resumed"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_without_first_chunk_pushes_nothing() {
+        // No real chunk has been delivered yet on this session
+        // (`last_chunk_bytes == None`). There is NOTHING codec-safe to push —
+        // pushing the rescue clip here is exactly the bug that locks YouTube
+        // onto the wrong SPS/PPS (green video). Keepalive must push NOTHING and
+        // simply wait for the first real chunk, then return it.
+        let pushes = Arc::new(Mutex::new(Vec::<usize>::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let mut pusher = RecordingPusher {
+            pushes: Arc::clone(&pushes),
+            closed: Arc::clone(&closed),
+        };
+
+        let (tx, mut rx) = mpsc::channel::<PrefetchedChunk>(10);
+        let (_stop_tx, mut stop_rx) = watch::channel(false);
+
+        // The crux: no chunk delivered yet.
+        let none: Option<Arc<Vec<u8>>> = None;
+        let audit_ring: Option<Arc<crate::audit_ring::AuditRing>> = None;
+
+        let stats: crate::endpoint_stats::Stats = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::endpoint_stats::EndpointStats::default(),
+        ));
+        let stats_task = stats.clone();
+        let buffer_state = Arc::new(crate::buffer_state::BufferState::new());
+        let buffer_state_task = buffer_state.clone();
+        let task = tokio::spawn(async move {
+            keepalive_until_chunk(
+                &mut pusher,
+                &mut rx,
+                &none,
+                "fast-test-nofirst",
+                &audit_ring,
+                &mut stop_rx,
+                &stats_task,
+                &buffer_state_task,
+            )
+            .await
+        });
+
+        // Hold the gap open well past the old 10s rescue threshold. With no
+        // first chunk, NOTHING may be pushed during this entire window.
+        advance_in_steps(Duration::from_millis(200), 80).await; // ~16s
+
+        {
+            let recorded = pushes.lock().unwrap();
+            // RED on current code: with last_chunk_bytes == None the old
+            // keepalive_mode returns Rescue from gap 0 and pushes
+            // DEFAULT_RESCUE_FLV repeatedly. Freeze-only forbids any push here.
+            assert!(
+                recorded.is_empty(),
+                "keepalive must push NOTHING before the first real chunk \
+                 (no codec-safe bytes exist yet); recorded lengths: {recorded:?}"
+            );
+        }
+
+        // First real chunk arrives — keepalive must return it.
+        tx.send(PrefetchedChunk {
+            chunk_id: 7,
+            data: vec![9, 9, 9],
+            duration_ms: 2000,
+        })
+        .await
+        .expect("send first chunk");
+        advance_in_steps(Duration::from_millis(50), 4).await;
+
+        let returned = task.await.expect("keepalive task panicked");
+        let chunk = returned.expect("keepalive must return the first real chunk, got None");
+        assert_eq!(
+            chunk.chunk_id, 7,
+            "keepalive must return the first real chunk (id 7) once one arrives"
+        );
+
+        // Still NOTHING pushed even after the chunk arrived — keepalive was a
+        // pure wait, no codec-foreign bytes on the wire.
+        assert!(
+            pushes.lock().unwrap().is_empty(),
+            "keepalive must never push when no chunk was ever delivered"
+        );
+
+        // Never closed the connection while waiting.
+        assert!(
+            !closed.load(Ordering::SeqCst),
+            "keepalive must NOT close the connection while waiting for the first chunk"
         );
     }
 

--- a/docs/superpowers/specs/2026-06-10-delivery-binary-lockstep-design.md
+++ b/docs/superpowers/specs/2026-06-10-delivery-binary-lockstep-design.md
@@ -126,3 +126,29 @@ controller:
 - Post-merge: next streampp event — audit log must show
   `delivery_binary_version` match row; if the bucket is ever stale again the
   event start FAILS LOUDLY instead of silently streaming a broken fast stream.
+
+## Revision 2026-06-11 — versioned immutable keys
+
+The mutable-key + sidecar design (Components 3 & 4 above) raced across
+concurrent CI runs. On 2026-06-11 `main` (building 0.22.7) and `dev` (building
+0.22.8) both uploaded to the single `rs-delivery` key + `rs-delivery.version`
+sidecar; last writer won. The deployed 0.22.7 client then read sidecar=0.22.8,
+tried to fetch the GitHub release `restreamer-v0.22.7` (which does not exist
+before the pre-release tag), and delivery start failed. A shared mutable object
+can never be made race-safe.
+
+**Fix:** the key name pins the version. Each build uploads its own immutable
+object `rs-delivery-{version}` (`delivery_binary::binary_key`); the client of a
+build requests EXACTLY `rs-delivery-{client_version}`. Disjoint keys ⇒
+concurrent builds/versions can never interfere — there is no comparison and no
+re-upload of a shared object. The pre-create check becomes a single anonymous
+HEAD of the versioned key (present → proceed; absent → download + verify +
+upload the versioned object).
+
+The mutable `rs-delivery` key and the `rs-delivery.version` sidecar are now
+written by CI **only** as a legacy-transition artifact for clients <=0.22.7
+still deployed (they still read the old path). They are removed once every box
+runs >=0.22.8 — tracked in #246. The orchestrator no longer reads them.
+
+The post-boot version gate (Component 2) is unchanged: it still parses
+`/api/health` `version` and aborts on mismatch.

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.22.7"
+version = "0.22.8"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.22.7"
+version = "0.22.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Two fixes bundled (both small, independent, per bundling gate)

### 1. Race elimination (2026-06-11 morning incident)
Concurrent main+dev CI runs raced on (a) the single mutable `rs-delivery` S3 key + sidecar from #245 and (b) deploys/E2E on the single stream.lan box — BOTH runs failed. Fixes:
- **Versioned immutable binary keys** (`rs-delivery-{version}`): key name pins the version; concurrent versions cannot interfere. Sidecar/mutable key kept only as CI-written legacy artifacts for ≤0.22.7 clients (removal: #246).
- **Cross-run CI serialization**: all 4 stream.lan jobs share the `stream-lan-box` concurrency group with **`queue: max`** (review-critical fix: default single-pending-slot semantics would cancel an older run's pending E2E sibling) + `cancel-in-progress: false` → later runs queue FIFO, never race.
- Push-discipline + stop-conflicting-run-first procedure documented in CLAUDE.md.

### 2. Freeze-only keepalive — fixes the GREEN VIDEO on the fast endpoint (2026-06-11 evening incident)
The v0.22.7 keepalive pushed `DEFAULT_RESCUE_FLV` on the LIVE RTMP session when no chunk was ready within the 2s trigger — at every delivery start on a jittery box (audit: `fast_keepalive_started{mode:"rescue"}` ~0.3s after init, every start on streampp). The rescue clip becomes the first content on the fresh session → YouTube locks its codec config; the pusher de-duplicates sequence headers (`tags_skipped=2`) → the real stream decodes with the wrong SPS/PPS → **solid green video all session** while every health metric stays good. Fix:
- Keepalive may only re-push the **last real chunk** (codec-homogeneous freeze). Never the rescue clip.
- No chunk delivered yet → pure wait (no pushes) until the first real chunk.
- 10s freeze→rescue switch removed (long gap = frozen picture, correct UX).
- RED→GREEN: `02e78105` (assertions fail on old behavior by inspection; not executed locally per no-local-builds) → `5801964a`.

Filed: #248 (one-correct-upgrade-path SOTA design — `www` frontend drift found same day), #249 (CI never verifies the actual YouTube PICTURE — this class is metric-invisible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)