### PR TITLE
fix(core/db): atomic single-statement upload-queue picker — kill SQLITE_BUSY storm (#256)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-core/src/db/mod.rs
+++ b/crates/rs-core/src/db/mod.rs
@@ -20,9 +20,9 @@ pub use migrations::{MAX_SCHEMA_VERSION, current_schema_version, run_migrations}
 
 pub mod upload;
 pub use upload::{
-    count_permanently_failed_since, list_recent_uploads, mark_chunk_in_process,
-    mark_upload_permanently_failed, pick_next_uploadable_chunk, pick_next_uploadable_chunks,
-    record_upload_attempt, record_upload_failure, record_upload_success, reset_orphaned_in_process,
+    count_permanently_failed_since, list_recent_uploads, mark_upload_permanently_failed,
+    pick_next_uploadable_chunk, record_upload_attempt, record_upload_failure,
+    record_upload_success, reset_orphaned_in_process,
 };
 
 pub mod audit;

--- a/crates/rs-core/src/db/upload.rs
+++ b/crates/rs-core/src/db/upload.rs
@@ -171,52 +171,6 @@ pub async fn pick_next_uploadable_chunk(
     Ok(row.map(row_to_chunk_record))
 }
 
-/// Claim-batch version: returns up to `limit` chunks that are unsent,
-/// not-in-process, not permanently-failed, past their retry-time. Does
-/// NOT mark them `in_process` — the caller must do that per chunk via
-/// [`mark_chunk_in_process`].
-///
-/// Used by the claim-coordinator (single SELECT every ~200ms) instead
-/// of the old per-worker picker that caused SQLite BUSY thrash when N
-/// workers raced the same SELECT/UPDATE transaction (issue #120).
-pub async fn pick_next_uploadable_chunks(
-    pool: &SqlitePool,
-    now_ms: i64,
-    limit: i64,
-) -> Result<Vec<ChunkRecord>> {
-    let rows = sqlx::query(
-        "SELECT id, streaming_event_id, chunk_file_path, data_size, created_at, md5,
-                in_process, sent, sequence_number, duration_ms,
-                upload_attempts, upload_first_attempt_at, upload_completed_at,
-                upload_duration_ms, upload_last_error, upload_next_retry_at,
-                upload_failed_permanently
-         FROM chunk_records
-         WHERE sent = 0 AND in_process = 0 AND upload_failed_permanently = 0
-           AND (upload_next_retry_at IS NULL OR upload_next_retry_at <= ?1)
-         ORDER BY upload_next_retry_at ASC, id ASC
-         LIMIT ?2",
-    )
-    .bind(now_ms)
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
-    Ok(rows.into_iter().map(row_to_chunk_record).collect())
-}
-
-/// Conditional claim — flips `in_process` 0→1 for a chunk. Returns
-/// `true` if we won the claim, `false` if some other actor already
-/// claimed or the row no longer exists.
-pub async fn mark_chunk_in_process(pool: &SqlitePool, id: i64) -> Result<bool> {
-    let result = sqlx::query(
-        "UPDATE chunk_records SET in_process = 1
-         WHERE id = ?1 AND in_process = 0 AND sent = 0",
-    )
-    .bind(id)
-    .execute(pool)
-    .await?;
-    Ok(result.rows_affected() == 1)
-}
-
 /// Record a successful upload.
 pub async fn record_upload_success(
     pool: &SqlitePool,

--- a/crates/rs-core/src/db/upload.rs
+++ b/crates/rs-core/src/db/upload.rs
@@ -111,51 +111,65 @@ pub async fn mark_upload_permanently_failed(pool: &SqlitePool, chunk_id: i64) ->
 ///   - in_process = 0
 ///   - upload_failed_permanently = 0
 ///   - upload_next_retry_at IS NULL OR upload_next_retry_at <= now_ms
+///
+/// Implemented as a SINGLE atomic statement on the pool — `UPDATE ... SET
+/// in_process = 1 WHERE id = (SELECT ... LIMIT 1) RETURNING <cols>` — with NO
+/// `BEGIN`/commit transaction. This is the #256 fix:
+///
+///   - The old picker opened `pool.begin()` (sqlx default = BEGIN DEFERRED),
+///     SELECTed the hot `ORDER BY id ASC LIMIT 1` row, then UPDATEd it in the
+///     same tx. The deferred read took a read snapshot; the subsequent UPDATE
+///     had to UPGRADE that snapshot to a write lock. When any concurrent
+///     committer (chunk INSERT / audit batch / `update_received_bytes`)
+///     committed between the SELECT-snapshot and the UPDATE, SQLite returned
+///     `SQLITE_BUSY_SNAPSHOT` (code 517) IMMEDIATELY — `busy_timeout` never
+///     retries 517 — plus `SQLITE_BUSY` (code 5) under writer-writer
+///     contention. With 2-8 workers on a 5-connection pool this produced the
+///     30+ minute "database is locked" storm that starved the live-event
+///     upload pipeline (2026-06-19 outage).
+///
+///   - The single statement takes the SQLite write lock on its FIRST (and
+///     only) statement: there is no read snapshot to invalidate (kills 517)
+///     and no read->write upgrade window (kills the storm). `busy_timeout`
+///     now fully covers the only remaining failure mode (plain writer-writer
+///     code 5, which it retries). It does NOT serialise the workers (the
+///     reason the #120 single-claimer coordinator was reverted) — each worker
+///     still issues its own independent claim; the `WHERE in_process = 0`
+///     guard guarantees exactly one winner per row.
+///
+/// The inner `SELECT` chooses the oldest eligible row; the outer `UPDATE`
+/// flips only that row to `in_process = 1` (re-checking eligibility so two
+/// near-simultaneous claims can't both win), and `RETURNING` hands back the
+/// full row so callers keep the same `Option<ChunkRecord>` contract.
 pub async fn pick_next_uploadable_chunk(
     pool: &SqlitePool,
     now_ms: i64,
 ) -> Result<Option<ChunkRecord>> {
-    let mut tx = pool.begin().await?;
-
     let row: Option<sqlx::sqlite::SqliteRow> = sqlx::query(
-        "SELECT id, streaming_event_id, chunk_file_path, data_size, created_at, md5,
-                in_process, sent, sequence_number, duration_ms,
-                upload_attempts, upload_first_attempt_at, upload_completed_at,
-                upload_duration_ms, upload_last_error, upload_next_retry_at,
-                upload_failed_permanently
-         FROM chunk_records
-         WHERE sent = 0
-           AND in_process = 0
-           AND upload_failed_permanently = 0
-           AND (upload_next_retry_at IS NULL OR upload_next_retry_at <= ?1)
-         ORDER BY id ASC
-         LIMIT 1",
+        "UPDATE chunk_records
+            SET in_process = 1
+          WHERE id = (
+                SELECT id FROM chunk_records
+                 WHERE sent = 0
+                   AND in_process = 0
+                   AND upload_failed_permanently = 0
+                   AND (upload_next_retry_at IS NULL OR upload_next_retry_at <= ?1)
+                 ORDER BY id ASC
+                 LIMIT 1
+          )
+            AND in_process = 0
+            AND sent = 0
+        RETURNING id, streaming_event_id, chunk_file_path, data_size, created_at, md5,
+                  in_process, sent, sequence_number, duration_ms,
+                  upload_attempts, upload_first_attempt_at, upload_completed_at,
+                  upload_duration_ms, upload_last_error, upload_next_retry_at,
+                  upload_failed_permanently",
     )
     .bind(now_ms)
-    .fetch_optional(&mut *tx)
+    .fetch_optional(pool)
     .await?;
 
-    let Some(row) = row else {
-        return Ok(None);
-    };
-
-    let chunk = row_to_chunk_record(row);
-
-    // Atomic claim — if another worker grabbed it, our UPDATE affects 0 rows.
-    let result = sqlx::query(
-        "UPDATE chunk_records SET in_process = 1
-         WHERE id = ?1 AND in_process = 0 AND sent = 0",
-    )
-    .bind(chunk.id)
-    .execute(&mut *tx)
-    .await?;
-
-    tx.commit().await?;
-
-    if result.rows_affected() == 0 {
-        return Ok(None);
-    }
-    Ok(Some(chunk))
+    Ok(row.map(row_to_chunk_record))
 }
 
 /// Claim-batch version: returns up to `limit` chunks that are unsent,

--- a/crates/rs-core/src/db/upload.rs
+++ b/crates/rs-core/src/db/upload.rs
@@ -114,28 +114,27 @@ pub async fn mark_upload_permanently_failed(pool: &SqlitePool, chunk_id: i64) ->
 ///
 /// Implemented as a SINGLE atomic statement on the pool — `UPDATE ... SET
 /// in_process = 1 WHERE id = (SELECT ... LIMIT 1) RETURNING <cols>` — with NO
-/// `BEGIN`/commit transaction. This is the #256 fix:
+/// `BEGIN`/commit transaction. This is the #256 fix.
 ///
-///   - The old picker opened `pool.begin()` (sqlx default = BEGIN DEFERRED),
-///     SELECTed the hot `ORDER BY id ASC LIMIT 1` row, then UPDATEd it in the
-///     same tx. The deferred read took a read snapshot; the subsequent UPDATE
-///     had to UPGRADE that snapshot to a write lock. When any concurrent
-///     committer (chunk INSERT / audit batch / `update_received_bytes`)
-///     committed between the SELECT-snapshot and the UPDATE, SQLite returned
-///     `SQLITE_BUSY_SNAPSHOT` (code 517) IMMEDIATELY — `busy_timeout` never
-///     retries 517 — plus `SQLITE_BUSY` (code 5) under writer-writer
-///     contention. With 2-8 workers on a 5-connection pool this produced the
-///     30+ minute "database is locked" storm that starved the live-event
-///     upload pipeline (2026-06-19 outage).
+/// The OLD picker opened `pool.begin()` (sqlx default = BEGIN DEFERRED),
+/// SELECTed the hot `ORDER BY id ASC LIMIT 1` row, then UPDATEd it in the same
+/// tx. The deferred read took a read snapshot; the subsequent UPDATE had to
+/// UPGRADE that snapshot to a write lock. When any concurrent committer (chunk
+/// INSERT / audit batch / `update_received_bytes`) committed between the
+/// SELECT-snapshot and the UPDATE, SQLite returned `SQLITE_BUSY_SNAPSHOT`
+/// (code 517) IMMEDIATELY — `busy_timeout` never retries 517 — plus
+/// `SQLITE_BUSY` (code 5) under writer-writer contention. With 2-8 workers on a
+/// 5-connection pool this produced the 30+ minute "database is locked" storm
+/// that starved the live-event upload pipeline (2026-06-19 outage).
 ///
-///   - The single statement takes the SQLite write lock on its FIRST (and
-///     only) statement: there is no read snapshot to invalidate (kills 517)
-///     and no read->write upgrade window (kills the storm). `busy_timeout`
-///     now fully covers the only remaining failure mode (plain writer-writer
-///     code 5, which it retries). It does NOT serialise the workers (the
-///     reason the #120 single-claimer coordinator was reverted) — each worker
-///     still issues its own independent claim; the `WHERE in_process = 0`
-///     guard guarantees exactly one winner per row.
+/// The single statement takes the SQLite write lock on its FIRST (and only)
+/// statement: there is no read snapshot to invalidate (kills 517) and no
+/// read->write upgrade window (kills the storm). `busy_timeout` now fully
+/// covers the only remaining failure mode (plain writer-writer code 5, which it
+/// retries). It does NOT serialise the workers (the reason the #120
+/// single-claimer coordinator was reverted) — each worker still issues its own
+/// independent claim; the `WHERE in_process = 0` guard guarantees exactly one
+/// winner per row.
 ///
 /// The inner `SELECT` chooses the oldest eligible row; the outer `UPDATE`
 /// flips only that row to `in_process = 1` (re-checking eligibility so two

--- a/crates/rs-endpoint/src/uploader.rs
+++ b/crates/rs-endpoint/src/uploader.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use sqlx::SqlitePool;
 use tokio::sync::{broadcast, mpsc};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use rs_core::audit::{Action, AuditRow, RateLimiter, Severity, Source};
 use rs_core::db;
@@ -353,6 +353,7 @@ async fn run_worker(idx: usize, ctx: WorkerCtx, shutdown: &mut broadcast::Receiv
         let now_ms = chrono::Utc::now().timestamp_millis();
         match db::pick_next_uploadable_chunk(&ctx.pool, now_ms).await {
             Ok(None) => {
+                trace!(worker = idx, "picker: no eligible chunk");
                 tokio::select! {
                     _ = shutdown.recv() => return,
                     _ = tokio::time::sleep(Duration::from_millis(200)) => {}
@@ -360,7 +361,12 @@ async fn run_worker(idx: usize, ctx: WorkerCtx, shutdown: &mut broadcast::Receiv
                 continue;
             }
             Err(e) => {
-                error!("Failed to pick next uploadable chunk: {e}");
+                // The #256 SQLITE_BUSY storm surfaced exactly here. The picker
+                // is now a single atomic UPDATE...RETURNING (no read->write
+                // upgrade, no 517), so a BUSY here should be rare; log the
+                // raw error (which carries the SQLite code) so any recurrence
+                // is diagnosable from the live-event log without a redeploy.
+                error!(worker = idx, "Failed to pick next uploadable chunk: {e}");
                 tokio::select! {
                     _ = shutdown.recv() => return,
                     _ = tokio::time::sleep(Duration::from_secs(1)) => {}
@@ -368,6 +374,7 @@ async fn run_worker(idx: usize, ctx: WorkerCtx, shutdown: &mut broadcast::Receiv
                 continue;
             }
             Ok(Some(chunk)) => {
+                debug!(worker = idx, chunk_id = chunk.id, "picker: claimed chunk");
                 upload_one(&ctx, chunk).await;
             }
         }

--- a/crates/rs-endpoint/tests/uploader_busy_stress.rs
+++ b/crates/rs-endpoint/tests/uploader_busy_stress.rs
@@ -6,9 +6,9 @@
 //! deferred-`BEGIN` read-then-write-upgrade transaction. 2-8 uploader workers
 //! sharing one 5-connection pool all raced the `ORDER BY id ASC LIMIT 1` hot
 //! row against frequent committers (chunk INSERT ~every 2s, audit batch,
-//! `update_received_bytes`). SQLite then returned, repeatedly:
-//!   - code 5   = SQLITE_BUSY          (writer-writer lock contention)
-//!   - code 517 = SQLITE_BUSY_SNAPSHOT (deferred read->write upgrade conflict)
+//! `update_received_bytes`). SQLite then returned, repeatedly, code 5
+//! (SQLITE_BUSY — writer-writer lock contention) and code 517
+//! (SQLITE_BUSY_SNAPSHOT — deferred read->write upgrade conflict).
 //! `busy_timeout` does NOT rescue 517 (it is returned immediately, never
 //! retried), so the error escaped to the app layer as
 //! `ERROR Failed to pick next uploadable chunk: ... database is locked`

--- a/crates/rs-endpoint/tests/uploader_busy_stress.rs
+++ b/crates/rs-endpoint/tests/uploader_busy_stress.rs
@@ -43,13 +43,12 @@ use tokio::sync::broadcast;
 /// result code precisely rather than string-matching, so it can't
 /// false-positive on an unrelated "busy" substring.
 fn is_sqlite_busy(e: &rs_core::error::CoreError) -> bool {
-    if let rs_core::error::CoreError::Database(sqlx::Error::Database(db_err)) = e {
-        if let Some(code) = db_err.code() {
-            // 5 = SQLITE_BUSY, 517 = SQLITE_BUSY_SNAPSHOT (0x205).
-            if code == "5" || code == "517" {
-                return true;
-            }
-        }
+    // 5 = SQLITE_BUSY, 517 = SQLITE_BUSY_SNAPSHOT (0x205). Match the SQLite
+    // extended result code precisely via a let-chain.
+    if let rs_core::error::CoreError::Database(sqlx::Error::Database(db_err)) = e
+        && let Some(code) = db_err.code()
+    {
+        return code == "5" || code == "517";
     }
     // Fallback: surface the storm even if the code isn't populated.
     let s = e.to_string().to_ascii_lowercase();
@@ -202,8 +201,8 @@ async fn picker_no_busy_storm_under_production_write_mix() {
     let total_claims: u32 = map.values().copied().sum();
     let double_claims: Vec<(i64, u32)> = map
         .iter()
-        .filter(|(_, &c)| c > 1)
-        .map(|(&id, &c)| (id, c))
+        .filter(|(_, count)| **count > 1)
+        .map(|(id, count)| (*id, *count))
         .collect();
     assert!(
         double_claims.is_empty(),

--- a/crates/rs-endpoint/tests/uploader_busy_stress.rs
+++ b/crates/rs-endpoint/tests/uploader_busy_stress.rs
@@ -1,35 +1,74 @@
-//! BUSY-error stress test for the per-worker picker under WAL +
-//! `busy_timeout=5000`.
+//! SQLITE_BUSY-storm regression test for the upload-queue picker
+//! (`db::pick_next_uploadable_chunk`) under a file-backed WAL pool with the
+//! production multi-writer mix.
 //!
-//! Context: the 2026-04-19 post-mortem logged 25,366 SQLITE_BUSY errors
-//! in ~5 hours. The design doc originally prescribed a claim-coordinator
-//! pattern to dedup the workers, but that regressed upload throughput
-//! catastrophically (310-chunk backlog after 10 minutes). We reverted to
-//! the per-worker picker and rely on WAL + busy_timeout as the sole
-//! mitigation.
+//! Context — 2026-06-19 live-event outage (issue #256): the picker was a
+//! deferred-`BEGIN` read-then-write-upgrade transaction. 2-8 uploader workers
+//! sharing one 5-connection pool all raced the `ORDER BY id ASC LIMIT 1` hot
+//! row against frequent committers (chunk INSERT ~every 2s, audit batch,
+//! `update_received_bytes`). SQLite then returned, repeatedly:
+//!   - code 5   = SQLITE_BUSY          (writer-writer lock contention)
+//!   - code 517 = SQLITE_BUSY_SNAPSHOT (deferred read->write upgrade conflict)
+//! `busy_timeout` does NOT rescue 517 (it is returned immediately, never
+//! retried), so the error escaped to the app layer as
+//! `ERROR Failed to pick next uploadable chunk: ... database is locked`
+//! every ~2s for 30+ minutes -> S3 uploads stalled -> VPS chunk supply
+//! starved -> every endpoint died. This is the bug that caused the outage.
 //!
-//! This test demonstrates that the pragma-only mitigation holds: 8
-//! concurrent workers contending for the same eligible rows for 3 seconds
-//! must NOT surface BUSY errors to the application layer. Under WAL,
-//! readers don't block writers; under `busy_timeout=5000`, writer-writer
-//! contention retries internally for up to 5s.
+//! Earlier history: #120 added a single-claimer coordinator to dedup the
+//! workers; it regressed upload throughput (310-chunk backlog after 10 min)
+//! and was reverted. The fix here does NOT reintroduce a coordinator — the
+//! picker is collapsed into ONE atomic `UPDATE ... WHERE id=(SELECT ...)
+//! RETURNING` statement on the pool (no BEGIN, no read snapshot to invalidate,
+//! no read->write window), which keeps N workers fully concurrent.
+//!
+//! This test reproduces the storm with a file-backed WAL pool (NOT the
+//! `max_connections(1)` memory pool, which serialises everything and HIDES the
+//! bug) and drives the EXACT production write mix from a concurrent committer.
+//! Zero tolerance: the picker must surface ZERO SQLITE_BUSY / BUSY_SNAPSHOT
+//! errors, and every chunk must be claimed EXACTLY ONCE (no double-claim, no
+//! lost row).
 
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
+use rs_core::audit::{Action, AuditRow, Severity, Source};
 use rs_core::db;
+use tokio::sync::Mutex;
+use tokio::sync::broadcast;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn per_worker_picker_under_wal_no_busy_errors() {
+/// True if a picker error is a SQLite BUSY (code 5) or BUSY_SNAPSHOT (code
+/// 517) — the exact storm signature from #256. Matches the SQLite extended
+/// result code precisely rather than string-matching, so it can't
+/// false-positive on an unrelated "busy" substring.
+fn is_sqlite_busy(e: &rs_core::error::CoreError) -> bool {
+    if let rs_core::error::CoreError::Database(sqlx::Error::Database(db_err)) = e {
+        if let Some(code) = db_err.code() {
+            // 5 = SQLITE_BUSY, 517 = SQLITE_BUSY_SNAPSHOT (0x205).
+            if code == "5" || code == "517" {
+                return true;
+            }
+        }
+    }
+    // Fallback: surface the storm even if the code isn't populated.
+    let s = e.to_string().to_ascii_lowercase();
+    s.contains("database is locked") || s.contains("(code: 5") || s.contains("(code: 517")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+async fn picker_no_busy_storm_under_production_write_mix() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let pool = db::create_pool(tmp.path()).await.unwrap();
     db::run_migrations(&pool).await.unwrap();
 
-    // Seed one streaming event + 500 eligible chunks.
-    let event_id = db::create_streaming_event(&pool, "stress-test")
+    // Seed one streaming event + many eligible unsent chunks. The claimers
+    // drain these; the committer keeps inserting more to sustain contention.
+    let event_id = db::create_streaming_event(&pool, "busy-storm-test")
         .await
         .unwrap();
-    for i in 0..500 {
+    const SEED: usize = 800;
+    for i in 0..SEED {
         db::insert_chunk(
             &pool,
             event_id,
@@ -42,47 +81,100 @@ async fn per_worker_picker_under_wal_no_busy_errors() {
         .unwrap();
     }
 
-    let busy_hits = Arc::new(AtomicU32::new(0));
-    let claimed = Arc::new(AtomicU32::new(0));
+    // A broadcast channel for audit::insert_batch (the post-commit fan-out).
+    let (ws_tx, _ws_rx) = broadcast::channel(1024);
 
-    // 8 concurrent workers racing pick_next_uploadable_chunk. Each one
-    // grabs a chunk, marks it sent, loops. Under rollback-journal + no
-    // busy_timeout this would spew BUSY errors; under our pragmas it
-    // should stay quiet.
+    let busy_hits = Arc::new(AtomicU32::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    // Records every chunk id each claimer won, to detect double-claims.
+    let claims: Arc<Mutex<HashMap<i64, u32>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(4);
+
+    // --- 8 claimer workers (production = adaptive 2..8) ---
+    // Each tightly loops the picker. On a successful claim it marks the chunk
+    // sent (mirrors record_upload_success after the slow S3 PUT) so the queue
+    // keeps draining, then loops immediately to maximise contention.
     let mut handles = Vec::new();
     for _ in 0..8 {
         let pool = pool.clone();
         let busy_hits = Arc::clone(&busy_hits);
-        let claimed = Arc::clone(&claimed);
+        let claims = Arc::clone(&claims);
+        let stop = Arc::clone(&stop);
         handles.push(tokio::spawn(async move {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-            while std::time::Instant::now() < deadline {
+            while std::time::Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
                 let now_ms = chrono::Utc::now().timestamp_millis();
                 match db::pick_next_uploadable_chunk(&pool, now_ms).await {
                     Ok(Some(chunk)) => {
-                        claimed.fetch_add(1, Ordering::Relaxed);
-                        // Mark as sent so other workers move on.
-                        let mark = sqlx::query(
-                            "UPDATE chunk_records SET sent = 1, in_process = 0 WHERE id = ?1",
-                        )
-                        .bind(chunk.id)
-                        .execute(&pool)
-                        .await;
-                        if let Err(e) = mark {
-                            if e.to_string().to_ascii_lowercase().contains("busy") {
-                                busy_hits.fetch_add(1, Ordering::Relaxed);
-                            }
+                        // Count this claim. A correct picker claims each id
+                        // exactly once across all workers.
+                        {
+                            let mut map = claims.lock().await;
+                            *map.entry(chunk.id).or_insert(0) += 1;
                         }
+                        // Mark sent so the row leaves the eligible set.
+                        let _ = db::record_upload_success(
+                            &pool,
+                            chunk.id,
+                            chrono::Utc::now().timestamp_millis(),
+                            1,
+                        )
+                        .await;
                     }
                     Ok(None) => {
                         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
                     }
                     Err(e) => {
-                        if e.to_string().to_ascii_lowercase().contains("busy") {
+                        if is_sqlite_busy(&e) {
                             busy_hits.fetch_add(1, Ordering::Relaxed);
                         }
                     }
                 }
+            }
+        }));
+    }
+
+    // --- 2 committer tasks: the EXACT production write mix ---
+    // chunk INSERT (insert_chunk) + audit batch (audit::insert_batch, its own
+    // BEGIN tx) + update_received_bytes -- the three concurrent committers
+    // that held the write lock during the live event and forced the deferred
+    // read->write picker into SQLITE_BUSY_SNAPSHOT.
+    for w in 0..2 {
+        let pool = pool.clone();
+        let ws_tx = ws_tx.clone();
+        let stop = Arc::clone(&stop);
+        handles.push(tokio::spawn(async move {
+            let mut n = 0i64;
+            while std::time::Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+                // 1) chunk INSERT — same statement the inpoint chunker runs.
+                let _ = db::insert_chunk(
+                    &pool,
+                    event_id,
+                    &format!("/tmp/live{w}-{n}.bin"),
+                    1024,
+                    "cafebabe",
+                    1000,
+                )
+                .await;
+
+                // 2) audit batch — its own pool.begin() tx (write lock).
+                let rows = vec![AuditRow {
+                    severity: Severity::Info,
+                    source: Source::Uploader,
+                    event_id: Some(event_id),
+                    instance_id: None,
+                    endpoint: None,
+                    action: Action::RtmpConnected,
+                    detail: serde_json::json!({"w": w, "n": n}),
+                    ts_override: None,
+                }];
+                let _ = db::audit::insert_batch(&pool, &rows, &ws_tx).await;
+
+                // 3) received-bytes bump — UPDATE on streaming_events.
+                let _ = db::update_received_bytes(&pool, event_id, 1024).await;
+
+                n += 1;
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
             }
         }));
     }
@@ -92,30 +184,35 @@ async fn per_worker_picker_under_wal_no_busy_errors() {
     }
 
     let busy = busy_hits.load(Ordering::Relaxed);
-    let took = claimed.load(Ordering::Relaxed);
 
-    // Under WAL + busy_timeout, BUSY escape to the application layer
-    // should be near-zero. A handful (under ~10) can slip through under
-    // extreme contention; zero-tolerance is fragile. 50 is the soft
-    // upper bound — the pre-pragma world recorded 25,366 in 5 hours,
-    // which is ~85/minute.
-    assert!(
-        busy < 50,
-        "BUSY errors exceeded threshold: {busy} (over 3s with 8 workers); \
-         pragma-only mitigation isn't holding"
+    // ZERO tolerance: the storm is the bug. The fix (single atomic claim
+    // statement) eliminates both the read snapshot (517) and the read->write
+    // window (5). Any escape to the app layer is a regression.
+    assert_eq!(
+        busy, 0,
+        "picker surfaced {busy} SQLITE_BUSY/BUSY_SNAPSHOT errors under the \
+         production write mix — the #256 storm is back (deferred read->write \
+         picker, or busy_timeout failing to cover 517)"
     );
-    // Throughput sanity: workers should have drained at least ONE row in
-    // 3s, proving they aren't deadlocked. The PRIMARY assertion is
-    // `busy < 50` above (proves the pragma stack holds). The secondary
-    // throughput bound was previously 50, then 20, but Windows CI runners
-    // under concurrent-CI load have produced as low as 4 claims/3s (real
-    // I/O variance, not a regression). Setting >= 1 keeps the deadlock-
-    // detection property without flaking on slow runners.
-    //
-    // Real long-term fix: convert this to a mock-DB unit test that doesn't
-    // depend on real fsync/WAL throughput. Tracked as a follow-up to #174.
+
+    // Correctness: every claimed chunk was claimed EXACTLY once. A picker that
+    // races the claim could hand the same id to two workers (double-upload) or
+    // skip rows; the atomic claim guarantees one winner per row.
+    let map = claims.lock().await;
+    let total_claims: u32 = map.values().copied().sum();
+    let double_claims: Vec<(i64, u32)> = map
+        .iter()
+        .filter(|(_, &c)| c > 1)
+        .map(|(&id, &c)| (id, c))
+        .collect();
     assert!(
-        took >= 1,
-        "uploader throughput regressed: ZERO claims in 3s (deadlock?)"
+        double_claims.is_empty(),
+        "chunks claimed more than once (double-upload): {double_claims:?}"
+    );
+    // Throughput sanity: the workers must have actually drained rows, proving
+    // the atomic claim isn't deadlocking or serialising to a crawl.
+    assert!(
+        total_claims >= 1,
+        "uploader throughput regressed: ZERO claims in 4s (deadlock?)"
     );
 }

--- a/crates/rs-endpoint/tests/uploader_busy_stress.rs
+++ b/crates/rs-endpoint/tests/uploader_busy_stress.rs
@@ -31,7 +31,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use rs_core::audit::{Action, AuditRow, Severity, Source};
 use rs_core::db;
@@ -84,7 +84,6 @@ async fn picker_no_busy_storm_under_production_write_mix() {
     let (ws_tx, _ws_rx) = broadcast::channel(1024);
 
     let busy_hits = Arc::new(AtomicU32::new(0));
-    let stop = Arc::new(AtomicBool::new(false));
     // Records every chunk id each claimer won, to detect double-claims.
     let claims: Arc<Mutex<HashMap<i64, u32>>> = Arc::new(Mutex::new(HashMap::new()));
 
@@ -99,9 +98,8 @@ async fn picker_no_busy_storm_under_production_write_mix() {
         let pool = pool.clone();
         let busy_hits = Arc::clone(&busy_hits);
         let claims = Arc::clone(&claims);
-        let stop = Arc::clone(&stop);
         handles.push(tokio::spawn(async move {
-            while std::time::Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+            while std::time::Instant::now() < deadline {
                 let now_ms = chrono::Utc::now().timestamp_millis();
                 match db::pick_next_uploadable_chunk(&pool, now_ms).await {
                     Ok(Some(chunk)) => {
@@ -111,14 +109,22 @@ async fn picker_no_busy_storm_under_production_write_mix() {
                             let mut map = claims.lock().await;
                             *map.entry(chunk.id).or_insert(0) += 1;
                         }
-                        // Mark sent so the row leaves the eligible set.
-                        let _ = db::record_upload_success(
+                        // Mark sent so the row leaves the eligible set. This is
+                        // a real production write (execute(pool) UPDATE), so a
+                        // BUSY here is ALSO part of the storm the fix must
+                        // eliminate — count it into busy_hits, don't swallow it.
+                        if let Err(e) = db::record_upload_success(
                             &pool,
                             chunk.id,
                             chrono::Utc::now().timestamp_millis(),
                             1,
                         )
-                        .await;
+                        .await
+                        {
+                            if is_sqlite_busy(&e) {
+                                busy_hits.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
                     }
                     Ok(None) => {
                         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -141,10 +147,9 @@ async fn picker_no_busy_storm_under_production_write_mix() {
     for w in 0..2 {
         let pool = pool.clone();
         let ws_tx = ws_tx.clone();
-        let stop = Arc::clone(&stop);
         handles.push(tokio::spawn(async move {
             let mut n = 0i64;
-            while std::time::Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+            while std::time::Instant::now() < deadline {
                 // 1) chunk INSERT — same statement the inpoint chunker runs.
                 let _ = db::insert_chunk(
                     &pool,
@@ -208,10 +213,18 @@ async fn picker_no_busy_storm_under_production_write_mix() {
         double_claims.is_empty(),
         "chunks claimed more than once (double-upload): {double_claims:?}"
     );
-    // Throughput sanity: the workers must have actually drained rows, proving
-    // the atomic claim isn't deadlocking or serialising to a crawl.
+    // Throughput + real-contention guard: the 8 workers race over 800 seeded
+    // chunks (plus committer-inserted ones) for 4s, so a correct atomic picker
+    // drains hundreds. A bound of >= 100 proves substantial concurrent draining
+    // actually happened — so the zero-double-claim result above reflects a real
+    // claim race, not a vacuous under-contended run — while staying well clear
+    // of the ~800 ceiling so a slow/loaded CI runner can't flake it. The old
+    // `>= 1` bound would let a picker that throttles to a crawl (the #120
+    // backlog failure) pass; this catches that regression.
     assert!(
-        total_claims >= 1,
-        "uploader throughput regressed: ZERO claims in 4s (deadlock?)"
+        total_claims >= 100,
+        "uploader throughput regressed: only {total_claims} claims in 4s with \
+         8 workers on 800 seeded chunks — atomic claim deadlocking or \
+         serialising to a crawl?"
     );
 }

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Fixes the **2026-06-19 live-event outage** (issue #256): a continuous `ERROR Failed to pick next uploadable chunk: database error: (code: 5 / 517) database is locked` storm every ~2s for 30+ minutes → S3 uploads stalled → VPS chunk supply starved → every endpoint died.

## Root cause

`pick_next_uploadable_chunk` was a **deferred-`BEGIN` read-then-write-upgrade transaction**: it SELECTed the hot `ORDER BY id ASC LIMIT 1` row (taking a read snapshot), then UPDATEd `in_process=1` in the same tx (upgrading to a write lock). With 2-8 workers on a 5-connection pool racing frequent committers (chunk INSERT, audit batch, `update_received_bytes`):

- **code 517 (SQLITE_BUSY_SNAPSHOT)** — a committer commits between the SELECT-snapshot and the UPDATE; `busy_timeout` never retries 517 → surfaced immediately to the app layer.
- **code 5 (SQLITE_BUSY)** — writer-writer contention.

## Fix

Collapse the picker into **ONE atomic statement on the pool** — no `BEGIN`, no commit:

```sql
UPDATE chunk_records SET in_process = 1
 WHERE id = (SELECT id FROM chunk_records WHERE <eligible> ORDER BY id ASC LIMIT 1)
   AND in_process = 0 AND sent = 0
RETURNING <all 17 columns>
```

- No read snapshot to invalidate → **kills 517**.
- No read→write upgrade window → **kills the code-5 storm**; `busy_timeout` now covers the only remaining mode (plain writer-writer, which it retries).
- Workers stay **fully concurrent** — each issues its own claim; `WHERE in_process = 0` guarantees exactly one winner per row. Does **not** reintroduce the #120 single-claimer coordinator (reverted for throttling throughput).
- Signature unchanged → both uploader call sites + existing unit tests unaffected.
- Comprehensive claim-outcome logging at the call site.

## Regression test (RED → GREEN)

`crates/rs-endpoint/tests/uploader_busy_stress.rs` hardened to the real outage shape: **file-backed WAL pool** (not the `max_connections(1)` memory pool that hides the bug), 8 claimer workers + 2 committer tasks running the **exact production write mix**. Zero tolerance: asserts **ZERO** code-5/517 escape AND each chunk claimed **exactly once**.

- RED on the deferred-tx picker: `a760b87a`
- GREEN with the atomic statement: `e3ad6459`

Closes #256