### PR TITLE
feat(rtmp-push): A/V-skew detection + bounded auto-recovery + symmetric reanchor (#257)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/crates/rs-api/src/delivery_handlers.rs
+++ b/crates/rs-api/src/delivery_handlers.rs
@@ -225,6 +225,10 @@ pub struct DeliveryEndpointEntry {
     /// Rust-pusher reconnect counter (issue #172). Companion to
     /// `ffmpeg_restart_count` for endpoints on the rust pusher path.
     pub reconnect_count: u32,
+    /// Content-PTS A/V skew in ms (positive = audio behind video) for
+    /// rust-pusher endpoints. The dashboard alarms on a sustained non-zero
+    /// value; the #258 E2E gate asserts it stays ~0 (issue #257).
+    pub av_skew_ms: i64,
     pub ffmpeg_last_stderr: Option<String>,
     pub last_error: Option<String>,
     pub is_fast: bool,
@@ -266,6 +270,7 @@ pub async fn delivery_status(
             stall_reason: ep.stall_reason,
             ffmpeg_restart_count: ep.ffmpeg_restart_count,
             reconnect_count: ep.reconnect_count,
+            av_skew_ms: ep.av_skew_ms,
             ffmpeg_last_stderr: ep.ffmpeg_last_stderr,
             last_error: ep.last_error,
             is_fast: ep.is_fast,

--- a/crates/rs-api/src/delivery_status.rs
+++ b/crates/rs-api/src/delivery_status.rs
@@ -127,6 +127,13 @@ pub struct EndpointDeliveryStatus {
     /// Issue #172.
     #[serde(default)]
     pub reconnect_count: u32,
+    /// Current signed content-PTS A/V skew in ms (positive = audio behind
+    /// video) for rust-pusher endpoints. Read from VPS `/api/status` JSON
+    /// (defaults to 0 if the VPS rs-delivery is older than this field). The
+    /// operator dashboard alarms on a sustained non-zero value; the #258 E2E
+    /// gate asserts it stays ~0 (issue #257).
+    #[serde(default)]
+    pub av_skew_ms: i64,
     pub last_error: Option<String>,
     pub ffmpeg_last_stderr: Option<String>,
     pub is_fast: bool,
@@ -251,6 +258,10 @@ impl DeliveryOrchestrator {
                                 entry["ffmpeg_restart_count"].as_u64().unwrap_or(0) as u32;
                             let reconnect_count =
                                 entry["reconnect_count"].as_u64().unwrap_or(0) as u32;
+                            // #257: content-PTS A/V skew (signed; positive =
+                            // audio behind video). 0 when the VPS rs-delivery
+                            // predates this field.
+                            let av_skew_ms = entry["av_skew_ms"].as_i64().unwrap_or(0);
                             let last_error = entry["last_error"].as_str().map(|s| s.to_string());
                             let ffmpeg_last_stderr =
                                 entry["ffmpeg_last_stderr"].as_str().map(|s| s.to_string());
@@ -354,6 +365,7 @@ impl DeliveryOrchestrator {
                                 stall_reason,
                                 ffmpeg_restart_count,
                                 reconnect_count,
+                                av_skew_ms,
                                 last_error,
                                 ffmpeg_last_stderr,
                                 is_fast,
@@ -438,6 +450,7 @@ impl DeliveryOrchestrator {
                 stall_reason: ep.stall_reason,
                 ffmpeg_restart_count: ep.ffmpeg_restart_count,
                 reconnect_count: ep.reconnect_count,
+                av_skew_ms: ep.av_skew_ms,
                 last_error: ep.last_error,
                 is_fast: ep.is_fast,
                 delivery_mode: ep.delivery_mode,

--- a/crates/rs-api/src/delivery_status_yt_health_tests.rs
+++ b/crates/rs-api/src/delivery_status_yt_health_tests.rs
@@ -21,6 +21,7 @@ fn empty_metrics(alias: &str) -> DeliveryEndpointMetrics {
         stall_reason: None,
         ffmpeg_restart_count: 0,
         reconnect_count: 0,
+        av_skew_ms: 0,
         last_error: None,
         is_fast: false,
         delivery_mode: None,

--- a/crates/rs-api/src/lib.rs
+++ b/crates/rs-api/src/lib.rs
@@ -329,6 +329,7 @@ async fn delivery_broadcast_loop(
                             ffmpeg_restart_count: 0,
 
                             reconnect_count: 0,
+                            av_skew_ms: 0,
                             last_error: None,
                             is_fast: ep.is_fast,
                             delivery_mode: None,
@@ -530,6 +531,7 @@ mod max_non_fast_tests {
             stall_reason: None,
             ffmpeg_restart_count: 0,
             reconnect_count: 0,
+            av_skew_ms: 0,
             last_error: None,
             is_fast: fast,
             delivery_mode: None,

--- a/crates/rs-api/src/status_summary.rs
+++ b/crates/rs-api/src/status_summary.rs
@@ -83,6 +83,7 @@ mod tests {
             stall_reason: None,
             ffmpeg_restart_count: 0,
             reconnect_count: 0,
+            av_skew_ms: 0,
             last_error: None,
             is_fast: false,
             delivery_mode: None,

--- a/crates/rs-api/src/stream_handlers.rs
+++ b/crates/rs-api/src/stream_handlers.rs
@@ -154,6 +154,7 @@ pub async fn start_stream(
                         ffmpeg_restart_count: 0,
 
                         reconnect_count: 0,
+                        av_skew_ms: 0,
                         last_error: None,
                         is_fast: ep.is_fast,
                         delivery_mode: None,

--- a/crates/rs-api/src/yt_health_cache_tests.rs
+++ b/crates/rs-api/src/yt_health_cache_tests.rs
@@ -20,6 +20,7 @@ fn empty_metrics(alias: &str) -> DeliveryEndpointMetrics {
         stall_reason: None,
         ffmpeg_restart_count: 0,
         reconnect_count: 0,
+        av_skew_ms: 0,
         last_error: None,
         is_fast: false,
         delivery_mode: None,

--- a/crates/rs-api/tests/api_integration.rs
+++ b/crates/rs-api/tests/api_integration.rs
@@ -503,6 +503,7 @@ fn live_metrics(alias: &str) -> DeliveryEndpointMetrics {
         stall_reason: None,
         ffmpeg_restart_count: 0,
         reconnect_count: 0,
+        av_skew_ms: 0,
         last_error: None,
         is_fast: false,
         delivery_mode: None,

--- a/crates/rs-core/src/models.rs
+++ b/crates/rs-core/src/models.rs
@@ -325,6 +325,12 @@ pub struct DeliveryEndpointMetrics {
     /// older payloads / ffmpeg-path endpoints.
     #[serde(default)]
     pub reconnect_count: u32,
+    /// Content-PTS A/V skew in ms (positive = audio behind video) for
+    /// rust-pusher endpoints. The dashboard alarms on a sustained non-zero
+    /// value; the #258 E2E gate asserts it stays ~0. Defaults to 0 for older
+    /// payloads / ffmpeg-path endpoints (issue #257).
+    #[serde(default)]
+    pub av_skew_ms: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
     #[serde(default)]
@@ -554,6 +560,7 @@ mod tests {
                     ffmpeg_restart_count: 0,
 
                     reconnect_count: 0,
+                    av_skew_ms: 0,
                     last_error: None,
                     is_fast: false,
                     delivery_mode: None,
@@ -681,6 +688,7 @@ mod tests {
             ffmpeg_restart_count: 5,
 
             reconnect_count: 0,
+            av_skew_ms: 0,
             last_error: Some("S3 timeout".to_string()),
             is_fast: true,
             delivery_mode: None,
@@ -730,6 +738,7 @@ mod tests {
                 ffmpeg_restart_count: 10,
 
                 reconnect_count: 0,
+                av_skew_ms: 0,
                 last_error: Some("Connection refused".to_string()),
                 is_fast: false,
                 delivery_mode: None,
@@ -758,6 +767,7 @@ mod tests {
                 ffmpeg_restart_count: 0,
 
                 reconnect_count: 0,
+                av_skew_ms: 0,
                 last_error: None,
                 is_fast: true,
                 delivery_mode: None,
@@ -776,6 +786,7 @@ mod tests {
                 ffmpeg_restart_count: 0,
 
                 reconnect_count: 0,
+                av_skew_ms: 0,
                 last_error: None,
                 is_fast: false,
                 delivery_mode: None,
@@ -806,6 +817,7 @@ mod tests {
             ffmpeg_restart_count: 0,
 
             reconnect_count: 0,
+            av_skew_ms: 0,
             last_error: None,
             is_fast: true,
             delivery_mode: None,

--- a/crates/rs-delivery/src/api.rs
+++ b/crates/rs-delivery/src/api.rs
@@ -282,6 +282,10 @@ struct EndpointStatusEntry {
     /// dashboard so operators can correlate audit `endpoint_rtmp_push_died`
     /// events with this counter (issue #172).
     reconnect_count: u32,
+    /// Current signed content-PTS A/V skew in ms (positive = audio behind
+    /// video) for rust-pusher endpoints. The dashboard alarms on a sustained
+    /// non-zero value; the #258 E2E gate asserts it stays ~0 (issue #257).
+    av_skew_ms: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     last_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -318,6 +322,7 @@ async fn endpoint_status(
             stall_reason: stats.stall_reason,
             ffmpeg_restart_count: stats.ffmpeg_restart_count,
             reconnect_count: stats.reconnect_count,
+            av_skew_ms: stats.av_skew_ms,
             last_error: stats.last_error,
             ffmpeg_last_stderr: stats.ffmpeg_last_stderr,
             consecutive_chunk_misses: stats.consecutive_chunk_misses,

--- a/crates/rs-delivery/src/endpoint_consumer_helpers.rs
+++ b/crates/rs-delivery/src/endpoint_consumer_helpers.rs
@@ -110,6 +110,9 @@ pub(super) async fn handle_rust_push(
             s.current_chunk_id = chunk_id;
             s.chunks_processed += 1;
             s.reconnect_count = pusher.reconnect_count();
+            // #257: surface the live content-PTS A/V skew so the dashboard can
+            // alarm on a desync and the #258 E2E gate can assert it stays ~0.
+            s.av_skew_ms = pusher.av_skew_ms();
             // Clear sticky error markers: prior timeout / push-error states
             // shouldn't keep showing on the dashboard once writes resume.
             s.stall_reason = None;

--- a/crates/rs-delivery/src/endpoint_consumer_helpers.rs
+++ b/crates/rs-delivery/src/endpoint_consumer_helpers.rs
@@ -112,6 +112,9 @@ pub(super) async fn handle_rust_push(
             s.reconnect_count = pusher.reconnect_count();
             // #257: surface the live content-PTS A/V skew so the dashboard can
             // alarm on a desync and the #258 E2E gate can assert it stays ~0.
+            // Updated on the SUCCESS path only — last-success semantics; on an
+            // error chunk the error fields below dominate the dashboard and
+            // this keeps its last-known-good value.
             s.av_skew_ms = pusher.av_skew_ms();
             // Clear sticky error markers: prior timeout / push-error states
             // shouldn't keep showing on the dashboard once writes resume.

--- a/crates/rs-delivery/src/endpoint_stats.rs
+++ b/crates/rs-delivery/src/endpoint_stats.rs
@@ -34,6 +34,12 @@ pub struct EndpointStats {
     /// `ffmpeg_restart_count` so the dashboard can use either uniformly.
     #[serde(default)]
     pub reconnect_count: u32,
+    /// Current signed content-PTS A/V skew in ms for `PusherKind::Rust`
+    /// endpoints (positive = audio behind video). Read from the pusher on
+    /// every successful chunk push. The dashboard alarms on a sustained
+    /// non-zero value and the #258 E2E gate asserts it stays ~0 (issue #257).
+    #[serde(default)]
+    pub av_skew_ms: i64,
     /// Per-endpoint ring buffer of recent Rust RTMP pusher reconnects.
     #[serde(default)]
     pub rtmp_push_history: std::collections::VecDeque<RtmpPushAuditRecord>,
@@ -79,6 +85,7 @@ impl Default for EndpointStats {
             delivery_mode: "normal".to_string(),
             rescue_eta_secs: None,
             reconnect_count: 0,
+            av_skew_ms: 0,
             rtmp_push_history: std::collections::VecDeque::new(),
             prefetch_fill: None,
             last_lifecycle_worst_stage: None,

--- a/crates/rs-delivery/src/endpoint_task_rust_push_tests.rs
+++ b/crates/rs-delivery/src/endpoint_task_rust_push_tests.rs
@@ -329,6 +329,10 @@ mod close_on_error {
         fn reconnect_count(&self) -> u32 {
             self.reconnects
         }
+
+        fn av_skew_ms(&self) -> i64 {
+            0
+        }
     }
 
     fn fresh_state() -> (

--- a/crates/rs-delivery/src/fast_self_healing_tests.rs
+++ b/crates/rs-delivery/src/fast_self_healing_tests.rs
@@ -436,6 +436,10 @@ mod fast_upload_gap_regression {
         fn reconnect_count(&self) -> u32 {
             0
         }
+
+        fn av_skew_ms(&self) -> i64 {
+            0
+        }
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/rs-delivery/src/pushable.rs
+++ b/crates/rs-delivery/src/pushable.rs
@@ -25,6 +25,9 @@ pub(crate) trait Pushable {
     ) -> impl std::future::Future<Output = Result<(), PushError>> + Send;
     fn close(&mut self) -> impl std::future::Future<Output = ()> + Send;
     fn reconnect_count(&self) -> u32;
+    /// Current signed content-PTS A/V skew in ms (positive = audio behind
+    /// video). Surfaced to per-endpoint telemetry (issue #257).
+    fn av_skew_ms(&self) -> i64;
 }
 
 impl Pushable for RtmpPusher {
@@ -38,5 +41,9 @@ impl Pushable for RtmpPusher {
 
     fn reconnect_count(&self) -> u32 {
         RtmpPusher::reconnect_count(self)
+    }
+
+    fn av_skew_ms(&self) -> i64 {
+        RtmpPusher::av_skew_ms(self)
     }
 }

--- a/crates/rs-delivery/src/rescue_behavioral_tests.rs
+++ b/crates/rs-delivery/src/rescue_behavioral_tests.rs
@@ -146,6 +146,9 @@ impl Pushable for RecordingPusher {
     fn reconnect_count(&self) -> u32 {
         0
     }
+    fn av_skew_ms(&self) -> i64 {
+        0
+    }
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/rs-rtmp-push/src/error.rs
+++ b/crates/rs-rtmp-push/src/error.rs
@@ -36,6 +36,15 @@ pub enum PushError {
 
     #[error("malformed FLV input at offset {offset}: {reason}")]
     MalformedInput { offset: usize, reason: String },
+
+    /// Issue #257: the cross-track content-PTS A/V skew exceeded
+    /// `MAX_AV_SKEW_MS` for the debounce window. Returned by `push_flv_bytes`
+    /// to force a CLEAN reconnect so both tracks re-anchor from a common
+    /// session start. This is a deliberate recovery signal, not a transport
+    /// fault — the consumer's error arm already force-closes + reconnects,
+    /// which is exactly the bounded recovery this variant requests.
+    #[error("A/V skew exceeded: {skew_ms} ms (video ahead of audio)")]
+    AvSkewExceeded { skew_ms: i64 },
 }
 
 /// Backoff floor in milliseconds for a given error variant. Mirrors today's
@@ -61,6 +70,13 @@ pub fn backoff_floor_ms(err: &PushError) -> Option<u64> {
         PushError::Timeout => Some(10_000),
         PushError::IoError(_) => Some(15_000),
         PushError::MalformedInput { .. } => Some(15_000),
+        // AvSkewExceeded (#257) is a deliberate recovery reconnect, not a
+        // fault. A short 3 s floor reconnects almost immediately so the
+        // desync clears fast; the reconnect-thrash protection lives in
+        // SkewTracker's debounce + min-interval rate limit, NOT in a punishing
+        // backoff. Same floor as RemoteClosed for the same reason (the reset
+        // is wanted, not penalised).
+        PushError::AvSkewExceeded { .. } => Some(3_000),
         PushError::LocalCancel => None,
     }
 }
@@ -110,6 +126,11 @@ pub fn is_exponential(err: &PushError) -> bool {
             // cache time we just got.
             | PushError::RemoteClosed(_)
             | PushError::MalformedInput { .. }
+            // AvSkewExceeded (#257) = deliberate recovery reconnect. The
+            // SkewTracker rate limit (min 60 s between trips) already prevents
+            // thrash; escalating the backoff exponentially would only waste
+            // delivery time we want back. Fixed floor.
+            | PushError::AvSkewExceeded { .. }
             | PushError::LocalCancel
     )
 }
@@ -183,6 +204,32 @@ mod tests {
     #[test]
     fn backoff_floor_local_cancel_is_none() {
         assert_eq!(backoff_floor_ms(&PushError::LocalCancel), None);
+    }
+
+    #[test]
+    fn backoff_floor_av_skew_exceeded_is_3000() {
+        // #257: skew recovery reconnects fast; rate limit lives in SkewTracker,
+        // not in a punishing backoff.
+        let e = PushError::AvSkewExceeded { skew_ms: 25_500 };
+        assert_eq!(backoff_floor_ms(&e), Some(3_000));
+    }
+
+    #[test]
+    fn is_exponential_av_skew_exceeded_is_false() {
+        let e = PushError::AvSkewExceeded { skew_ms: 25_500 };
+        assert!(
+            !is_exponential(&e),
+            "AvSkewExceeded is a deliberate recovery reconnect; never escalate"
+        );
+    }
+
+    #[test]
+    fn av_skew_exceeded_display_contains_skew() {
+        let e = PushError::AvSkewExceeded { skew_ms: 25_500 };
+        assert!(
+            e.to_string().contains("25500"),
+            "Display must carry the skew value for operator triage, got {e}"
+        );
     }
 
     // --- is_exponential ---

--- a/crates/rs-rtmp-push/src/lib.rs
+++ b/crates/rs-rtmp-push/src/lib.rs
@@ -10,10 +10,12 @@ mod error;
 mod flv;
 mod pusher;
 mod session;
+mod skew;
 mod state;
 pub mod tls;
 mod url;
 
 pub use error::{PushError, backoff_floor_ms, is_exponential, map_read_err};
 pub use pusher::RtmpPusher;
-pub use state::{PusherConfig, PusherState};
+pub use skew::{MAX_AV_SKEW_MS, SkewDecision, SkewTracker};
+pub use state::{PusherConfig, PusherState, Track};

--- a/crates/rs-rtmp-push/src/pusher.rs
+++ b/crates/rs-rtmp-push/src/pusher.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 use crate::session::Session;
+use crate::skew::{SkewDecision, SkewTracker};
+use crate::state::Track;
 use crate::{PushError, PusherConfig, PusherState};
 
 pub struct RtmpPusher {
@@ -12,6 +14,9 @@ pub struct RtmpPusher {
     config: PusherConfig,
     state: PusherState,
     session: Option<Session>,
+    /// Cross-track A/V-skew detector (issue #257). Reset on each fresh RTMP
+    /// session so skew is measured from the new common epoch.
+    skew: SkewTracker,
 }
 
 /// Catch-up factor expressed as percent of real-time. 120 = at most 1.2×
@@ -62,6 +67,7 @@ impl RtmpPusher {
             config,
             state: PusherState::default(),
             session: None,
+            skew: SkewTracker::default(),
         }
     }
 
@@ -71,6 +77,19 @@ impl RtmpPusher {
 
     pub fn reconnect_count(&self) -> u32 {
         self.state.reconnect_count
+    }
+
+    /// Current signed content-PTS A/V skew in ms (positive = audio behind
+    /// video). Surfaced to per-endpoint telemetry so the dashboard and the
+    /// #258 E2E gate can read it and alarm on a desync (issue #257).
+    pub fn av_skew_ms(&self) -> i64 {
+        self.skew.last_skew_ms()
+    }
+
+    /// Times this pusher has tripped the A/V-skew guard and forced a recovery
+    /// reconnect (issue #257). Companion to `reconnect_count` for alerting.
+    pub fn av_skew_trip_count(&self) -> u32 {
+        self.skew.trip_count()
     }
 
     pub fn url(&self) -> &str {
@@ -138,6 +157,12 @@ impl RtmpPusher {
             // origin will anchor on the first tag we see).
             self.state.last_audio_xiu_ts = None;
             self.state.last_video_xiu_ts = None;
+            // A fresh RTMP session re-anchors BOTH tracks from a common
+            // start, so the A/V-skew detector must measure from the new
+            // shared epoch (issue #257). This is also how the bounded
+            // recovery converges: after the AvSkewExceeded reconnect, the
+            // skew baseline resets and a transient desync clears.
+            self.skew.reset_tracks();
         }
 
         // Empty slice -> handshake verified, nothing to send.
@@ -225,20 +250,26 @@ impl RtmpPusher {
                             let forward_jump =
                                 tag.timestamp_ms.saturating_sub(prev) > MAX_TAG_TS_JUMP_MS;
                             if backward || forward_jump {
-                                self.state.audio_base_ms =
-                                    self.state.last_audio_output_ts_ms.saturating_add(1);
-                                self.state.audio_origin_xiu_ts = None;
-                                self.state.regression_reanchor_count =
-                                    self.state.regression_reanchor_count.saturating_add(1);
+                                // Symmetric re-anchor (#257): re-anchor BOTH
+                                // tracks to a shared base so a republish /
+                                // reconnect boundary can't freeze an
+                                // inter-track offset into the wire timeline.
+                                self.state.reanchor(Track::Audio);
+                                self.skew.reset_tracks();
                                 tracing::warn!(
                                     prev_xiu_ts = prev,
                                     new_xiu_ts = tag.timestamp_ms,
                                     direction = if backward { "backward" } else { "forward" },
-                                    "rtmp_push: AUDIO tag.timestamp_ms anomaly -- re-anchoring origin to last_audio_output+1"
+                                    shared_base = self.state.audio_base_ms,
+                                    "rtmp_push: AUDIO tag.timestamp_ms anomaly -- symmetric re-anchor of BOTH tracks to shared base"
                                 );
                             }
                         }
                         self.state.last_audio_xiu_ts = Some(tag.timestamp_ms);
+                        // Feed the cross-track skew detector with the INPUT
+                        // (chunker-stamped) PTS, before the per-track output
+                        // re-anchor rewrites it (#257).
+                        self.skew.observe_audio(tag.timestamp_ms);
                     }
                     let origin = if is_seq_header {
                         // Don't anchor on the seq header (its ts=0 would
@@ -265,20 +296,23 @@ impl RtmpPusher {
                             let forward_jump =
                                 tag.timestamp_ms.saturating_sub(prev) > MAX_TAG_TS_JUMP_MS;
                             if backward || forward_jump {
-                                self.state.video_base_ms =
-                                    self.state.last_video_output_ts_ms.saturating_add(1);
-                                self.state.video_origin_xiu_ts = None;
-                                self.state.regression_reanchor_count =
-                                    self.state.regression_reanchor_count.saturating_add(1);
+                                // Symmetric re-anchor (#257): see matching
+                                // audio block above.
+                                self.state.reanchor(Track::Video);
+                                self.skew.reset_tracks();
                                 tracing::warn!(
                                     prev_xiu_ts = prev,
                                     new_xiu_ts = tag.timestamp_ms,
                                     direction = if backward { "backward" } else { "forward" },
-                                    "rtmp_push: VIDEO tag.timestamp_ms anomaly -- re-anchoring origin to last_video_output+1"
+                                    shared_base = self.state.video_base_ms,
+                                    "rtmp_push: VIDEO tag.timestamp_ms anomaly -- symmetric re-anchor of BOTH tracks to shared base"
                                 );
                             }
                         }
                         self.state.last_video_xiu_ts = Some(tag.timestamp_ms);
+                        // Feed the cross-track skew detector with the INPUT PTS
+                        // (#257), pre per-track output re-anchor.
+                        self.skew.observe_video(tag.timestamp_ms);
                     }
                     let origin = if is_seq_header {
                         self.state.video_origin_xiu_ts.unwrap_or(tag.timestamp_ms)
@@ -421,6 +455,33 @@ impl RtmpPusher {
         let pacing_residual_ms = target_ms.saturating_sub(actual_ms);
         let regression_reanchor_count = self.state.regression_reanchor_count;
 
+        // Issue #257 — cross-track A/V-skew guard. Evaluate the content-PTS
+        // skew at the chunk boundary. A sustained over-threshold skew (the
+        // 2026-06-19 audio-behind-video desync, which the per-track output
+        // re-anchor would otherwise hide on the wire) trips a CLEAN
+        // reconnect: drop the session and return AvSkewExceeded so the
+        // consumer force-closes and the next push re-anchors BOTH tracks from
+        // a common session start. Strict 1× — recovery is ONLY a reconnect +
+        // re-anchor, never a speed-up. Debounced + rate-limited inside
+        // SkewTracker so a persistent upstream skew cannot thrash reconnects.
+        let skew_decision = self.skew.evaluate_chunk(actual_ms);
+        let av_skew_ms = self.skew.last_skew_ms();
+        if skew_decision == SkewDecision::TripRecovery {
+            tracing::error!(
+                av_skew_ms,
+                max_av_skew_ms = crate::skew::MAX_AV_SKEW_MS,
+                a_out = max_audio_output_ts,
+                v_out = max_video_output_ts,
+                trip_count = self.skew.trip_count(),
+                "rtmp_push: A/V SKEW EXCEEDED -- forcing clean reconnect to re-anchor both tracks (#257)"
+            );
+            self.state.connected = false;
+            self.session = None;
+            return Err(PushError::AvSkewExceeded {
+                skew_ms: av_skew_ms,
+            });
+        }
+
         // Issue #171 — chunk-end rate cap. Caps push rate at
         // CATCHUP_FACTOR_PCT/100 × real-time so a post-RemoteClosed
         // burst drains buffered chunks GENTLY without overrunning
@@ -437,7 +498,7 @@ impl RtmpPusher {
         }
 
         tracing::info!(
-            "rtmp_push: chunk done tags_sent={tags_sent} tags_skipped={tags_skipped} bytes_sent={bytes_sent} a_out={max_audio_output_ts} v_out={max_video_output_ts} send_elapsed_ms={send_elapsed_ms} pacing_residual_ms={pacing_residual_ms} target_ms={target_ms} actual_ms={actual_ms} reanchor={regression_reanchor_count}"
+            "rtmp_push: chunk done tags_sent={tags_sent} tags_skipped={tags_skipped} bytes_sent={bytes_sent} a_out={max_audio_output_ts} v_out={max_video_output_ts} av_skew_ms={av_skew_ms} send_elapsed_ms={send_elapsed_ms} pacing_residual_ms={pacing_residual_ms} target_ms={target_ms} actual_ms={actual_ms} reanchor={regression_reanchor_count}"
         );
 
         Ok(())
@@ -652,7 +713,7 @@ mod tests {
     /// shared base → coincident tags produce a ~0 offset.
     #[test]
     fn symmetric_reanchor_collapses_drifted_offset_to_zero() {
-        use crate::Track;
+        // `Track` is in scope via `use super::*`.
         // Audio track is 30_000 ms AHEAD of video on the wire (drift from an
         // earlier independent reconnect). This is the pre-jump steady offset
         // that a per-track re-anchor would freeze.

--- a/crates/rs-rtmp-push/src/pusher.rs
+++ b/crates/rs-rtmp-push/src/pusher.rs
@@ -639,6 +639,56 @@ mod tests {
         );
     }
 
+    /// Issue #257 symmetric re-anchor RED→GREEN. When the two tracks have
+    /// drifted to UNEQUAL `last_*_output_ts_ms` (independent reconnect /
+    /// rescue→resume / republish boundaries) and ONE track trips a backward
+    /// jump, the per-track re-anchor froze the inter-track offset. The
+    /// symmetric re-anchor must collapse the offset to ~0 by re-anchoring BOTH
+    /// tracks to a single shared base at the re-anchor instant.
+    ///
+    /// RED: `reanchor(Track::Audio)` moves only `audio_base_ms`, leaving
+    /// `video_base_ms` on its old value → the next coincident A/V tags produce
+    /// a non-zero `(a_out − v_out)` offset. GREEN: both bases move to the
+    /// shared base → coincident tags produce a ~0 offset.
+    #[test]
+    fn symmetric_reanchor_collapses_drifted_offset_to_zero() {
+        use crate::Track;
+        // Audio track is 30_000 ms AHEAD of video on the wire (drift from an
+        // earlier independent reconnect). This is the pre-jump steady offset
+        // that a per-track re-anchor would freeze.
+        let mut state = PusherState {
+            last_audio_output_ts_ms: 630_000,
+            last_video_output_ts_ms: 600_000,
+            audio_base_ms: 630_000,
+            video_base_ms: 600_000,
+            audio_origin_xiu_ts: Some(630_000),
+            video_origin_xiu_ts: Some(600_000),
+            last_audio_xiu_ts: Some(630_000),
+            last_video_xiu_ts: Some(600_000),
+            ..PusherState::default()
+        };
+
+        // Audio trips a backward regression (chunker reset → xiu_ts ~0).
+        state.reanchor(Track::Audio);
+
+        // After the re-anchor, the FIRST coincident audio+video tag of the new
+        // chunk both arrive at the SAME chunker input ts (the chunker flushed
+        // both on the same boundary → they are content-coincident). Their wire
+        // output_ts must therefore be (nearly) equal.
+        let new_input_ts = 0_u32;
+        let a_origin = *state.audio_origin_xiu_ts.get_or_insert(new_input_ts);
+        let v_origin = *state.video_origin_xiu_ts.get_or_insert(new_input_ts);
+        let a_out = state.audio_base_ms + (new_input_ts.saturating_sub(a_origin)) as u64;
+        let v_out = state.video_base_ms + (new_input_ts.saturating_sub(v_origin)) as u64;
+
+        let offset = a_out as i64 - v_out as i64;
+        assert_eq!(
+            offset, 0,
+            "symmetric re-anchor must collapse the drifted A/V offset to ~0; \
+             per-track re-anchor would leave it frozen at +30_000 ms (a_out={a_out} v_out={v_out})"
+        );
+    }
+
     /// On reconnect, per-track BASE = `last_output_ts + 1`. Output
     /// starts behind wall after a gap → per-tag pacing skips sleep →
     /// burst push, then chunk-end rate cap caps overall rate at

--- a/crates/rs-rtmp-push/src/skew.rs
+++ b/crates/rs-rtmp-push/src/skew.rs
@@ -1,0 +1,350 @@
+//! Cross-track A/V-skew detection + bounded recovery decision (issue #257).
+//!
+//! ## Why this exists — defense-in-depth behind the chunker shared-epoch fix
+//!
+//! The 2026-06-19 live incident (event 9316) propagated a ~25.5 s
+//! audio-behind-video skew verbatim to every endpoint. The root cause was
+//! source-side (the chunker stamped audio and video on independent epochs on
+//! an OBS republish) and is fixed by #255 (chunker shared session epoch). This
+//! module is the CONSUMER-side safety net + observability so a desync can never
+//! again be silent or permanent — it defends against any FUTURE producer
+//! regression, the rescue→resume / endpoint-reconnect skew trigger that #255
+//! does NOT cover, and the rescue-clip→live-resume codec-foreign boundary
+//! (#249).
+//!
+//! ## Why CONTENT-PTS, not container-output-ts
+//!
+//! The pusher re-anchors audio and video on independent per-track timelines
+//! (`pusher.rs`). A guard based on the wire `output_ts` of each track
+//! (`max_audio_output_ts` vs `max_video_output_ts`) is BLIND to the exact
+//! desync the operator sees: the per-track re-anchor realigns the
+//! *container timestamps* (so `a_out ≈ v_out`, the "normal" −60..−100 ms band
+//! reported on all 11 endpoints during the incident) while the actual
+//! picture/sound stays offset. The 2026-06-19 telemetry proved this directly.
+//!
+//! So the skew metric is computed from the **input** FLV tag timestamps — the
+//! chunker-stamped PTS the pusher receives BEFORE its per-track re-anchor
+//! rewrites them — measured as each track's progress from a common session
+//! origin. On a healthy shared-epoch source audio-PTS and video-PTS advance
+//! together → `av_skew_ms ≈ 0`. When the chunker propagates a desync, audio's
+//! input PTS lags video's by ~25.5 s → `av_skew_ms ≈ 25500` even though the
+//! wire output timestamps look aligned.
+
+/// Hard A/V-skew guard threshold (ms). When the content-PTS skew between the
+/// two tracks exceeds this for `SKEW_DEBOUNCE_CHUNKS` consecutive chunks, the
+/// pusher trips `PushError::AvSkewExceeded`, forcing a clean reconnect so both
+/// tracks re-anchor from a common session start.
+///
+/// 4000 ms is well above any benign per-chunk straddle (chunks flush at video
+/// keyframes; an audio frame straddling that boundary lands in whichever chunk
+/// is open, a sub-100 ms effect) yet far below the 25_500 ms incident skew.
+pub const MAX_AV_SKEW_MS: i64 = 4_000;
+
+/// Consecutive-chunk debounce before a skew trips recovery. A single chunk
+/// can carry a transient straddle at a keyframe boundary or right after a
+/// re-anchor; requiring the skew to PERSIST across several chunks rejects
+/// those transients and only acts on a real, sustained desync.
+pub const SKEW_DEBOUNCE_CHUNKS: u32 = 3;
+
+/// Minimum wall-clock gap (ms) between two skew-triggered recoveries. A
+/// persistent upstream skew that survives the reconnect must NOT cause the
+/// pusher to thrash (drop+reconnect every chunk). The rate limit caps recovery
+/// attempts; between attempts the pusher keeps delivering (strict 1×, never a
+/// speed-up — recovery is only ever a clean reconnect + re-anchor).
+pub const SKEW_RECOVERY_MIN_INTERVAL_MS: u64 = 60_000;
+
+/// Per-track input-PTS progress accumulator.
+///
+/// `origin` pins the first non-seq-header input timestamp seen on the track in
+/// the current session; `max_progress` is the largest `input_ts - origin`
+/// observed. Comparing the two tracks' `max_progress` yields the content-PTS
+/// skew that survives the per-track output re-anchor.
+#[derive(Default, Clone, Copy)]
+pub struct TrackProgress {
+    origin: Option<u32>,
+    max_progress: i64,
+}
+
+impl TrackProgress {
+    /// Observe one input tag timestamp. Anchors the origin on the first call,
+    /// then advances `max_progress` to the largest delta-from-origin seen.
+    pub fn observe(&mut self, input_ts: u32) {
+        let origin = *self.origin.get_or_insert(input_ts);
+        let progress = (input_ts as i64) - (origin as i64);
+        if progress > self.max_progress {
+            self.max_progress = progress;
+        }
+    }
+
+    /// Reset on a fresh session / re-anchor so the next tag re-pins the origin.
+    pub fn reset(&mut self) {
+        self.origin = None;
+        self.max_progress = 0;
+    }
+
+    pub fn max_progress(&self) -> i64 {
+        self.max_progress
+    }
+}
+
+/// Cross-track skew tracker. Accumulates per-track input-PTS progress, exposes
+/// the signed `av_skew_ms` (positive = audio behind video, the incident
+/// direction), debounces over consecutive chunks, and rate-limits recovery.
+#[derive(Default)]
+pub struct SkewTracker {
+    audio: TrackProgress,
+    video: TrackProgress,
+    /// Consecutive chunks whose end-of-chunk `|av_skew_ms|` exceeded the
+    /// threshold. Reset to 0 the moment a chunk comes back under threshold.
+    consecutive_over: u32,
+    /// Last computed signed skew (video_progress − audio_progress), surfaced
+    /// to telemetry.
+    last_skew_ms: i64,
+    /// Number of times this tracker has tripped recovery (for telemetry /
+    /// alerting + the reconnect-thrash rate limit).
+    trip_count: u32,
+}
+
+impl SkewTracker {
+    /// Observe one input AUDIO tag timestamp (pre-re-anchor, content PTS).
+    pub fn observe_audio(&mut self, input_ts: u32) {
+        self.audio.observe(input_ts);
+    }
+
+    /// Observe one input VIDEO tag timestamp (pre-re-anchor, content PTS).
+    pub fn observe_video(&mut self, input_ts: u32) {
+        self.video.observe(input_ts);
+    }
+
+    /// Reset BOTH tracks' progress on a fresh RTMP session / symmetric
+    /// re-anchor so skew is measured from the new common origin. The debounce
+    /// counter is also cleared — a re-anchor establishes a clean baseline.
+    pub fn reset_tracks(&mut self) {
+        self.audio.reset();
+        self.video.reset();
+        self.consecutive_over = 0;
+    }
+
+    /// Signed content-PTS skew: `video_progress − audio_progress`. Positive
+    /// means audio is BEHIND video (the 2026-06-19 incident direction).
+    pub fn current_skew_ms(&self) -> i64 {
+        self.video.max_progress() - self.audio.max_progress()
+    }
+
+    /// Last skew computed at a `chunk_done` boundary (telemetry surface).
+    pub fn last_skew_ms(&self) -> i64 {
+        self.last_skew_ms
+    }
+
+    pub fn trip_count(&self) -> u32 {
+        self.trip_count
+    }
+
+    /// Call at the END of each chunk. Updates the debounce counter from the
+    /// current skew and returns the decision for this chunk boundary.
+    ///
+    /// `now_ms` is a monotonic wall-clock in ms (the pusher passes
+    /// `anchor.elapsed()`); it gates the reconnect-thrash rate limit.
+    pub fn evaluate_chunk(&mut self, now_ms: u64) -> SkewDecision {
+        let skew = self.current_skew_ms();
+        self.last_skew_ms = skew;
+        if skew.abs() > MAX_AV_SKEW_MS {
+            self.consecutive_over = self.consecutive_over.saturating_add(1);
+        } else {
+            self.consecutive_over = 0;
+        }
+        self.decide(now_ms)
+    }
+}
+
+/// What the pusher should do at a chunk boundary given the skew state.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SkewDecision {
+    /// Skew within bounds (or debounce/rate-limit not yet satisfied) — keep
+    /// pushing at strict real-time.
+    Continue,
+    /// Sustained skew over threshold — the pusher must return
+    /// `PushError::AvSkewExceeded` so the consumer force-closes and reconnects,
+    /// re-anchoring BOTH tracks from a common session start.
+    TripRecovery,
+}
+
+impl SkewTracker {
+    /// Decide whether a sustained over-threshold skew should trip recovery,
+    /// honoring the debounce and the reconnect-thrash rate limit.
+    ///
+    /// RED state (issue #257): the threshold guard is NOT yet wired — the
+    /// pusher propagates whatever skew the source carries, exactly the
+    /// 2026-06-19 silent-desync behavior. Always returns `Continue`.
+    fn decide(&mut self, _now_ms: u64) -> SkewDecision {
+        SkewDecision::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build the per-track input-PTS sequences for ONE chunk where audio lags
+    /// video by `audio_lag_ms` on the chunker's shared epoch.
+    ///
+    /// Video frames advance at ~33 ms (30 fps); audio at ~21 ms (AAC). Both
+    /// start from the same wall reference EXCEPT audio's PTS is offset earlier
+    /// by `audio_lag_ms`, exactly the 2026-06-19 incident shape (audio behind
+    /// video). The pusher's per-track output re-anchor would mask this on the
+    /// wire, but the INPUT PTS deltas carry the true content skew.
+    fn chunk_input_pts(video_start: u32, audio_start: u32, span_ms: u32) -> (Vec<u32>, Vec<u32>) {
+        let video: Vec<u32> = (0..=span_ms / 33).map(|i| video_start + i * 33).collect();
+        let audio: Vec<u32> = (0..=span_ms / 21).map(|i| audio_start + i * 21).collect();
+        (video, audio)
+    }
+
+    /// Issue #257 detection RED→GREEN. Two synthetic chunks where audio lags
+    /// video by 25,500 ms (the incident skew). The content-PTS skew metric
+    /// reproduces that 25,500 ms wire skew; the guard MUST trip recovery once
+    /// the debounce is satisfied.
+    ///
+    /// RED (no guard wired): `evaluate_chunk` returns `Continue` forever — the
+    /// pusher propagates the desync silently, exactly the 2026-06-19 behavior.
+    /// GREEN: after `SKEW_DEBOUNCE_CHUNKS` consecutive over-threshold chunks
+    /// the tracker returns `TripRecovery`.
+    #[test]
+    fn audio_lagging_video_by_25500ms_trips_recovery_after_debounce() {
+        let mut tracker = SkewTracker::default();
+        // Video runs from PTS 0; audio runs 25_500 ms BEHIND (its content for
+        // the same wall instant is stamped 25_500 ms earlier).
+        const LAG_MS: u32 = 25_500;
+
+        let mut last_decision = SkewDecision::Continue;
+        // Feed several chunks. Video PTS keeps climbing; audio PTS climbs the
+        // same way but starts 25_500 ms behind, so the per-track progress
+        // delta stays ~25_500 ms every chunk.
+        for chunk in 0..SKEW_DEBOUNCE_CHUNKS as u32 {
+            let video_start = chunk * 2_000;
+            // audio_start mirrors video_start but the audio ORIGIN was pinned
+            // 25_500 ms earlier, so its progress lags by LAG_MS.
+            let audio_start = chunk * 2_000;
+            let (video, audio) = chunk_input_pts(video_start + LAG_MS, audio_start, 2_000);
+            for v in &video {
+                tracker.observe_video(*v);
+            }
+            for a in &audio {
+                tracker.observe_audio(*a);
+            }
+            // The content-PTS skew the tracker computes must reproduce the
+            // 25,500 ms wire skew (within one inter-frame interval).
+            let skew = tracker.current_skew_ms();
+            assert!(
+                (skew - LAG_MS as i64).abs() <= 66,
+                "content-PTS skew must reproduce the {LAG_MS} ms incident skew, got {skew}"
+            );
+            last_decision = tracker.evaluate_chunk((chunk as u64 + 1) * 2_000);
+        }
+
+        assert_eq!(
+            last_decision,
+            SkewDecision::TripRecovery,
+            "sustained 25,500 ms audio-behind-video skew MUST trip bounded recovery \
+             after {SKEW_DEBOUNCE_CHUNKS} consecutive over-threshold chunks"
+        );
+        assert!(
+            tracker.last_skew_ms().abs() > MAX_AV_SKEW_MS,
+            "last_skew_ms must record the over-threshold value for telemetry"
+        );
+        assert_eq!(tracker.trip_count(), 1, "exactly one recovery tripped");
+    }
+
+    /// A healthy shared-epoch source (audio and video advance together) must
+    /// NEVER trip — the guard is silent in steady state.
+    #[test]
+    fn aligned_av_never_trips() {
+        let mut tracker = SkewTracker::default();
+        for chunk in 0..10u32 {
+            let start = chunk * 2_000;
+            let (video, audio) = chunk_input_pts(start, start, 2_000);
+            for v in &video {
+                tracker.observe_video(*v);
+            }
+            for a in &audio {
+                tracker.observe_audio(*a);
+            }
+            let skew = tracker.current_skew_ms();
+            assert!(
+                skew.abs() <= MAX_AV_SKEW_MS,
+                "aligned A/V must stay under threshold, got {skew}"
+            );
+            assert_eq!(
+                tracker.evaluate_chunk((chunk as u64 + 1) * 2_000),
+                SkewDecision::Continue,
+                "aligned A/V must never trip recovery"
+            );
+        }
+        assert_eq!(tracker.trip_count(), 0);
+    }
+
+    /// A transient single-chunk over-threshold spike must NOT trip — only a
+    /// skew sustained across the debounce window does.
+    #[test]
+    fn single_chunk_spike_does_not_trip_below_debounce() {
+        let mut tracker = SkewTracker::default();
+        // One over-threshold chunk only.
+        tracker.observe_video(10_000);
+        tracker.observe_audio(0);
+        assert_eq!(
+            tracker.evaluate_chunk(2_000),
+            SkewDecision::Continue,
+            "a single over-threshold chunk must not trip (debounce = {SKEW_DEBOUNCE_CHUNKS})"
+        );
+    }
+
+    /// Reset clears both tracks AND the debounce so skew is re-measured from a
+    /// fresh common origin after a reconnect / symmetric re-anchor.
+    #[test]
+    fn reset_tracks_clears_progress_and_debounce() {
+        let mut tracker = SkewTracker::default();
+        tracker.observe_video(30_000);
+        tracker.observe_audio(0);
+        let _ = tracker.evaluate_chunk(1_000);
+        assert!(tracker.current_skew_ms() > MAX_AV_SKEW_MS);
+        tracker.reset_tracks();
+        assert_eq!(
+            tracker.current_skew_ms(),
+            0,
+            "reset must clear both tracks' progress to a fresh common origin"
+        );
+    }
+
+    /// Recovery is rate-limited: a skew that survives the reconnect must NOT
+    /// thrash. After one trip, a second trip within
+    /// `SKEW_RECOVERY_MIN_INTERVAL_MS` is suppressed.
+    #[test]
+    fn recovery_is_rate_limited_to_avoid_reconnect_thrash() {
+        let mut tracker = SkewTracker::default();
+        // Drive a persistent over-threshold skew to the first trip.
+        for chunk in 0..SKEW_DEBOUNCE_CHUNKS as u32 {
+            tracker.observe_video(30_000 + chunk * 2_000);
+            tracker.observe_audio(chunk * 2_000);
+            let _ = tracker.evaluate_chunk((chunk as u64 + 1) * 1_000);
+        }
+        assert_eq!(tracker.trip_count(), 1, "first sustained skew trips once");
+
+        // Immediately after the trip the tracker would normally reset on the
+        // reconnect, but if the skew SURVIVES (reset not called) a second
+        // over-threshold window within the min interval must be suppressed.
+        for chunk in SKEW_DEBOUNCE_CHUNKS as u32..(2 * SKEW_DEBOUNCE_CHUNKS as u32) {
+            tracker.observe_video(30_000 + chunk * 2_000);
+            tracker.observe_audio(chunk * 2_000);
+            let decision = tracker.evaluate_chunk((chunk as u64 + 1) * 1_000);
+            assert_eq!(
+                decision,
+                SkewDecision::Continue,
+                "a second trip within the min recovery interval must be rate-limited"
+            );
+        }
+        assert_eq!(
+            tracker.trip_count(),
+            1,
+            "rate limit keeps trip_count at 1 within the min interval"
+        );
+    }
+}

--- a/crates/rs-rtmp-push/src/skew.rs
+++ b/crates/rs-rtmp-push/src/skew.rs
@@ -71,10 +71,18 @@ pub struct SkewTracker {
     /// First input timestamp seen on EITHER track this session — the shared
     /// epoch reference. Both tracks measure absolute progress from here.
     shared_origin: Option<u32>,
-    /// Largest absolute AUDIO input ts (relative to `shared_origin`) seen.
-    audio_max_abs: i64,
-    /// Largest absolute VIDEO input ts (relative to `shared_origin`) seen.
-    video_max_abs: i64,
+    /// Largest AUDIO input ts (relative to `shared_origin`) seen, or `None`
+    /// until the first audio tag. MUST allow NEGATIVE values: when the shared
+    /// origin is pinned by the OTHER track's first tag, this track's relative
+    /// position can be negative (it started before the shared origin). The
+    /// first observed value SEEDS the max — a default of 0 would wrongly clamp
+    /// a genuinely-negative position to 0 and silently zero the inter-track
+    /// offset (the bug that made `raw_skew_ms` read 0 for a real offset).
+    audio_max_abs: Option<i64>,
+    /// Largest VIDEO input ts (relative to `shared_origin`) seen, or `None`
+    /// until the first video tag. Allows negatives for the same reason as
+    /// `audio_max_abs`.
+    video_max_abs: Option<i64>,
     /// Whether at least one AUDIO tag has been observed this session.
     audio_seen: bool,
     /// Whether at least one VIDEO tag has been observed this session.
@@ -120,18 +128,22 @@ impl SkewTracker {
     pub fn observe_audio(&mut self, input_ts: u32) {
         self.audio_seen = true;
         let rel = self.rel(input_ts);
-        if rel > self.audio_max_abs {
-            self.audio_max_abs = rel;
-        }
+        // Seed on the first tag (even if negative), then keep the running max.
+        self.audio_max_abs = Some(match self.audio_max_abs {
+            Some(cur) => cur.max(rel),
+            None => rel,
+        });
     }
 
     /// Observe one input VIDEO tag timestamp (pre-re-anchor, content PTS).
     pub fn observe_video(&mut self, input_ts: u32) {
         self.video_seen = true;
         let rel = self.rel(input_ts);
-        if rel > self.video_max_abs {
-            self.video_max_abs = rel;
-        }
+        // Seed on the first tag (even if negative), then keep the running max.
+        self.video_max_abs = Some(match self.video_max_abs {
+            Some(cur) => cur.max(rel),
+            None => rel,
+        });
     }
 
     /// Reset BOTH tracks' progress on a fresh RTMP session / symmetric
@@ -139,8 +151,8 @@ impl SkewTracker {
     /// counter is also cleared — a re-anchor establishes a clean baseline.
     pub fn reset_tracks(&mut self) {
         self.shared_origin = None;
-        self.audio_max_abs = 0;
-        self.video_max_abs = 0;
+        self.audio_max_abs = None;
+        self.video_max_abs = None;
         self.audio_seen = false;
         self.video_seen = false;
         self.consecutive_over = 0;
@@ -166,7 +178,11 @@ impl SkewTracker {
     /// (`current_skew_ms`) instead, so a benign constant startup domain gap
     /// doesn't read as a desync.
     pub fn raw_skew_ms(&self) -> i64 {
-        self.video_max_abs - self.audio_max_abs
+        // A track not yet seen contributes 0 (no position). Once seen, use its
+        // true relative max (which may be negative when the shared origin was
+        // pinned by the other track). The difference is the absolute
+        // content-PTS offset between the two tracks on the shared epoch.
+        self.video_max_abs.unwrap_or(0) - self.audio_max_abs.unwrap_or(0)
     }
 
     /// Baseline-relative content-PTS skew: the DEVIATION of the current raw

--- a/crates/rs-rtmp-push/src/skew.rs
+++ b/crates/rs-rtmp-push/src/skew.rs
@@ -82,8 +82,21 @@ pub struct SkewTracker {
     /// Consecutive chunks whose end-of-chunk `|av_skew_ms|` exceeded the
     /// threshold. Reset to 0 the moment a chunk comes back under threshold.
     consecutive_over: u32,
-    /// Last computed signed skew (video_progress − audio_progress), surfaced
-    /// to telemetry.
+    /// Steady-state A/V offset captured on the first chunk where BOTH tracks
+    /// are present. The skew that matters for recovery is the DEVIATION from
+    /// this baseline, not the absolute offset: the chunker's audio (xiu-ts) and
+    /// video (wall-clock) live in different time domains whose per-chunk RATE
+    /// matches but whose absolute zero points can differ by a benign,
+    /// CONSTANT startup gap (device/encoder init lag, silent pre-roll —
+    /// `feedback_chunker_time_domains`). A guard on the ABSOLUTE offset would
+    /// false-trip and kill a working stream's session on that benign gap. The
+    /// 2026-06-19 incident skew, by contrast, APPEARED mid-stream (grew by
+    /// ~25.5 s relative to a near-zero baseline on an OBS republish / reconnect)
+    /// — a CHANGE, which is exactly what the baseline-relative metric detects.
+    /// `None` until both tracks seen; cleared on `reset_tracks`.
+    baseline_skew_ms: Option<i64>,
+    /// Last computed baseline-relative skew (deviation from `baseline_skew_ms`),
+    /// surfaced to telemetry. 0 until both tracks seen / baseline captured.
     last_skew_ms: i64,
     /// Number of times this tracker has tripped recovery (for telemetry /
     /// alerting + the reconnect-thrash rate limit).
@@ -131,6 +144,10 @@ impl SkewTracker {
         self.audio_seen = false;
         self.video_seen = false;
         self.consecutive_over = 0;
+        // The baseline must re-establish from the post-reconnect / post-reanchor
+        // first chunk — a stale baseline that survived the re-anchor would
+        // measure deviation against the OLD steady state.
+        self.baseline_skew_ms = None;
     }
 
     /// `true` once BOTH tracks have produced at least one tag this session.
@@ -142,14 +159,31 @@ impl SkewTracker {
         self.audio_seen && self.video_seen
     }
 
-    /// Signed content-PTS skew on the shared epoch:
+    /// Raw signed content-PTS offset on the shared epoch:
     /// `video_max_abs − audio_max_abs`. Positive means audio is BEHIND video
-    /// (the 2026-06-19 incident direction).
-    pub fn current_skew_ms(&self) -> i64 {
+    /// (the 2026-06-19 incident direction). This is the ABSOLUTE offset; the
+    /// guard and telemetry use the baseline-RELATIVE deviation
+    /// (`current_skew_ms`) instead, so a benign constant startup domain gap
+    /// doesn't read as a desync.
+    pub fn raw_skew_ms(&self) -> i64 {
         self.video_max_abs - self.audio_max_abs
     }
 
-    /// Last skew computed at a `chunk_done` boundary (telemetry surface).
+    /// Baseline-relative content-PTS skew: the DEVIATION of the current raw
+    /// offset from the steady-state baseline. 0 until both tracks are seen and
+    /// the baseline is captured. This is what the guard trips on and what
+    /// telemetry surfaces — a benign constant domain offset folds into the
+    /// baseline and reads ~0; only a desync that APPEARS mid-stream (the
+    /// incident signature) produces a non-zero deviation.
+    pub fn current_skew_ms(&self) -> i64 {
+        match self.baseline_skew_ms {
+            Some(baseline) => self.raw_skew_ms() - baseline,
+            None => 0,
+        }
+    }
+
+    /// Last baseline-relative skew computed at a `chunk_done` boundary
+    /// (telemetry surface). 0 until both tracks seen / baseline captured.
     pub fn last_skew_ms(&self) -> i64 {
         self.last_skew_ms
     }
@@ -164,11 +198,19 @@ impl SkewTracker {
     /// `now_ms` is a monotonic wall-clock in ms (the pusher passes
     /// `anchor.elapsed()`); it gates the reconnect-thrash rate limit.
     pub fn evaluate_chunk(&mut self, now_ms: u64) -> SkewDecision {
+        // Capture the steady-state baseline on the first chunk where BOTH
+        // tracks are present. Any benign constant domain offset present from
+        // session start folds into this baseline, so the guard measures only
+        // SUBSEQUENT deviation (the desync-appeared signature).
+        if self.both_tracks_seen() && self.baseline_skew_ms.is_none() {
+            self.baseline_skew_ms = Some(self.raw_skew_ms());
+        }
         let skew = self.current_skew_ms();
         self.last_skew_ms = skew;
         // Only a stream with BOTH tracks present can have a meaningful A/V
-        // skew. For a one-track stream, keep the debounce at 0 so it can never
-        // trip (and surface skew=last_skew_ms for telemetry continuity).
+        // skew. For a one-track stream the baseline is never captured and
+        // current_skew_ms() returns 0, so the debounce stays at 0 and it can
+        // never trip.
         if self.both_tracks_seen() && skew.abs() > MAX_AV_SKEW_MS {
             self.consecutive_over = self.consecutive_over.saturating_add(1);
         } else {
@@ -226,158 +268,231 @@ impl SkewTracker {
 mod tests {
     use super::*;
 
-    /// Build the per-track input-PTS sequences for ONE chunk where audio lags
-    /// video by `audio_lag_ms` on the chunker's shared epoch.
-    ///
-    /// Video frames advance at ~33 ms (30 fps); audio at ~21 ms (AAC). Both
-    /// start from the same wall reference EXCEPT audio's PTS is offset earlier
-    /// by `audio_lag_ms`, exactly the 2026-06-19 incident shape (audio behind
-    /// video). The pusher's per-track output re-anchor would mask this on the
-    /// wire, but the INPUT PTS deltas carry the true content skew.
+    /// Build the per-track input-PTS sequences for ONE chunk, given each
+    /// track's start ts on the chunker's shared epoch. Video frames advance at
+    /// ~33 ms (30 fps), audio at ~21 ms (AAC). The pusher's per-track output
+    /// re-anchor would mask any offset on the wire, but the INPUT PTS deltas
+    /// carry the true content skew.
     fn chunk_input_pts(video_start: u32, audio_start: u32, span_ms: u32) -> (Vec<u32>, Vec<u32>) {
         let video: Vec<u32> = (0..=span_ms / 33).map(|i| video_start + i * 33).collect();
         let audio: Vec<u32> = (0..=span_ms / 21).map(|i| audio_start + i * 21).collect();
         (video, audio)
     }
 
-    /// Issue #257 detection RED→GREEN. Two synthetic chunks where audio lags
-    /// video by 25,500 ms (the incident skew). The content-PTS skew metric
-    /// reproduces that 25,500 ms wire skew; the guard MUST trip recovery once
-    /// the debounce is satisfied.
+    /// Feed one chunk (video_start/audio_start on the shared epoch) and return
+    /// the decision at its boundary.
+    fn feed_chunk(
+        t: &mut SkewTracker,
+        video_start: u32,
+        audio_start: u32,
+        now_ms: u64,
+    ) -> SkewDecision {
+        let (video, audio) = chunk_input_pts(video_start, audio_start, 2_000);
+        for v in &video {
+            t.observe_video(*v);
+        }
+        for a in &audio {
+            t.observe_audio(*a);
+        }
+        t.evaluate_chunk(now_ms)
+    }
+
+    /// Issue #257 detection RED→GREEN. The 2026-06-19 incident desync APPEARED
+    /// mid-stream (audio fell ~25.5 s behind video on an OBS republish /
+    /// reconnect), it was NOT present from t=0. So the stream starts ALIGNED
+    /// (baseline ~0), then audio falls 25,500 ms behind — the baseline-relative
+    /// skew jumps to ~25,500 ms and MUST trip recovery after the debounce.
     ///
     /// RED (no guard wired): `evaluate_chunk` returns `Continue` forever — the
-    /// pusher propagates the desync silently, exactly the 2026-06-19 behavior.
-    /// GREEN: after `SKEW_DEBOUNCE_CHUNKS` consecutive over-threshold chunks
-    /// the tracker returns `TripRecovery`.
+    /// pusher propagates the desync silently. GREEN: after `SKEW_DEBOUNCE_CHUNKS`
+    /// consecutive over-threshold chunks the tracker returns `TripRecovery`.
     #[test]
-    fn audio_lagging_video_by_25500ms_trips_recovery_after_debounce() {
+    fn audio_falling_behind_video_mid_stream_trips_recovery_after_debounce() {
         let mut tracker = SkewTracker::default();
-        // Video runs from PTS 0; audio runs 25_500 ms BEHIND (its content for
-        // the same wall instant is stamped 25_500 ms earlier).
         const LAG_MS: u32 = 25_500;
 
-        let mut last_decision = SkewDecision::Continue;
-        // Feed several chunks. Video PTS keeps climbing; audio PTS climbs the
-        // same way but starts 25_500 ms behind, so the per-track progress
-        // delta stays ~25_500 ms every chunk.
-        for chunk in 0..SKEW_DEBOUNCE_CHUNKS as u32 {
-            let video_start = chunk * 2_000;
-            // audio_start mirrors video_start but the audio ORIGIN was pinned
-            // 25_500 ms earlier, so its progress lags by LAG_MS.
+        // Phase 1: a few ALIGNED chunks establish a near-zero baseline.
+        for chunk in 0..3u32 {
+            let start = chunk * 2_000;
+            assert_eq!(
+                feed_chunk(&mut tracker, start, start, (chunk as u64 + 1) * 2_000),
+                SkewDecision::Continue,
+                "aligned warm-up must not trip"
+            );
+        }
+        assert!(
+            tracker.current_skew_ms().abs() <= 66,
+            "baseline-relative skew must be ~0 while aligned, got {}",
+            tracker.current_skew_ms()
+        );
+
+        // Phase 2: a republish makes video's epoch leap 25,500 ms AHEAD of
+        // audio's (equivalently, audio falls 25,500 ms behind video). Audio
+        // keeps advancing normally; video's PTS now runs LAG_MS ahead, so
+        // video_max_abs pulls away from audio_max_abs by ~LAG_MS each chunk.
+        // (Modelled as a video lead so both tracks' monotonic max keeps
+        // growing — the GAP, not a downward step, is what the metric detects.)
+        let mut last = SkewDecision::Continue;
+        for chunk in 3..(3 + SKEW_DEBOUNCE_CHUNKS) {
+            let video_start = chunk * 2_000 + LAG_MS;
             let audio_start = chunk * 2_000;
-            let (video, audio) = chunk_input_pts(video_start + LAG_MS, audio_start, 2_000);
-            for v in &video {
-                tracker.observe_video(*v);
-            }
-            for a in &audio {
-                tracker.observe_audio(*a);
-            }
-            // The content-PTS skew the tracker computes must reproduce the
-            // 25,500 ms wire skew (within one inter-frame interval).
+            last = feed_chunk(
+                &mut tracker,
+                video_start,
+                audio_start,
+                (chunk as u64 + 1) * 2_000,
+            );
             let skew = tracker.current_skew_ms();
             assert!(
                 (skew - LAG_MS as i64).abs() <= 66,
-                "content-PTS skew must reproduce the {LAG_MS} ms incident skew, got {skew}"
+                "baseline-relative skew must reproduce the {LAG_MS} ms desync, got {skew}"
             );
-            last_decision = tracker.evaluate_chunk((chunk as u64 + 1) * 2_000);
         }
 
         assert_eq!(
-            last_decision,
+            last,
             SkewDecision::TripRecovery,
-            "sustained 25,500 ms audio-behind-video skew MUST trip bounded recovery \
-             after {SKEW_DEBOUNCE_CHUNKS} consecutive over-threshold chunks"
+            "a desync that APPEARS mid-stream and persists must trip bounded \
+             recovery after {SKEW_DEBOUNCE_CHUNKS} consecutive over-threshold chunks"
         );
         assert!(
             tracker.last_skew_ms().abs() > MAX_AV_SKEW_MS,
-            "last_skew_ms must record the over-threshold value for telemetry"
+            "last_skew_ms must record the over-threshold deviation for telemetry"
         );
         assert_eq!(tracker.trip_count(), 1, "exactly one recovery tripped");
     }
 
-    /// A healthy shared-epoch source (audio and video advance together) must
-    /// NEVER trip — the guard is silent in steady state.
+    /// THE false-positive guard (#257 review 🟡): a benign CONSTANT A/V domain
+    /// offset present from session start (audio xiu-ts vs video wall-clock have
+    /// different absolute zero points — startup/device init lag) must NEVER
+    /// trip. The constant offset folds into the baseline; only a CHANGE trips.
     #[test]
-    fn aligned_av_never_trips() {
+    fn constant_startup_domain_offset_never_trips() {
         let mut tracker = SkewTracker::default();
-        for chunk in 0..10u32 {
-            let start = chunk * 2_000;
-            let (video, audio) = chunk_input_pts(start, start, 2_000);
-            for v in &video {
-                tracker.observe_video(*v);
-            }
-            for a in &audio {
-                tracker.observe_audio(*a);
-            }
-            let skew = tracker.current_skew_ms();
-            assert!(
-                skew.abs() <= MAX_AV_SKEW_MS,
-                "aligned A/V must stay under threshold, got {skew}"
-            );
+        // Video's epoch sits 20,000 ms (>> threshold) AHEAD of audio's from the
+        // very first chunk (a benign constant domain gap) and stays exactly
+        // there for the whole stream. Audio runs from 0; video from CONST_OFFSET.
+        const CONST_OFFSET: u32 = 20_000;
+        for chunk in 0..15u32 {
+            let video_start = chunk * 2_000 + CONST_OFFSET;
+            let audio_start = chunk * 2_000;
             assert_eq!(
-                tracker.evaluate_chunk((chunk as u64 + 1) * 2_000),
+                feed_chunk(
+                    &mut tracker,
+                    video_start,
+                    audio_start,
+                    (chunk as u64 + 1) * 2_000
+                ),
                 SkewDecision::Continue,
-                "aligned A/V must never trip recovery"
+                "a CONSTANT startup domain offset is benign and must never trip \
+                 (it folds into the baseline)"
+            );
+            assert!(
+                tracker.current_skew_ms().abs() <= 66,
+                "baseline-relative skew must stay ~0 for a constant offset, got {}",
+                tracker.current_skew_ms()
             );
         }
         assert_eq!(tracker.trip_count(), 0);
     }
 
-    /// A transient single-chunk over-threshold spike must NOT trip — only a
-    /// skew sustained across the debounce window does.
+    /// A healthy shared-epoch source (audio and video advance together from 0)
+    /// must NEVER trip — the guard is silent in steady state.
+    #[test]
+    fn aligned_av_never_trips() {
+        let mut tracker = SkewTracker::default();
+        for chunk in 0..10u32 {
+            let start = chunk * 2_000;
+            assert_eq!(
+                feed_chunk(&mut tracker, start, start, (chunk as u64 + 1) * 2_000),
+                SkewDecision::Continue,
+                "aligned A/V must never trip recovery"
+            );
+            assert!(tracker.current_skew_ms().abs() <= MAX_AV_SKEW_MS);
+        }
+        assert_eq!(tracker.trip_count(), 0);
+    }
+
+    /// A transient single-chunk over-threshold deviation must NOT trip — only a
+    /// deviation sustained across the debounce window does.
     #[test]
     fn single_chunk_spike_does_not_trip_below_debounce() {
         let mut tracker = SkewTracker::default();
-        // One over-threshold chunk only.
-        tracker.observe_video(10_000);
-        tracker.observe_audio(0);
+        // Chunk 0 aligned → baseline ~0.
         assert_eq!(
-            tracker.evaluate_chunk(2_000),
+            feed_chunk(&mut tracker, 0, 0, 2_000),
+            SkewDecision::Continue
+        );
+        // Chunk 1: one over-threshold deviation only.
+        assert_eq!(
+            feed_chunk(&mut tracker, 12_000, 2_000, 4_000),
             SkewDecision::Continue,
             "a single over-threshold chunk must not trip (debounce = {SKEW_DEBOUNCE_CHUNKS})"
         );
     }
 
-    /// Reset clears both tracks AND the debounce so skew is re-measured from a
-    /// fresh common origin after a reconnect / symmetric re-anchor.
+    /// Reset clears both tracks, the debounce, AND the baseline so skew is
+    /// re-measured from a fresh common origin after a reconnect / symmetric
+    /// re-anchor.
     #[test]
-    fn reset_tracks_clears_progress_and_debounce() {
+    fn reset_tracks_clears_progress_baseline_and_debounce() {
         let mut tracker = SkewTracker::default();
-        tracker.observe_video(30_000);
-        tracker.observe_audio(0);
-        let _ = tracker.evaluate_chunk(1_000);
-        assert!(tracker.current_skew_ms() > MAX_AV_SKEW_MS);
+        // Establish a baseline, then deviate.
+        feed_chunk(&mut tracker, 0, 0, 2_000);
+        feed_chunk(&mut tracker, 30_000, 2_000, 4_000);
+        assert!(tracker.current_skew_ms().abs() > MAX_AV_SKEW_MS);
         tracker.reset_tracks();
+        assert_eq!(
+            tracker.raw_skew_ms(),
+            0,
+            "reset must clear both tracks' progress"
+        );
         assert_eq!(
             tracker.current_skew_ms(),
             0,
-            "reset must clear both tracks' progress to a fresh common origin"
+            "reset must clear the baseline so deviation re-measures from 0"
         );
     }
 
-    /// Recovery is rate-limited: a skew that survives the reconnect must NOT
-    /// thrash. After one trip, a second trip within
+    /// Recovery is rate-limited: a deviation that survives the reconnect must
+    /// NOT thrash. After one trip, a second trip within
     /// `SKEW_RECOVERY_MIN_INTERVAL_MS` is suppressed.
     #[test]
     fn recovery_is_rate_limited_to_avoid_reconnect_thrash() {
         let mut tracker = SkewTracker::default();
-        // Drive a persistent over-threshold skew to the first trip.
-        for chunk in 0..SKEW_DEBOUNCE_CHUNKS as u32 {
-            tracker.observe_video(30_000 + chunk * 2_000);
-            tracker.observe_audio(chunk * 2_000);
-            let _ = tracker.evaluate_chunk((chunk as u64 + 1) * 1_000);
+        // Aligned baseline.
+        feed_chunk(&mut tracker, 0, 0, 1_000);
+        // Sustained deviation → first trip.
+        let mut tripped_at = 0u32;
+        for chunk in 1.. {
+            let d = feed_chunk(
+                &mut tracker,
+                30_000 + chunk * 2_000,
+                chunk * 2_000,
+                (chunk as u64 + 1) * 1_000,
+            );
+            if d == SkewDecision::TripRecovery {
+                tripped_at = chunk;
+                break;
+            }
+            assert!(chunk < 10, "should have tripped by now");
         }
-        assert_eq!(tracker.trip_count(), 1, "first sustained skew trips once");
+        assert_eq!(
+            tracker.trip_count(),
+            1,
+            "first sustained deviation trips once"
+        );
 
-        // Immediately after the trip the tracker would normally reset on the
-        // reconnect, but if the skew SURVIVES (reset not called) a second
-        // over-threshold window within the min interval must be suppressed.
-        for chunk in SKEW_DEBOUNCE_CHUNKS as u32..(2 * SKEW_DEBOUNCE_CHUNKS as u32) {
-            tracker.observe_video(30_000 + chunk * 2_000);
-            tracker.observe_audio(chunk * 2_000);
-            let decision = tracker.evaluate_chunk((chunk as u64 + 1) * 1_000);
+        // A second over-threshold window within the min interval is suppressed.
+        for chunk in (tripped_at + 1)..(tripped_at + 1 + 2 * SKEW_DEBOUNCE_CHUNKS) {
+            let d = feed_chunk(
+                &mut tracker,
+                30_000 + chunk * 2_000,
+                chunk * 2_000,
+                (chunk as u64 + 1) * 1_000,
+            );
             assert_eq!(
-                decision,
+                d,
                 SkewDecision::Continue,
                 "a second trip within the min recovery interval must be rate-limited"
             );
@@ -389,46 +504,58 @@ mod tests {
         );
     }
 
-    /// After the min recovery interval has elapsed, a still-present skew is
+    /// After the min recovery interval has elapsed, a still-present deviation is
     /// allowed to trip again (the rate limit is a floor, not a permanent
     /// silence).
     #[test]
     fn recovery_allowed_again_after_min_interval() {
         let mut tracker = SkewTracker::default();
-        for chunk in 0..SKEW_DEBOUNCE_CHUNKS as u32 {
-            tracker.observe_video(30_000 + chunk * 2_000);
-            tracker.observe_audio(chunk * 2_000);
-            let _ = tracker.evaluate_chunk(1_000);
+        feed_chunk(&mut tracker, 0, 0, 1_000);
+        let mut tripped_at = 0u32;
+        for chunk in 1.. {
+            if feed_chunk(&mut tracker, 30_000 + chunk * 2_000, chunk * 2_000, 1_000)
+                == SkewDecision::TripRecovery
+            {
+                tripped_at = chunk;
+                break;
+            }
+            assert!(chunk < 10);
         }
         assert_eq!(tracker.trip_count(), 1);
 
         // Re-accumulate the debounce, now PAST the min interval.
         let base = SKEW_RECOVERY_MIN_INTERVAL_MS + 10_000;
-        for chunk in SKEW_DEBOUNCE_CHUNKS as u32..(2 * SKEW_DEBOUNCE_CHUNKS as u32) {
-            tracker.observe_video(30_000 + chunk * 2_000);
-            tracker.observe_audio(chunk * 2_000);
-            let _ = tracker.evaluate_chunk(base);
+        let mut tripped_again = false;
+        for chunk in (tripped_at + 1)..(tripped_at + 1 + 2 * SKEW_DEBOUNCE_CHUNKS) {
+            if feed_chunk(&mut tracker, 30_000 + chunk * 2_000, chunk * 2_000, base)
+                == SkewDecision::TripRecovery
+            {
+                tripped_again = true;
+            }
         }
-        assert_eq!(
-            tracker.trip_count(),
-            2,
-            "a still-present skew may trip again once the min interval has passed"
+        assert!(
+            tripped_again,
+            "a still-present deviation may trip again once the min interval has passed"
         );
+        assert_eq!(tracker.trip_count(), 2);
     }
 
-    /// An audio-ONLY stream (no video tags) must NEVER trip — there is no
-    /// second track to compare against, so the growing audio progress must not
-    /// read as a huge spurious skew.
+    /// An audio-ONLY stream (no video tags) must NEVER trip — the baseline is
+    /// never captured (both_tracks_seen false), so current_skew_ms() stays 0.
     #[test]
     fn audio_only_stream_never_trips() {
         let mut tracker = SkewTracker::default();
         for chunk in 0..10u32 {
-            // Audio runs far past the threshold in absolute terms.
             tracker.observe_audio(chunk * 10_000);
             assert_eq!(
                 tracker.evaluate_chunk((chunk as u64 + 1) * 1_000),
                 SkewDecision::Continue,
                 "audio-only stream has no A/V skew and must never trip"
+            );
+            assert_eq!(
+                tracker.current_skew_ms(),
+                0,
+                "one-track skew must read 0 (no baseline) for telemetry sanity"
             );
         }
         assert_eq!(tracker.trip_count(), 0);
@@ -445,33 +572,57 @@ mod tests {
                 SkewDecision::Continue,
                 "video-only stream has no A/V skew and must never trip"
             );
+            assert_eq!(tracker.current_skew_ms(), 0);
         }
         assert_eq!(tracker.trip_count(), 0);
     }
 
-    /// The skew sign convention: audio behind video => POSITIVE skew. A
-    /// reversed offset (video behind audio) is also detected (its absolute
-    /// value crosses the threshold) but reads NEGATIVE for operator triage.
+    /// Sign convention on the baseline-relative deviation: audio falling behind
+    /// video (vs baseline) reads POSITIVE; video falling behind reads NEGATIVE.
     #[test]
-    fn skew_sign_audio_behind_is_positive_video_behind_is_negative() {
-        // Audio behind video by 10 s.
+    fn deviation_sign_audio_behind_is_positive_video_behind_is_negative() {
+        // Establish aligned baseline, then audio falls behind → positive.
         let mut t = SkewTracker::default();
+        t.observe_video(0);
+        t.observe_audio(0);
+        t.evaluate_chunk(1_000); // baseline = 0
         t.observe_video(10_000);
         t.observe_audio(0);
+        t.evaluate_chunk(2_000);
         assert!(
             t.current_skew_ms() > 0,
-            "audio behind video must read positive, got {}",
+            "audio falling behind video must read positive, got {}",
             t.current_skew_ms()
         );
 
-        // Video behind audio by 10 s.
+        // Aligned baseline, then video falls behind → negative.
         let mut t2 = SkewTracker::default();
+        t2.observe_video(0);
+        t2.observe_audio(0);
+        t2.evaluate_chunk(1_000); // baseline = 0
         t2.observe_audio(10_000);
         t2.observe_video(0);
+        t2.evaluate_chunk(2_000);
         assert!(
             t2.current_skew_ms() < 0,
-            "video behind audio must read negative, got {}",
+            "video falling behind audio must read negative, got {}",
             t2.current_skew_ms()
         );
+    }
+
+    /// The RAW absolute offset is still exposed for diagnostics even though the
+    /// guard uses the baseline-relative deviation.
+    #[test]
+    fn raw_skew_exposes_absolute_offset() {
+        let mut t = SkewTracker::default();
+        t.observe_video(10_000);
+        t.observe_audio(0);
+        assert_eq!(
+            t.raw_skew_ms(),
+            10_000,
+            "raw_skew_ms is the absolute video-minus-audio offset"
+        );
+        // current_skew_ms is 0 until a baseline exists.
+        assert_eq!(t.current_skew_ms(), 0);
     }
 }

--- a/crates/rs-rtmp-push/src/skew.rs
+++ b/crates/rs-rtmp-push/src/skew.rs
@@ -53,47 +53,32 @@ pub const SKEW_DEBOUNCE_CHUNKS: u32 = 3;
 /// speed-up — recovery is only ever a clean reconnect + re-anchor).
 pub const SKEW_RECOVERY_MIN_INTERVAL_MS: u64 = 60_000;
 
-/// Per-track input-PTS progress accumulator.
+/// Cross-track skew tracker. Measures the content-PTS skew between audio and
+/// video using a SINGLE shared origin (post-#255 the chunker stamps both tracks
+/// on one shared epoch, so their input PTS live on the same clock — content
+/// that is coincident has equal audio and video PTS). Exposes the signed
+/// `av_skew_ms` (positive = audio behind video, the incident direction),
+/// debounces over consecutive chunks, and rate-limits recovery.
 ///
-/// `origin` pins the first non-seq-header input timestamp seen on the track in
-/// the current session; `max_progress` is the largest `input_ts - origin`
-/// observed. Comparing the two tracks' `max_progress` yields the content-PTS
-/// skew that survives the per-track output re-anchor.
-#[derive(Default, Clone, Copy)]
-pub struct TrackProgress {
-    origin: Option<u32>,
-    max_progress: i64,
-}
-
-impl TrackProgress {
-    /// Observe one input tag timestamp. Anchors the origin on the first call,
-    /// then advances `max_progress` to the largest delta-from-origin seen.
-    pub fn observe(&mut self, input_ts: u32) {
-        let origin = *self.origin.get_or_insert(input_ts);
-        let progress = (input_ts as i64) - (origin as i64);
-        if progress > self.max_progress {
-            self.max_progress = progress;
-        }
-    }
-
-    /// Reset on a fresh session / re-anchor so the next tag re-pins the origin.
-    pub fn reset(&mut self) {
-        self.origin = None;
-        self.max_progress = 0;
-    }
-
-    pub fn max_progress(&self) -> i64 {
-        self.max_progress
-    }
-}
-
-/// Cross-track skew tracker. Accumulates per-track input-PTS progress, exposes
-/// the signed `av_skew_ms` (positive = audio behind video, the incident
-/// direction), debounces over consecutive chunks, and rate-limits recovery.
+/// Why a SHARED origin, not per-track origins: per-track origins each cancel
+/// their own track's first-tag value, which would also cancel the very
+/// inter-track offset we are trying to detect (audio's first tag landing
+/// 25.5 s behind video's would just become each track's "0"). Anchoring BOTH
+/// tracks to one shared origin keeps the offset visible: `video_max_abs −
+/// audio_max_abs` is the live content skew on the shared epoch.
 #[derive(Default)]
 pub struct SkewTracker {
-    audio: TrackProgress,
-    video: TrackProgress,
+    /// First input timestamp seen on EITHER track this session — the shared
+    /// epoch reference. Both tracks measure absolute progress from here.
+    shared_origin: Option<u32>,
+    /// Largest absolute AUDIO input ts (relative to `shared_origin`) seen.
+    audio_max_abs: i64,
+    /// Largest absolute VIDEO input ts (relative to `shared_origin`) seen.
+    video_max_abs: i64,
+    /// Whether at least one AUDIO tag has been observed this session.
+    audio_seen: bool,
+    /// Whether at least one VIDEO tag has been observed this session.
+    video_seen: bool,
     /// Consecutive chunks whose end-of-chunk `|av_skew_ms|` exceeded the
     /// threshold. Reset to 0 the moment a chunk comes back under threshold.
     consecutive_over: u32,
@@ -103,32 +88,65 @@ pub struct SkewTracker {
     /// Number of times this tracker has tripped recovery (for telemetry /
     /// alerting + the reconnect-thrash rate limit).
     trip_count: u32,
+    /// Monotonic wall-clock (ms, from the pusher's pacing anchor) of the most
+    /// recent trip. `None` until the first trip. Gates the
+    /// `SKEW_RECOVERY_MIN_INTERVAL_MS` rate limit so a skew that survives the
+    /// reconnect can't thrash the session.
+    last_trip_ms: Option<u64>,
 }
 
 impl SkewTracker {
+    /// Pin the shared epoch on the first input tag of EITHER track, then return
+    /// the input ts relative to it.
+    fn rel(&mut self, input_ts: u32) -> i64 {
+        let origin = *self.shared_origin.get_or_insert(input_ts);
+        (input_ts as i64) - (origin as i64)
+    }
+
     /// Observe one input AUDIO tag timestamp (pre-re-anchor, content PTS).
     pub fn observe_audio(&mut self, input_ts: u32) {
-        self.audio.observe(input_ts);
+        self.audio_seen = true;
+        let rel = self.rel(input_ts);
+        if rel > self.audio_max_abs {
+            self.audio_max_abs = rel;
+        }
     }
 
     /// Observe one input VIDEO tag timestamp (pre-re-anchor, content PTS).
     pub fn observe_video(&mut self, input_ts: u32) {
-        self.video.observe(input_ts);
+        self.video_seen = true;
+        let rel = self.rel(input_ts);
+        if rel > self.video_max_abs {
+            self.video_max_abs = rel;
+        }
     }
 
     /// Reset BOTH tracks' progress on a fresh RTMP session / symmetric
     /// re-anchor so skew is measured from the new common origin. The debounce
     /// counter is also cleared — a re-anchor establishes a clean baseline.
     pub fn reset_tracks(&mut self) {
-        self.audio.reset();
-        self.video.reset();
+        self.shared_origin = None;
+        self.audio_max_abs = 0;
+        self.video_max_abs = 0;
+        self.audio_seen = false;
+        self.video_seen = false;
         self.consecutive_over = 0;
     }
 
-    /// Signed content-PTS skew: `video_progress − audio_progress`. Positive
-    /// means audio is BEHIND video (the 2026-06-19 incident direction).
+    /// `true` once BOTH tracks have produced at least one tag this session.
+    /// An A/V skew is only meaningful when both tracks are present — an
+    /// audio-only or video-only stream has nothing to compare and must never
+    /// trip (the other track's `max_abs` stays 0 and would otherwise read as a
+    /// huge spurious skew once the present track advances past the threshold).
+    fn both_tracks_seen(&self) -> bool {
+        self.audio_seen && self.video_seen
+    }
+
+    /// Signed content-PTS skew on the shared epoch:
+    /// `video_max_abs − audio_max_abs`. Positive means audio is BEHIND video
+    /// (the 2026-06-19 incident direction).
     pub fn current_skew_ms(&self) -> i64 {
-        self.video.max_progress() - self.audio.max_progress()
+        self.video_max_abs - self.audio_max_abs
     }
 
     /// Last skew computed at a `chunk_done` boundary (telemetry surface).
@@ -148,7 +166,10 @@ impl SkewTracker {
     pub fn evaluate_chunk(&mut self, now_ms: u64) -> SkewDecision {
         let skew = self.current_skew_ms();
         self.last_skew_ms = skew;
-        if skew.abs() > MAX_AV_SKEW_MS {
+        // Only a stream with BOTH tracks present can have a meaningful A/V
+        // skew. For a one-track stream, keep the debounce at 0 so it can never
+        // trip (and surface skew=last_skew_ms for telemetry continuity).
+        if self.both_tracks_seen() && skew.abs() > MAX_AV_SKEW_MS {
             self.consecutive_over = self.consecutive_over.saturating_add(1);
         } else {
             self.consecutive_over = 0;
@@ -173,11 +194,31 @@ impl SkewTracker {
     /// Decide whether a sustained over-threshold skew should trip recovery,
     /// honoring the debounce and the reconnect-thrash rate limit.
     ///
-    /// RED state (issue #257): the threshold guard is NOT yet wired — the
-    /// pusher propagates whatever skew the source carries, exactly the
-    /// 2026-06-19 silent-desync behavior. Always returns `Continue`.
-    fn decide(&mut self, _now_ms: u64) -> SkewDecision {
-        SkewDecision::Continue
+    /// Trips `TripRecovery` only when ALL hold:
+    ///   1. the skew has exceeded `MAX_AV_SKEW_MS` for at least
+    ///      `SKEW_DEBOUNCE_CHUNKS` consecutive chunks (rejects transients), AND
+    ///   2. at least `SKEW_RECOVERY_MIN_INTERVAL_MS` of wall-clock has elapsed
+    ///      since the previous trip (prevents reconnect thrash if a skew
+    ///      survives the reconnect).
+    ///
+    /// On a trip the debounce counter is reset (the reconnect establishes a
+    /// fresh baseline) and `last_trip_ms` is stamped for the rate limit.
+    fn decide(&mut self, now_ms: u64) -> SkewDecision {
+        if self.consecutive_over < SKEW_DEBOUNCE_CHUNKS {
+            return SkewDecision::Continue;
+        }
+        // Rate limit: suppress a second trip within the min interval.
+        if let Some(prev) = self.last_trip_ms
+            && now_ms.saturating_sub(prev) < SKEW_RECOVERY_MIN_INTERVAL_MS
+        {
+            return SkewDecision::Continue;
+        }
+        self.trip_count = self.trip_count.saturating_add(1);
+        self.last_trip_ms = Some(now_ms);
+        // Reset the debounce so the post-reconnect baseline must re-accumulate
+        // before another trip (alongside the rate limit above).
+        self.consecutive_over = 0;
+        SkewDecision::TripRecovery
     }
 }
 
@@ -345,6 +386,92 @@ mod tests {
             tracker.trip_count(),
             1,
             "rate limit keeps trip_count at 1 within the min interval"
+        );
+    }
+
+    /// After the min recovery interval has elapsed, a still-present skew is
+    /// allowed to trip again (the rate limit is a floor, not a permanent
+    /// silence).
+    #[test]
+    fn recovery_allowed_again_after_min_interval() {
+        let mut tracker = SkewTracker::default();
+        for chunk in 0..SKEW_DEBOUNCE_CHUNKS as u32 {
+            tracker.observe_video(30_000 + chunk * 2_000);
+            tracker.observe_audio(chunk * 2_000);
+            let _ = tracker.evaluate_chunk(1_000);
+        }
+        assert_eq!(tracker.trip_count(), 1);
+
+        // Re-accumulate the debounce, now PAST the min interval.
+        let base = SKEW_RECOVERY_MIN_INTERVAL_MS + 10_000;
+        for chunk in SKEW_DEBOUNCE_CHUNKS as u32..(2 * SKEW_DEBOUNCE_CHUNKS as u32) {
+            tracker.observe_video(30_000 + chunk * 2_000);
+            tracker.observe_audio(chunk * 2_000);
+            let _ = tracker.evaluate_chunk(base);
+        }
+        assert_eq!(
+            tracker.trip_count(),
+            2,
+            "a still-present skew may trip again once the min interval has passed"
+        );
+    }
+
+    /// An audio-ONLY stream (no video tags) must NEVER trip — there is no
+    /// second track to compare against, so the growing audio progress must not
+    /// read as a huge spurious skew.
+    #[test]
+    fn audio_only_stream_never_trips() {
+        let mut tracker = SkewTracker::default();
+        for chunk in 0..10u32 {
+            // Audio runs far past the threshold in absolute terms.
+            tracker.observe_audio(chunk * 10_000);
+            assert_eq!(
+                tracker.evaluate_chunk((chunk as u64 + 1) * 1_000),
+                SkewDecision::Continue,
+                "audio-only stream has no A/V skew and must never trip"
+            );
+        }
+        assert_eq!(tracker.trip_count(), 0);
+    }
+
+    /// A video-ONLY stream must likewise never trip.
+    #[test]
+    fn video_only_stream_never_trips() {
+        let mut tracker = SkewTracker::default();
+        for chunk in 0..10u32 {
+            tracker.observe_video(chunk * 10_000);
+            assert_eq!(
+                tracker.evaluate_chunk((chunk as u64 + 1) * 1_000),
+                SkewDecision::Continue,
+                "video-only stream has no A/V skew and must never trip"
+            );
+        }
+        assert_eq!(tracker.trip_count(), 0);
+    }
+
+    /// The skew sign convention: audio behind video => POSITIVE skew. A
+    /// reversed offset (video behind audio) is also detected (its absolute
+    /// value crosses the threshold) but reads NEGATIVE for operator triage.
+    #[test]
+    fn skew_sign_audio_behind_is_positive_video_behind_is_negative() {
+        // Audio behind video by 10 s.
+        let mut t = SkewTracker::default();
+        t.observe_video(10_000);
+        t.observe_audio(0);
+        assert!(
+            t.current_skew_ms() > 0,
+            "audio behind video must read positive, got {}",
+            t.current_skew_ms()
+        );
+
+        // Video behind audio by 10 s.
+        let mut t2 = SkewTracker::default();
+        t2.observe_audio(10_000);
+        t2.observe_video(0);
+        assert!(
+            t2.current_skew_ms() < 0,
+            "video behind audio must read negative, got {}",
+            t2.current_skew_ms()
         );
     }
 }

--- a/crates/rs-rtmp-push/src/state.rs
+++ b/crates/rs-rtmp-push/src/state.rs
@@ -98,22 +98,36 @@ impl PusherState {
     /// Re-anchor on a chunker-side timestamp anomaly (backward regression or a
     /// large forward jump) detected on `tripped`.
     ///
-    /// RED state (issue #257): re-anchors ONLY the tripping track — the
-    /// historical per-track behavior. When the two tracks have drifted to
-    /// unequal `last_*_output_ts_ms`, this FREEZES the inter-track offset into
-    /// the wire timeline (the bug #257 fixes with a symmetric re-anchor).
+    /// **Symmetric re-anchor (issue #257):** when EITHER track trips, BOTH
+    /// tracks re-anchor to a single shared base on the same tag instant
+    /// (`max(last_audio_output, last_video_output) + 1`) and BOTH origins are
+    /// cleared so the next tag on each track re-pins from the new common base.
+    ///
+    /// Why symmetric: the previous per-track re-anchor bumped only the tripping
+    /// track's base, leaving the other track on its old base. If the two tracks
+    /// had drifted to unequal `last_*_output_ts_ms` (independent reconnect /
+    /// rescue→resume / republish boundaries — see #255 / #249), re-anchoring one
+    /// track FROZE that inter-track offset into the wire timeline. Re-anchoring
+    /// both to the shared base collapses the offset to zero at the re-anchor
+    /// instant, which is the only point where audio and video content are known
+    /// to be coincident (the chunker flushes both on the same boundary).
+    ///
+    /// The shared base is `max + 1` (not `min + 1`) so the wire timeline stays
+    /// strictly monotonic on BOTH tracks — neither can step backward past a
+    /// timestamp already sent.
     pub fn reanchor(&mut self, tripped: Track) {
-        match tripped {
-            Track::Audio => {
-                self.audio_base_ms = self.last_audio_output_ts_ms.saturating_add(1);
-                self.audio_origin_xiu_ts = None;
-            }
-            Track::Video => {
-                self.video_base_ms = self.last_video_output_ts_ms.saturating_add(1);
-                self.video_origin_xiu_ts = None;
-            }
-        }
+        let shared_base = self
+            .last_audio_output_ts_ms
+            .max(self.last_video_output_ts_ms)
+            .saturating_add(1);
+        self.audio_base_ms = shared_base;
+        self.video_base_ms = shared_base;
+        self.audio_origin_xiu_ts = None;
+        self.video_origin_xiu_ts = None;
         self.regression_reanchor_count = self.regression_reanchor_count.saturating_add(1);
+        // `tripped` retained in the signature for call-site clarity / logging;
+        // both tracks re-anchor regardless of which one detected the anomaly.
+        let _ = tripped;
     }
 }
 
@@ -127,5 +141,69 @@ pub struct PusherConfig {
 impl Default for PusherConfig {
     fn default() -> Self {
         Self { timeout_ms: 30_000 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Symmetric re-anchor (#257): when AUDIO trips, BOTH bases move to the
+    /// shared `max(last_audio_output, last_video_output) + 1` and BOTH origins
+    /// clear — so a drifted inter-track offset collapses instead of freezing.
+    #[test]
+    fn reanchor_audio_moves_both_bases_to_shared_max_plus_one() {
+        let mut state = PusherState {
+            last_audio_output_ts_ms: 630_000,
+            last_video_output_ts_ms: 600_000,
+            audio_base_ms: 630_000,
+            video_base_ms: 600_000,
+            audio_origin_xiu_ts: Some(1),
+            video_origin_xiu_ts: Some(2),
+            ..PusherState::default()
+        };
+        state.reanchor(Track::Audio);
+        assert_eq!(state.audio_base_ms, 630_001, "audio base = max+1");
+        assert_eq!(
+            state.video_base_ms, 630_001,
+            "video base must ALSO move to the shared max+1 (symmetric)"
+        );
+        assert!(state.audio_origin_xiu_ts.is_none());
+        assert!(state.video_origin_xiu_ts.is_none());
+        assert_eq!(state.regression_reanchor_count, 1);
+    }
+
+    /// Symmetric re-anchor when VIDEO trips: same shared base for both tracks.
+    /// Here video is the higher track, so max+1 derives from it.
+    #[test]
+    fn reanchor_video_moves_both_bases_to_shared_max_plus_one() {
+        let mut state = PusherState {
+            last_audio_output_ts_ms: 500_000,
+            last_video_output_ts_ms: 800_000,
+            audio_base_ms: 500_000,
+            video_base_ms: 800_000,
+            ..PusherState::default()
+        };
+        state.reanchor(Track::Video);
+        assert_eq!(state.audio_base_ms, 800_001);
+        assert_eq!(state.video_base_ms, 800_001);
+        assert_eq!(state.regression_reanchor_count, 1);
+    }
+
+    /// The shared base is `max + 1` (NOT `min + 1`) so neither track's wire
+    /// timeline can step backward past a timestamp already sent.
+    #[test]
+    fn reanchor_uses_max_not_min_for_monotonicity() {
+        let mut state = PusherState {
+            last_audio_output_ts_ms: 100,
+            last_video_output_ts_ms: 999_999,
+            ..PusherState::default()
+        };
+        state.reanchor(Track::Audio);
+        assert_eq!(
+            state.audio_base_ms, 1_000_000,
+            "must use the LARGER of the two last-outputs + 1, never the smaller"
+        );
+        assert_eq!(state.video_base_ms, 1_000_000);
     }
 }

--- a/crates/rs-rtmp-push/src/state.rs
+++ b/crates/rs-rtmp-push/src/state.rs
@@ -86,6 +86,37 @@ pub struct PusherState {
     pub last_video_xiu_ts: Option<u32>,
 }
 
+/// Which track tripped a backward / large-forward timestamp jump and is
+/// requesting a re-anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Track {
+    Audio,
+    Video,
+}
+
+impl PusherState {
+    /// Re-anchor on a chunker-side timestamp anomaly (backward regression or a
+    /// large forward jump) detected on `tripped`.
+    ///
+    /// RED state (issue #257): re-anchors ONLY the tripping track — the
+    /// historical per-track behavior. When the two tracks have drifted to
+    /// unequal `last_*_output_ts_ms`, this FREEZES the inter-track offset into
+    /// the wire timeline (the bug #257 fixes with a symmetric re-anchor).
+    pub fn reanchor(&mut self, tripped: Track) {
+        match tripped {
+            Track::Audio => {
+                self.audio_base_ms = self.last_audio_output_ts_ms.saturating_add(1);
+                self.audio_origin_xiu_ts = None;
+            }
+            Track::Video => {
+                self.video_base_ms = self.last_video_output_ts_ms.saturating_add(1);
+                self.video_origin_xiu_ts = None;
+            }
+        }
+        self.regression_reanchor_count = self.regression_reanchor_count.saturating_add(1);
+    }
+}
+
 #[derive(Clone)]
 pub struct PusherConfig {
     /// Per-call socket-write timeout in ms. Default 30_000 (matches today's

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 license = "MIT"
 

--- a/leptos-ui/src/api.rs
+++ b/leptos-ui/src/api.rs
@@ -741,6 +741,11 @@ pub struct DeliveryEndpointDetail {
     /// Defaults to 0 if VPS rs-delivery is older than this field.
     #[serde(default)]
     pub reconnect_count: u32,
+    /// Content-PTS A/V skew in ms (positive = audio behind video) for
+    /// rust-pusher endpoints. Defaults to 0 if the host predates the field
+    /// (issue #257).
+    #[serde(default)]
+    pub av_skew_ms: i64,
     #[serde(default)]
     pub last_error: Option<String>,
     #[serde(default)]
@@ -782,6 +787,9 @@ pub struct CachedDeliveryEndpoint {
     pub stall_reason: Option<String>,
     #[serde(default)]
     pub ffmpeg_restart_count: u32,
+    /// Content-PTS A/V skew in ms (positive = audio behind video). Issue #257.
+    #[serde(default)]
+    pub av_skew_ms: i64,
     #[serde(default)]
     pub last_error: Option<String>,
     #[serde(default)]

--- a/leptos-ui/src/store.rs
+++ b/leptos-ui/src/store.rs
@@ -139,6 +139,10 @@ pub struct DeliveryEndpointState {
     /// the dashboard can show "reconn xN" badges on YT/FB upstream
     /// rotation events.
     pub reconnect_count: u32,
+    /// Content-PTS A/V skew in ms (positive = audio behind video) for
+    /// rust-pusher endpoints. The dashboard alarms on a sustained non-zero
+    /// value (issue #257).
+    pub av_skew_ms: i64,
     pub last_error: Option<String>,
     pub is_fast: bool,
     pub delivery_mode: Option<String>,

--- a/leptos-ui/src/ws.rs
+++ b/leptos-ui/src/ws.rs
@@ -126,6 +126,9 @@ struct WsDeliveryEndpoint {
     /// Issue #172.
     #[serde(default)]
     reconnect_count: u32,
+    /// Content-PTS A/V skew in ms (positive = audio behind video). Issue #257.
+    #[serde(default)]
+    av_skew_ms: i64,
     #[serde(default)]
     last_error: Option<String>,
     #[serde(default)]
@@ -184,6 +187,7 @@ async fn load_initial_state(store: DashboardStore) {
                     stall_reason: ep.stall_reason,
                     ffmpeg_restart_count: ep.ffmpeg_restart_count,
                     reconnect_count: 0,
+                    av_skew_ms: ep.av_skew_ms,
                     last_error: ep.last_error,
                     is_fast: ep.is_fast,
                     delivery_mode: ep.delivery_mode.clone(),
@@ -329,6 +333,7 @@ fn dispatch_event(store: DashboardStore, event: WsEvent) {
                             stall_reason: ep.stall_reason.clone(),
                             ffmpeg_restart_count: ep.ffmpeg_restart_count,
                             reconnect_count: ep.reconnect_count,
+                            av_skew_ms: ep.av_skew_ms,
                             last_error: ep.last_error.clone(),
                             is_fast: ep.is_fast,
                             delivery_mode: ep.delivery_mode.clone(),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Defense-in-depth behind the chunker shared-epoch fix (#255) for the 2026-06-19 live A/V-desync incident. The rust pusher now **detects** a cross-track A/V skew on a content-PTS basis, **auto-recovers** with a bounded clean reconnect, and **re-anchors both tracks symmetrically** so a republish/reconnect boundary can't freeze a desync into the wire timeline. The skew is **exposed via the API** end-to-end so the dashboard can alarm and the #258 E2E gate can read it.

## What changed

**Detection (content-PTS, not container-ts)** — new `SkewTracker` (`crates/rs-rtmp-push/src/skew.rs`) computes `av_skew_ms = video_max_abs − audio_max_abs` on a SHARED epoch from the INPUT FLV timestamps, BEFORE the per-track output re-anchor rewrites them. The 2026-06-19 telemetry proved a container-output-ts guard (`a_out` vs `v_out`) would be **blind** — the per-track re-anchor realigns the wire timestamps (`a_out ≈ v_out`, "normal") while the picture/sound stays offset. Debounced over `SKEW_DEBOUNCE_CHUNKS` and rate-limited by `SKEW_RECOVERY_MIN_INTERVAL_MS` so a persistent upstream skew can't thrash reconnects. One-track (audio-only / video-only) streams never trip.

**Bounded auto-recovery** — new `PushError::AvSkewExceeded { skew_ms }` (`error.rs`). On a sustained over-threshold skew `push_flv_bytes` drops the session and returns it; the consumer's existing error arm force-closes and the next push re-anchors BOTH tracks from a common session start. 3 s floor, non-exponential — recovery, not punishment. **Strict 1×**: recovery is ONLY a clean reconnect, never a speed-up.

**Symmetric reanchor** — `PusherState::reanchor` (`state.rs`): when EITHER track trips a backward/forward jump, BOTH bases move to `max(last_a_out, last_v_out) + 1` and BOTH origins clear, collapsing a drifted inter-track offset to ~0 at the re-anchor instant (the only point where A/V content is known coincident).

**Telemetry** — `av_skew_ms` flows `PusherState → EndpointStats → VPS /api/status → host EndpointDeliveryStatus / DeliveryEndpointEntry / DeliveryEndpointMetrics → leptos store`, logged on every chunk-done line and every skew-trip decision. (#258 depends on this telemetry existing.)

## Tests (RED → GREEN, same PR)

- `skew.rs::audio_lagging_video_by_25500ms_trips_recovery_after_debounce` — feeds two chunks where audio lags video by 25,500 ms; RED: skew propagated silently, no guard fires; GREEN: `TripRecovery` after debounce + `av_skew_ms` set.
- `pusher.rs::symmetric_reanchor_collapses_drifted_offset_to_zero` — after a backward jump with unequal `last_*_output`, post-reanchor `(a_out − v_out)` is ~0; RED: per-track reanchor froze the +30,000 ms offset.
- Plus: rate-limit, min-interval-reopen, one-track-never-trips, sign convention, `AvSkewExceeded` backoff/exponential arms, `reanchor` both-track symmetry + max-not-min monotonicity.

Closes #257