### PR TITLE
fix(inpoint): re-anchor audio+video onto a shared session epoch on OBS republish (#255)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rs-api"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rs-cloud"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rs-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-delivery"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "rs-endpoint"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "rs-ffmpeg"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "rs-inpoint"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "env_logger 0.11.10",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "rs-rtmp-push"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "rs-runtime"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "rs-service"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rs-youtube"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-inpoint/src/flv_chunker.rs
+++ b/crates/rs-inpoint/src/flv_chunker.rs
@@ -322,6 +322,16 @@ impl FlvChunkSink {
         }
     }
 
+    /// Start a new ingest session at an OBS mid-stream republish boundary.
+    ///
+    /// RED placeholder (#255): currently only flushes the partial chunk —
+    /// this reproduces the production republish behaviour (UnPublish calls
+    /// `flush()`, nothing re-anchors). The GREEN commit re-zeros the shared
+    /// per-session epoch here.
+    pub async fn start_new_session(&self) {
+        self.flush().await;
+    }
+
     /// Reset the chunker state.
     ///
     /// Resets the session wall-clock anchor so timestamps restart from 0

--- a/crates/rs-inpoint/src/flv_chunker.rs
+++ b/crates/rs-inpoint/src/flv_chunker.rs
@@ -66,6 +66,18 @@ struct FlvChunkSinkInner {
     /// Highest output timestamp emitted in the current session. Enforces
     /// monotonic stamping under OS clock skew or wall-clock anomalies.
     last_session_ts: u32,
+    /// xiu RTMP timestamp of the first audio tag of the current session.
+    /// Audio output ts = `xiu_ts - audio_session_origin_xiu`, putting audio on
+    /// the SAME 0-based per-session epoch as video (which restarts at 0 via
+    /// `current_session_ts`). `None` until the first audio tag of a session;
+    /// re-captured on `start_new_session()` or a backward-jump self-heal (#255).
+    /// Preserves the #142 chipmunk fix: the inter-tag deltas (xiu cadence) are
+    /// untouched, only the per-session offset is removed.
+    audio_session_origin_xiu: Option<u32>,
+    /// Last raw xiu audio ts seen — used to detect a backward jump (a missed
+    /// republish) so the audio epoch can self-heal even if `start_new_session()`
+    /// was never called (#255).
+    last_audio_xiu_ts: Option<u32>,
 }
 
 /// Data extracted from the buffer, ready to be written to disk outside the lock.
@@ -98,6 +110,8 @@ impl FlvChunkSink {
                 chunk_first_wall_clock_ms: 0,
                 session_start_wall_clock_ms: 0,
                 last_session_ts: 0,
+                audio_session_origin_xiu: None,
+                last_audio_xiu_ts: None,
             }),
             chunk_tx,
             pending_writes: Arc::new(AtomicU32::new(0)),
@@ -122,6 +136,8 @@ impl FlvChunkSink {
                 chunk_first_wall_clock_ms: 0,
                 session_start_wall_clock_ms: 0,
                 last_session_ts: 0,
+                audio_session_origin_xiu: None,
+                last_audio_xiu_ts: None,
             }),
             chunk_tx,
             pending_writes: Arc::new(AtomicU32::new(0)),
@@ -250,14 +266,17 @@ impl FlvChunkSink {
     /// Process an audio frame from xiu's FrameData::Audio.
     ///
     /// `timestamp` is the xiu-forwarded RTMP timestamp (in milliseconds).
-    /// Audio uses xiu timestamps directly — unlike video, which is rewritten
-    /// to wall-clock to fix #135 cache drift. AAC frames are 1024 samples;
-    /// cadence = 1024 / sample_rate seconds (e.g. 21.3 ms at 48 kHz, 23.2 ms
-    /// at 44.1 kHz), so the producer cannot drift. Wall-clock stamping would
-    /// inject RTMP delivery jitter into PTS, causing decoder resampling
-    /// artefacts (chipmunk pitch + glitches).
+    /// Audio is stamped on the SAME 0-based per-session epoch as video
+    /// (`audio_out = xiu_ts - audio_session_origin_xiu`) — unlike video, which
+    /// derives its session ts from wall-clock to fix #135 cache drift. Audio
+    /// keeps the xiu inter-tag DELTAS (AAC cadence: 1024 samples => 21.3 ms at
+    /// 48 kHz, 23.2 ms at 44.1 kHz, drift-free) and only removes the constant
+    /// per-session offset. This preserves the #142 chipmunk fix (no wall-clock
+    /// jitter in PTS, no resampling artefacts) while keeping audio aligned with
+    /// video across an OBS mid-stream republish (#255) — both restart at 0 on
+    /// each new session.
     ///
-    /// Internally, this function writes the xiu timestamp into the FLV tag
+    /// Internally, this function writes the re-based timestamp into the FLV tag
     /// only — it must NOT touch `chunk_last_ts`, which is an accounting
     /// field owned by `write_video` for tracking wall-clock chunk duration.
     /// Mixing the two domains causes `duration_ms` to underflow and produce
@@ -284,14 +303,44 @@ impl FlvChunkSink {
                 return;
             }
 
-            // Audio FLV tags carry the xiu RTMP timestamp directly so the
-            // decoder gets correct PTS (chipmunk fix from #142). The
-            // chunk_last_ts field is owned by write_video — it tracks the
-            // wall-clock span used for chunk-duration accounting. The two
-            // timestamp domains MUST NOT cross: writing the xiu value into
-            // chunk_last_ts here corrupts the duration computation
-            // (#146 follow-up regression).
-            Self::write_tag(&mut inner, FLV_TAG_AUDIO, timestamp, data);
+            // Defensive self-heal (#255): if the incoming xiu ts jumps backward
+            // vs the last audio ts we saw, an OBS republish happened without a
+            // start_new_session() re-anchor reaching us. Re-capture the audio
+            // origin so audio re-zeroes with the (also-restarting) video epoch
+            // instead of baking the dead-air gap into the A/V skew. Mirrors the
+            // pusher-side guard (pusher.rs).
+            if let Some(prev) = inner.last_audio_xiu_ts {
+                if timestamp < prev {
+                    let old_origin = inner.audio_session_origin_xiu;
+                    inner.audio_session_origin_xiu = Some(timestamp);
+                    tracing::warn!(
+                        prev_xiu_ts = prev,
+                        new_xiu_ts = timestamp,
+                        old_origin = ?old_origin,
+                        "flv_chunker: AUDIO xiu ts jumped backward -- self-healing audio session origin to new ts (#255)"
+                    );
+                }
+            }
+            inner.last_audio_xiu_ts = Some(timestamp);
+
+            // Capture the per-session audio origin on the first real audio tag
+            // of the session (set to None by new()/start_new_session()).
+            let origin = *inner.audio_session_origin_xiu.get_or_insert(timestamp);
+
+            // Re-base audio onto the shared 0-based session epoch:
+            //   audio_out = xiu_ts - origin
+            // Video already restarts at 0 each session via current_session_ts,
+            // so both tracks share one 0-based epoch and stay aligned across an
+            // OBS republish (#255). This PRESERVES the #142 chipmunk fix: only
+            // the constant per-session offset is removed, the inter-tag deltas
+            // (xiu AAC cadence) are untouched, so PTS still carries correct
+            // sample timing (no wall-clock jitter, no resampling artefacts).
+            //
+            // chunk_last_ts is owned by write_video (wall-clock span for
+            // chunk-duration accounting) and MUST NOT be touched here — mixing
+            // the domains underflows duration_ms (#146).
+            let audio_out = timestamp.saturating_sub(origin);
+            Self::write_tag(&mut inner, FLV_TAG_AUDIO, audio_out, data);
             None
         };
 
@@ -324,12 +373,42 @@ impl FlvChunkSink {
 
     /// Start a new ingest session at an OBS mid-stream republish boundary.
     ///
-    /// RED placeholder (#255): currently only flushes the partial chunk —
-    /// this reproduces the production republish behaviour (UnPublish calls
-    /// `flush()`, nothing re-anchors). The GREEN commit re-zeros the shared
-    /// per-session epoch here.
+    /// Flushes the partial chunk FIRST, then re-zeros the shared per-session
+    /// epoch for BOTH tracks so the next session restarts video and audio at a
+    /// common 0 — fixing the ~25.5s A/V skew that was baked into the chunk bytes
+    /// after each OBS restart at live event 9315 (#255). Video re-zeroes via
+    /// `session_start_wall_clock_ms = 0` (next `current_session_ts` returns 0);
+    /// audio re-zeroes via `audio_session_origin_xiu = None` (next audio tag
+    /// captures the new origin).
+    ///
+    /// Deliberately does NOT clear `chunk_index` (chunk numbering must stay
+    /// monotonic across republishes) or the saved `video_sequence_header` /
+    /// `audio_sequence_header` (the next chunk must remain independently
+    /// playable). This is distinct from `reset()`, which is the full-disconnect
+    /// teardown.
     pub async fn start_new_session(&self) {
+        // Flush the partial chunk on the OLD epoch before re-anchoring.
         self.flush().await;
+
+        let mut inner = self.inner.lock().await;
+        let old_anchor = inner.session_start_wall_clock_ms;
+        let old_audio_origin = inner.audio_session_origin_xiu;
+        // Re-zero the per-session epoch fields for both domains. Keep
+        // chunk_index and the saved sequence headers.
+        inner.chunk_start = None;
+        inner.chunk_first_ts = 0;
+        inner.chunk_last_ts = 0;
+        inner.chunk_first_wall_clock_ms = 0;
+        inner.session_start_wall_clock_ms = 0;
+        inner.last_session_ts = 0;
+        inner.audio_session_origin_xiu = None;
+        inner.last_audio_xiu_ts = None;
+        info!(
+            chunk_index = inner.chunk_index,
+            old_video_anchor_ms = old_anchor,
+            old_audio_origin_xiu = ?old_audio_origin,
+            "flv_chunker: start_new_session -- re-anchored audio+video to a shared 0 epoch on republish (#255)"
+        );
     }
 
     /// Reset the chunker state.
@@ -346,6 +425,8 @@ impl FlvChunkSink {
         inner.chunk_first_wall_clock_ms = 0;
         inner.session_start_wall_clock_ms = 0;
         inner.last_session_ts = 0;
+        inner.audio_session_origin_xiu = None;
+        inner.last_audio_xiu_ts = None;
     }
 
     /// Get the total number of chunks produced.

--- a/crates/rs-inpoint/src/flv_chunker.rs
+++ b/crates/rs-inpoint/src/flv_chunker.rs
@@ -662,6 +662,8 @@ impl FlvChunkSinkInner {
             chunk_first_wall_clock_ms: 0,
             session_start_wall_clock_ms: 0,
             last_session_ts: 0,
+            audio_session_origin_xiu: None,
+            last_audio_xiu_ts: None,
         }
     }
 }

--- a/crates/rs-inpoint/src/flv_chunker_tests.rs
+++ b/crates/rs-inpoint/src/flv_chunker_tests.rs
@@ -37,6 +37,36 @@ fn first_flv_audio_timestamp_with_marker(bytes: &[u8], marker: &[u8]) -> Option<
     None
 }
 
+/// Find the first FLV tag of `tag_type` whose body begins with `marker` and
+/// return its 32-bit timestamp. Generalises
+/// `first_flv_audio_timestamp_with_marker` to any tag type so tests can read
+/// the video-tag timestamp written into the actual FLV byte stream.
+fn first_flv_tag_timestamp(bytes: &[u8], tag_type: u8, marker: &[u8]) -> Option<u32> {
+    // FLV header is 9 bytes + 4 bytes "previous tag size 0" trailer.
+    let mut offset = 9 + 4;
+    while offset + 11 <= bytes.len() {
+        let this_type = bytes[offset];
+        let data_size = ((bytes[offset + 1] as u32) << 16)
+            | ((bytes[offset + 2] as u32) << 8)
+            | (bytes[offset + 3] as u32);
+        let ts_low = ((bytes[offset + 4] as u32) << 16)
+            | ((bytes[offset + 5] as u32) << 8)
+            | (bytes[offset + 6] as u32);
+        let ts_high = bytes[offset + 7] as u32;
+        let ts = (ts_high << 24) | ts_low;
+        let body_start = offset + 11;
+        let body_end = body_start + data_size as usize;
+        if this_type == tag_type
+            && body_end <= bytes.len()
+            && bytes[body_start..].starts_with(marker)
+        {
+            return Some(ts);
+        }
+        offset = body_end + 4; // skip body + 4-byte previous-tag-size trailer
+    }
+    None
+}
+
 #[tokio::test]
 async fn null_sink_discards_data() {
     let sink = FlvChunkSink::new_null();
@@ -396,4 +426,146 @@ async fn audio_flv_tag_carries_xiu_timestamp() {
         Some(42),
         "audio FLV tag must carry xiu timestamp 42 in the byte stream"
     );
+}
+
+/// REGRESSION (#255): On an OBS mid-stream unpublish->republish the FLV
+/// chunker must re-anchor BOTH audio and video onto a single 0-based session
+/// epoch. Pre-fix, video kept counting on its never-reset wall-clock anchor
+/// (~600ms into session 1) while audio restarted from raw xiu ts ~0 on the
+/// fresh session -> ~600ms (in production ~25.5s) audio-behind-video skew
+/// baked into the session-2 chunk bytes.
+///
+/// Session 1: write seq headers + keyframe, then interleave audio while
+/// ~600ms of wall-clock elapses (video `current_session_ts` advances). flush.
+/// `start_new_session()` (the republish boundary).
+/// Session 2: keyframe + audio at xiu ts 0/21/43. Read the session-2 chunk
+/// and assert the first real video tag and first real audio tag are within
+/// 100ms of each other. RED pre-fix (skew ~600ms); GREEN after re-anchor.
+#[tokio::test]
+async fn republish_keeps_audio_and_video_aligned() {
+    let dir = tempfile::tempdir().unwrap();
+    let sink = Arc::new(FlvChunkSink::new(
+        dir.path().to_path_buf(),
+        Duration::from_secs(60),
+    ));
+    let mut rx = sink.subscribe();
+
+    // --- Session 1 ---
+    let video_seq = BytesMut::from(&[0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x64][..]);
+    sink.write_video(0, &video_seq).await;
+    let audio_seq = BytesMut::from(&[0xAF, 0x00, 0x12, 0x10][..]);
+    sink.write_audio(0, &audio_seq).await;
+
+    // First keyframe anchors the session wall-clock and starts chunk #0.
+    let keyframe = BytesMut::from(&[0x17, 0x01, 0x00, 0x00, 0x00, 0xAA, 0xBB][..]);
+    sink.write_video(0, &keyframe).await;
+
+    // Interleave audio (xiu cadence) while ~600ms of wall-clock passes so the
+    // video session timestamp advances well past 100ms.
+    let aac_s1 = BytesMut::from(&[0xAF, 0x01, 0x11, 0x11][..]);
+    for i in 0..6u32 {
+        sink.write_audio(i * 21, &aac_s1).await;
+        let interframe = BytesMut::from(&[0x27, 0x01, 0x00, 0x00, 0x00, 0xBB][..]);
+        sink.write_video(0, &interframe).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    sink.flush().await;
+
+    // Drain the session-1 chunk so the next recv() is the session-2 chunk.
+    let _ = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .expect("session-1 chunk should flush")
+        .expect("recv should succeed");
+
+    // --- Republish boundary ---
+    sink.start_new_session().await;
+
+    // --- Session 2 --- fresh xiu epoch (audio restarts near 0).
+    // First keyframe of the new session, with a recognizable marker so the
+    // tag finder can locate the first REAL video tag (not the seq header).
+    let keyframe2 = BytesMut::from(&[0x17, 0x01, 0x00, 0x00, 0x00, 0xCC, 0xDD][..]);
+    sink.write_video(0, &keyframe2).await;
+
+    // Audio frames on the fresh session at xiu ts 0, 21, 43.
+    let aac_s2 = BytesMut::from(&[0xAF, 0x01, 0x22, 0x22][..]);
+    sink.write_audio(0, &aac_s2).await;
+    sink.write_audio(21, &aac_s2).await;
+    sink.write_audio(43, &aac_s2).await;
+
+    sink.flush().await;
+
+    let chunk = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .expect("session-2 chunk should flush")
+        .expect("recv should succeed");
+
+    let bytes = std::fs::read(&chunk.path).unwrap();
+
+    // First REAL video tag (the 0xCC,0xDD keyframe) and first REAL audio tag
+    // (0x22,0x22 payload) of session 2.
+    let video_ts = first_flv_tag_timestamp(
+        &bytes,
+        FLV_TAG_VIDEO,
+        &[0x17, 0x01, 0x00, 0x00, 0x00, 0xCC, 0xDD],
+    )
+    .expect("session-2 video tag must be present");
+    let audio_ts = first_flv_audio_timestamp_with_marker(&bytes, &[0xAF, 0x01, 0x22, 0x22])
+        .expect("session-2 audio tag must be present");
+
+    let skew = (video_ts as i64 - audio_ts as i64).abs();
+    assert!(
+        skew < 100,
+        "after republish, A/V skew must be <100ms; got video_ts={video_ts} audio_ts={audio_ts} skew={skew}ms"
+    );
+}
+
+/// `start_new_session()` re-anchors the per-session epoch but MUST preserve
+/// the running chunk numbering and the saved codec sequence headers, so the
+/// next chunk stays independently playable and chunk indices never reset.
+#[tokio::test]
+async fn start_new_session_preserves_chunk_index_and_sequence_headers() {
+    let dir = tempfile::tempdir().unwrap();
+    let sink = Arc::new(FlvChunkSink::new(
+        dir.path().to_path_buf(),
+        Duration::from_secs(60),
+    ));
+
+    // Seed sequence headers + a keyframe + flush to advance chunk_index to 1.
+    let video_seq = BytesMut::from(&[0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x64][..]);
+    sink.write_video(0, &video_seq).await;
+    let audio_seq = BytesMut::from(&[0xAF, 0x00, 0x12, 0x10][..]);
+    sink.write_audio(0, &audio_seq).await;
+    let keyframe = BytesMut::from(&[0x17, 0x01, 0x00, 0x00, 0x00, 0xAA, 0xBB][..]);
+    sink.write_video(0, &keyframe).await;
+    sink.flush().await;
+
+    let index_before = sink.chunk_count().await;
+    assert_eq!(index_before, 1, "one chunk should have been produced");
+
+    sink.start_new_session().await;
+
+    // chunk_index preserved (NOT reset to 0).
+    assert_eq!(
+        sink.chunk_count().await,
+        index_before,
+        "start_new_session() must not reset chunk_index"
+    );
+
+    // Saved sequence headers preserved (so next chunk is independently playable).
+    {
+        let inner = sink.inner.lock().await;
+        assert!(
+            inner.video_sequence_header.is_some(),
+            "start_new_session() must keep the saved video sequence header"
+        );
+        assert!(
+            inner.audio_sequence_header.is_some(),
+            "start_new_session() must keep the saved audio sequence header"
+        );
+        // But the per-session epoch IS re-zeroed.
+        assert_eq!(
+            inner.session_start_wall_clock_ms, 0,
+            "start_new_session() must re-zero the wall-clock anchor"
+        );
+    }
 }

--- a/crates/rs-inpoint/src/flv_chunker_tests.rs
+++ b/crates/rs-inpoint/src/flv_chunker_tests.rs
@@ -384,12 +384,21 @@ async fn chunk_duration_tracks_video_wall_span_not_audio_xiu_ts() {
     );
 }
 
-/// Audio FLV tags must still carry the xiu RTMP timestamp in the FLV
-/// byte stream (PR #142 chipmunk fix preserved). This is the user-facing
-/// guarantee -- chunk_last_ts is an internal accounting variable that
-/// MUST NOT be confused with what gets written into the audio tag.
+/// Audio FLV tags carry the xiu RTMP timestamp DELTAS (chipmunk fix #142
+/// preserved) re-based onto the 0-based per-session epoch (#255). The
+/// user-facing guarantee is that audio PTS keeps the drift-free AAC cadence
+/// (inter-tag deltas), aligned with the also-0-based video epoch — NOT that
+/// the absolute xiu offset survives.
+///
+/// BEHAVIOUR CHANGE (#255): pre-fix audio carried the RAW xiu ts (first tag at
+/// xiu 42 -> tag ts 42); now audio is session-relative (first tag captures the
+/// session origin -> tag ts 0, the next tag carries its delta). This is the
+/// deliberate fix: after an OBS republish the new session's audio xiu restarts
+/// near 0 while video also restarts at 0, so audio MUST be offset-removed to
+/// stay aligned. The chipmunk fix is fully preserved because only the constant
+/// per-session offset is removed — the inter-tag deltas are byte-identical.
 #[tokio::test]
-async fn audio_flv_tag_carries_xiu_timestamp() {
+async fn audio_flv_tag_is_session_relative_and_preserves_xiu_deltas() {
     let dir = tempfile::tempdir().unwrap();
     let sink = Arc::new(FlvChunkSink::new(
         dir.path().to_path_buf(),
@@ -405,9 +414,12 @@ async fn audio_flv_tag_carries_xiu_timestamp() {
     let keyframe = BytesMut::from(&[0x17, 0x01, 0x00, 0x00, 0x00, 0xAA, 0xBB][..]);
     sink.write_video(0, &keyframe).await;
 
-    // AAC payload tag with xiu timestamp 42.
-    let aac = BytesMut::from(&[0xAF, 0x01, 0xDE, 0xAD][..]);
-    sink.write_audio(42, &aac).await;
+    // Two AAC payload tags at xiu 42 and 63 (delta 21ms = one 48kHz AAC frame).
+    // Distinct body markers so each can be located independently.
+    let aac_first = BytesMut::from(&[0xAF, 0x01, 0xDE, 0xAD][..]);
+    let aac_second = BytesMut::from(&[0xAF, 0x01, 0xBE, 0xEF][..]);
+    sink.write_audio(42, &aac_first).await;
+    sink.write_audio(63, &aac_second).await;
 
     sink.flush().await;
 
@@ -418,13 +430,20 @@ async fn audio_flv_tag_carries_xiu_timestamp() {
 
     let bytes = std::fs::read(&chunk.path).unwrap();
 
-    // The audio sequence header has body 0xAF 0x00; the AAC payload tag we
-    // wrote has body 0xAF 0x01. Match on the latter to skip the seq header.
-    let ts = first_flv_audio_timestamp_with_marker(&bytes, &[0xAF, 0x01]);
+    // First real audio tag (xiu 42) captures the session origin -> ts 0.
+    let ts_first = first_flv_audio_timestamp_with_marker(&bytes, &[0xAF, 0x01, 0xDE, 0xAD]);
     assert_eq!(
-        ts,
-        Some(42),
-        "audio FLV tag must carry xiu timestamp 42 in the byte stream"
+        ts_first,
+        Some(0),
+        "first audio tag of the session must re-zero to the session epoch"
+    );
+
+    // Second tag (xiu 63) keeps the xiu delta (63 - 42 = 21) -> chipmunk fix.
+    let ts_second = first_flv_audio_timestamp_with_marker(&bytes, &[0xAF, 0x01, 0xBE, 0xEF]);
+    assert_eq!(
+        ts_second,
+        Some(21),
+        "audio FLV tag must preserve the xiu inter-tag delta (chipmunk fix #142)"
     );
 }
 

--- a/crates/rs-inpoint/src/media_receiver.rs
+++ b/crates/rs-inpoint/src/media_receiver.rs
@@ -71,6 +71,14 @@ impl MediaReceiver {
                     BroadcastEvent::Publish { identifier } => {
                         info!("Stream published: {identifier}");
                         self.inpoint_state.mark_connected().await;
+                        // Re-anchor audio+video onto a fresh shared 0-based
+                        // session epoch on every (re)publish. The xiu server
+                        // stays up across an OBS mid-stream restart, so Publish
+                        // is the reliable per-session boundary; without this the
+                        // video wall-clock keeps counting the dead-air gap while
+                        // audio xiu restarts ~0, baking A/V skew into the chunks
+                        // (#255 — event 9315 had ~25.5s audio-behind-video).
+                        self.flv_chunk_sink.start_new_session().await;
                         // Audit: RtmpConnected.
                         if let Some(tx) = self.inpoint_state.audit_tx() {
                             rs_core::audit::record(

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Fixes the live-event A/V desync after a mid-stream OBS restart (event 9315 "Koncert vonku", 2026-06-19 — operator: "obraz a zvuk sa úplne rozišiel", ~25.5s audio-behind-video baked into the chunk bytes).

## Root cause
The FLV chunker stamped **video from a never-reset wall-clock anchor** (`current_session_ts`) and **audio from raw xiu RTMP ts**. The only re-anchor `reset()` was dead in production (tests only) — production called only `flush()` on unpublish. On an OBS unpublish→republish, xiu audio restarts ~0 while the video wall-clock keeps counting straight through the dead-air gap → cumulative audio-behind-video skew.

## Fix
- New `FlvChunkSink::start_new_session()`: flush the partial chunk, then re-zero the shared per-session epoch for **both** tracks (video via `session_start_wall_clock_ms=0`, audio via `audio_session_origin_xiu=None`) **without** clearing `chunk_index` or saved sequence headers.
- `write_audio` re-bases onto the session epoch (`audio_out = xiu_ts - audio_session_origin_xiu`) — shares the 0-based epoch with video, **preserving the #142 chipmunk fix** (only the constant offset removed; inter-tag deltas untouched).
- Wired `start_new_session()` into the `media_receiver` **Publish** boundary (xiu server stays up across an OBS restart → Publish is the reliable per-session signal).
- Defensive self-heal in `write_audio`: re-capture the audio origin on a backward xiu jump (a missed republish), mirroring the pusher-side guard.
- Comprehensive logging on the re-anchor decision (session #, old anchor, old audio origin) and the backward-jump self-heal — this path runs unattended during a live event.

## RED → GREEN regression test
`flv_chunker_tests.rs::republish_keeps_audio_and_video_aligned`:
- RED (test commit 6e664a4b): `start_new_session()` shipped as a flush-only placeholder mirroring production republish behaviour (no re-anchor) → session-2 chunk has ~600ms A/V skew → fails the `<100ms` assertion.
- GREEN (fix commit 5a091917): `start_new_session()` re-anchors → skew ~0 → passes.

Second test `start_new_session_preserves_chunk_index_and_sequence_headers` locks the chunk-numbering + sequence-header preservation.

## Notes
- `audio_flv_tag_carries_xiu_timestamp` → renamed `audio_flv_tag_is_session_relative_and_preserves_xiu_deltas`: deliberate, documented behavior change (audio is now session-relative; deltas preserved). Justified in the test doc + GREEN commit message.

Closes #255