### PR TITLE
test(e2e): assert A/V alignment after OBS republish via av_skew_ms (#258)

### DIFF
--- a/.claude/skills/facebook-streaming/SKILL.md
+++ b/.claude/skills/facebook-streaming/SKILL.md
@@ -85,7 +85,7 @@ ffmpeg -y -i "$dash" -frames:v 1 -q:v 2 frame.jpg
 
 **FB App**: `restreamer-fb-ci` / App display name `New Level Church`
 - App ID: `355685179541516` (GitHub secret: `FB_APP_ID`)
-- App Secret: `dde1f03a6ac90094082a99db480178ae` (GitHub secret: `FB_APP_SECRET`)
+- App Secret: `<FB App Secret — GitHub secret FB_APP_SECRET, NOT committed>` (GitHub secret: `FB_APP_SECRET`)
 
 **FB Page**: "New level church"
 - Page ID: `163104934022649` (GitHub secret: `FB_PAGE_ID`)

--- a/.claude/skills/facebook-streaming/SKILL.md
+++ b/.claude/skills/facebook-streaming/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: facebook-streaming
+description: >
+  Facebook Live streaming gotchas, CI verification architecture, Graph API
+  credentials, and operator procedures. Load when working on FB endpoints,
+  FB CI gate, e2e-fb-push-stream-lan job, or diagnosing FB delivery failures.
+triggers:
+  - facebook
+  - FB endpoint
+  - FB Live
+  - e2e-fb-push
+  - FB Graph API
+  - live_video
+  - FB CI
+---
+
+# Facebook Live Streaming
+
+## Critical Gotchas (DO NOT RE-LEARN)
+
+### Persistent stream key requires a BOUND live_video
+
+A FB **persistent stream key** (`FB-<id>-0-<rand>`) only ingests into a decodable `live_video` when a session is **bound** to it — either an active Live Producer composer in "ready to go live" state, OR a Graph-API-created `live_video` whose `stream_url` key you push to.
+
+**Pushing to a bare persistent key with no bound session**: FB's edge accepts the TCP/RTMP connection (no close, no error), but **silently discards the bytes**. No `live_video` is created, nothing decodes, preview stays BLACK. This is an FB platform binding behavior, NOT a pusher bug.
+
+**CI works because**: restreamer creates the `live_video` via `POST /<page>/live_videos` first, parses the key from `stream_url`, pushes to THAT key → ingest is bound → decodes. The per-run-fresh-broadcast design is correct.
+
+### FB live BROADCAST dies after ~6 hours
+
+FB's RTMP server kills broadcast sessions older than ~6 hours. Symptoms: `endpoint_rtmp_push_died` + error `upstream closed connection mid-stream: unexpected end of file` + `chunks_pushed=0` + `bytes_sent_since_connect=0`.
+
+**When this happens**: FIRST hypothesis is "FB live broadcast expired (6h session limit)", NOT bitrate.
+
+**Fix**: Operator opens Facebook Live Producer/Studio and **creates a NEW live broadcast** (the broadcast/session, not the key). The persistent stream key itself stays the same — the 6h cap applies to the broadcast session, not the key.
+
+- Do NOT propose bitrate reduction as the fix
+- Do NOT change the persistent stream key
+- Other endpoints (YouTube, Kiko/Resolume) are unaffected — only FB enforces this limit
+
+### Stream keys are persistent — never propose rotation
+
+All FB stream keys configured in Restreamer are FB "Always Active" / persistent keys. Do NOT suggest the keys are "expired", "stale", "single-use", or that the user must rotate them.
+
+### FB local signals do NOT prove FB acceptance
+
+`alive`, `chunks_processed`, `bytes_processed_total`, zero deaths — these do NOT prove FB accepts the stream. FB can silently discard. Only Live Producer preview (or Graph API `stream_health` with `status=LIVE`) = proof.
+
+### No ffmpeg fallback — ever
+
+NEVER propose ffmpeg fallback for FB endpoints. ffmpeg pusher never worked correctly in production — that is the exact reason for the rust pusher migration.
+
+### CI must be hands-free — no daily re-auth
+
+NEVER propose a CI verification architecture that requires operator to re-authenticate periodically. Always use refresh-token / long-lived API paths. Persistent-browser-session approaches are BANNED — FB session cookies expire ~17h after operator setup.
+
+## CI Verification Architecture (FINAL — DO NOT RE-ASK)
+
+**Architecture**: Graph API + per-run live_video create + delete. No browser, no Playwright, no persistent Chrome profile, no daily re-auth.
+
+For each CI push that runs `e2e-fb-push-stream-lan`:
+
+1. **Create** broadcast: `POST https://graph.facebook.com/v17.0/$FB_PAGE_ID/live_videos?access_token=$FB_PAGE_ACCESS_TOKEN&status=UNPUBLISHED&title=CI-restreamer-test-$run_id` → returns `{id, stream_url}`
+2. **Parse stream key**: from `stream_url` matches `rtmps://live-api-s.facebook.com:443/rtmp/FB-<id>-0-<random>` — the segment after `/rtmp/` IS the stream key string
+3. **Seed restreamer** via `POST /api/v1/facebook/config/seed` with the fresh key
+4. **Activate event + attach `e2e fb` endpoint + delivery_start**
+5. **Watchdog** local signals (chunks_processed, bytes, zero deaths)
+6. **Verify FB-side**: poll `GET https://graph.facebook.com/v17.0/<live_video_id>?access_token=$FB_PAGE_ACCESS_TOKEN&fields=status` — assert `status=LIVE` within ~2 min of delivery start
+7. **Cleanup**: `DELETE https://graph.facebook.com/v17.0/<live_video_id>?access_token=$FB_PAGE_ACCESS_TOKEN`
+
+**Definition of done** for FB PR: CI fully green + dashboard green + 4h soak green + CI FB auto-verification green. First-preview observation is 25%, not done.
+
+## Visual Verification (when operator wants to SEE the stream)
+
+UNPUBLISHED broadcasts are NOT viewable via the public producer URL. Pull a frame from FB's own DASH transcode instead:
+
+```powershell
+$dash = (Invoke-RestMethod -Uri "https://graph.facebook.com/v17.0/<live_video_id>?access_token=<token>&fields=ingest_streams{dash_preview_url}").ingest_streams[0].dash_preview_url
+ffmpeg -y -i "$dash" -frames:v 1 -q:v 2 frame.jpg
+```
+
+`dash_preview_url` is a live MPEG-DASH manifest FB generates FROM our incoming RTMP. A frame extracted from it proves FB received and decoded the stream.
+
+## Credentials (CI — GitHub Secrets)
+
+**FB App**: `restreamer-fb-ci` / App display name `New Level Church`
+- App ID: `355685179541516` (GitHub secret: `FB_APP_ID`)
+- App Secret: `dde1f03a6ac90094082a99db480178ae` (GitHub secret: `FB_APP_SECRET`)
+
+**FB Page**: "New level church"
+- Page ID: `163104934022649` (GitHub secret: `FB_PAGE_ID`)
+
+**Page Access Token** (GitHub secret: `FB_PAGE_ACCESS_TOKEN`):
+- `expires_at: 0` — NEVER EXPIRES (verified 2026-05-19)
+- Valid as long as: Zbynek remains admin of Page 163104934022649 + App 355685179541516 stays valid
+
+**If token is compromised or revoked**:
+1. Operator regenerates User Token in Graph API Explorer with same scopes
+2. Re-run long-lived exchange + page-token derivation:
+   ```bash
+   LONG_USER=$(curl -s "https://graph.facebook.com/v17.0/oauth/access_token?grant_type=fb_exchange_token&client_id=$APP_ID&client_secret=$APP_SECRET&fb_exchange_token=$SHORT_TOKEN" | jq -r .access_token)
+   PAGE_TOKEN=$(curl -s "https://graph.facebook.com/v17.0/me/accounts?access_token=$LONG_USER" | jq -r '.data[]|select(.id=="163104934022649")|.access_token')
+   ```
+3. `gh secret set FB_PAGE_ACCESS_TOKEN --body "$PAGE_TOKEN"`
+4. Update this file with the new value + mint timestamp
+
+## Iterating on FB Failures (Not CI)
+
+For unknown FB failure modes, iterate via **direct MCP test against streamsnv + VPS binary swap** (5-15 min/cycle), NOT 80-min CI cycles. CI is for regression verification after the fix is confirmed working.
+
+## E2E Cleanup
+
+ALWAYS detach and delete test endpoints from stream.lan's shared E2E-Test event after soaks/experiments. Leftovers fail CI because the e2e gate checks ALL attached endpoints. Do NOT cancel-thrash stuck runs.

--- a/.claude/skills/obs-recovery/SKILL.md
+++ b/.claude/skills/obs-recovery/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: obs-recovery
+description: >
+  Autonomous OBS and CI runner recovery procedures for stream.lan (streamsnv).
+  Load when OBS is in degraded state, CI E2E fails on OBS state, or runner
+  appears offline. Covers graceful restart, machine reboot authorization,
+  and OBS health verification.
+triggers:
+  - OBS degraded
+  - OBS not starting
+  - OBS recovery
+  - CI runner offline
+  - runner stalled
+  - obs64
+  - WebSocket not listening
+  - streamsnv runner
+---
+
+# OBS and CI Runner Recovery
+
+## Autonomous Recovery Authorization
+
+When CI fails on OBS state on the streamsnv runner and operator is **away / not in a live event**, autonomously recover without pausing to ask. Operator explicitly authorized this autonomy for non-live-event windows (2026-05-16).
+
+**First: verify NOT in a live event** — check audit log for recent EventStarted / no `delivering_activated` event within the past hour.
+
+**Banned phrasings during autonomous sessions:**
+- "OBS is in degraded state, please restart"
+- "Approve graceful WM_CLOSE?"
+- "Want me to reboot the runner?"
+- Any AskUserQuestion that asks permission to recover a runner
+
+## OBS Restart Procedure
+
+### Step 1 — Graceful shutdown
+
+```powershell
+# Via MCP shell — always WM_CLOSE first, NEVER /F unless graceful fails
+mcp__win-stream-snv__Shell command="taskkill /IM obs64.exe /T"
+```
+
+Wait 15-30 seconds and verify gone:
+```powershell
+mcp__win-stream-snv__ListProcesses filter="obs64"
+```
+
+If still running after 30s: `/F` is acceptable during operator-away autonomous sessions.
+
+### Step 2 — Relaunch via existing scheduled task
+
+```powershell
+# Use the EXISTING scheduled task — do NOT re-register it
+mcp__win-stream-snv__Shell command="Start-ScheduledTask -TaskName 'OBS Studio'"
+```
+
+**Do NOT re-register the OBS scheduled task** — it already works (do not guess parameters and rewrite it).
+
+### Step 3 — Wait and verify health
+
+Wait 60-90 seconds for OBS to load scene. A healthy OBS uses ~1 GB+ memory.
+
+```powershell
+# Check memory usage — must be > 500 MB (healthy), not ~37 MB (broken)
+mcp__win-stream-snv__Shell command="Get-Process obs64 | Format-List Id, WorkingSet64"
+
+# Verify single OBS process
+mcp__win-stream-snv__ListProcesses filter="obs64"
+
+# Verify WebSocket is listening
+mcp__win-stream-snv__PortCheck host="127.0.0.1" port=4455
+
+# Visual confirmation
+mcp__win-stream-snv__Snapshot
+```
+
+### Step 4 — Machine reboot (last resort)
+
+If OBS or Restreamer cannot be recovered by relaunch:
+
+```powershell
+mcp__win-stream-snv__Shell command="Restart-Computer -Force"
+```
+
+After reboot: wait ~2-3 minutes, then verify all services recovered, then rerun the failed CI job.
+
+## Critical OBS Rules
+
+### NEVER use `/F` (force kill) as the first move
+
+Force-killing OBS leaves a crash-recovery dialog on next launch. The `--disable-shutdown-check` argument does NOT prevent this dialog — it still hangs OBS at ~18 MB working set.
+
+**Exception**: `/F` is acceptable during operator-away autonomous sessions IF graceful `taskkill /IM obs64.exe /T` fails within 30 seconds.
+
+### NEVER try to kill OBS processes to fix duplicate/bad state
+
+If OBS is in a bad state with recovery dialogs, ask the operator to manually close OBS and dismiss dialogs, then start fresh. Killing OBS remotely when it's showing recovery dialogs makes things worse.
+
+### Starting OBS Correctly (when needed)
+
+OBS MUST be started with the correct working directory (CRITICAL for proper initialization):
+
+```powershell
+mcp__win-stream-snv__Shell command="Start-Process 'C:\Program Files\obs-studio\bin\64bit\obs64.exe' -ArgumentList '--disable-shutdown-check'" cwd="C:\Program Files\obs-studio\bin\64bit"
+```
+
+Without the correct working directory, OBS starts in a broken state (~37 MB memory, no WebSocket server, error dialogs).
+
+### OBS Config Locations
+
+| File | Purpose |
+|---|---|
+| `C:\Users\newlevel\AppData\Roaming\obs-studio\global.ini` | Global OBS settings |
+| `C:\Users\newlevel\AppData\Roaming\obs-studio\basic\profiles\Stream_Obs\service.json` | Stream destination config |
+| `C:\Users\newlevel\AppData\Roaming\obs-studio\basic\profiles\Stream_Obs\streamEncoder.json` | Encoder/bitrate config |
+| `C:\Users\newlevel\AppData\Roaming\obs-studio\plugin_config\obs-websocket\config.json` | WebSocket settings |
+
+**OBS uses Advanced mode, Stream_Obs profile. Bitrate is in `streamEncoder.json`, NOT `basic.ini`.**
+
+## Runner Offline Detection
+
+When a CI deploy/E2E job stays "queued" with `startedAt` set, the runner is likely offline. Alert user within first poll (within 5 minutes of detecting the queue condition) — do NOT wait hours.
+
+## When Operator Must Be Involved
+
+If OBS is in a bad state with visible recovery dialogs AND it cannot be cleared remotely:
+- Ask operator to manually close OBS and dismiss dialogs
+- Then start fresh using the MCP shell command above
+- This is the ONLY case where operator assistance is needed for OBS state

--- a/.claude/skills/outage-rescue/SKILL.md
+++ b/.claude/skills/outage-rescue/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: outage-rescue
+description: >
+  Outage survival design, rescue mechanism behavior, and operator decisions
+  for the rescue/notification UX cluster. Load when working on outage handling,
+  rescue clip activation, keepalive logic, RTMP push behavior during outages,
+  or the notification/overlay features (#259-#263, #73).
+triggers:
+  - outage
+  - rescue
+  - keepalive
+  - stream behind
+  - continuity
+  - replay
+  - EndpointLifecycle
+  - outage notification
+  - rescue overlay
+---
+
+# Outage Survival and Rescue Design
+
+## Locked Design Decisions (DO NOT RE-ASK)
+
+### Recovery = Replay Everything / Continuity
+
+Network-class upload errors (timeout/5xx/conn/other) retry **FOREVER** at capped 30s backoff — never abandoned. Only structural rejects (400/403/404) abandon after a 5-attempt budget (`should_abandon_upload`).
+
+On restore, the VPS replays the backlog in sequence order. **By design the stream stays ~outage_duration behind real-time after a long outage** (strict 1x, no catch-up burst). This is intentional: continuity over latency. Full recording preserved locally for VOD.
+
+**RTMP push to YT/FB MUST ALWAYS be strictly 1x — never speed up or burst to catch up.** Speeding up corrupts quality and YT/FB kills the stream. Recovery is never via speed-up.
+
+### Topology = OBS Local on stream.lan
+
+During an outage, OBS keeps feeding; only the S3 uplink dies. A local backlog always exists.
+
+### Lifecycle Semaphore (EndpointLifecycle)
+
+Defined in `crates/rs-core/src/endpoint_lifecycle.rs`, computed host-side in `delivery_status.rs`:
+
+- **Live** = GREEN
+- **Buffering/Rescue/Recovering** = BLUE ("protected, recovering, no action needed")
+- **Attention** = RED ONLY for auth/key-reject, disk-critical, or poison chunk
+
+A survivable outage shows BLUE, never RED. Calm `OutageBanner` replaces the red wall. Actionable `last_error` only reds when `!alive` (stale-error guard).
+
+### disk_critical Safety Valve
+
+`disk_pressure.rs` monitor (warn 80%/critical 90%, alert-only, NEVER drops) sets an `AtomicBool` shared via `AppState` → `DeliveryOrchestrator.disk_critical()` → lifecycle goes Attention (red) on disk-full.
+
+## Fast Endpoints and Rescue (Operator Decision 2026-06-14)
+
+**Fast (is_fast) endpoints MUST escalate to the rescue clip on a fresh RTMP session during sustained outage.** This reverses the old "fast unprotected" tradeoff (root cause of #251 all-dark crash test).
+
+**LIVE RTMP session = codec-homogeneous bytes ONLY.** A rescue clip pushed on a live session with different codec settings (wrong SPS/PPS) locks the decoder → solid GREEN video with all health metrics showing good — silent visual corruption. Keepalive is freeze-only. Codec-foreign content requires a session drop + reconnect.
+
+**Rescue activation requires**: push rescue clip on a **fresh** RTMP session (not the existing live session).
+
+## E2E Test Requirements
+
+CI proof for outage survival:
+- `e2e-obs-youtube` "Long outage" step blocks S3 for 5 min
+- Assert: zero abandoned chunks + rescue activated + calm blue banner (Playwright) + backlog drains in order + rescue recovered
+- `RescueRecovered` event fires ~120s after chunks resume (`RESCUE_REFILL_TARGET_SECS`)
+- CI assertions must **POLL** for RescueRecovered, not check once
+
+## Rescue UX Cluster — Operator Decisions (2026-06-22)
+
+Design decisions for tickets #259-#263 and #73:
+
+| Ticket | Feature | Decision |
+|---|---|---|
+| #259 | Rescue overlay language | Slovak text + live countdown timer |
+| #260 | No-rescue-url warning | Show warning if no rescue_video_url configured |
+| #261 | Discord alert | Implement now (top priority) |
+| #263 | Dashboard banner | Implement |
+| #73 | Desktop screen-edge glow overlay | RESCOPED: Tauri transparent always-on-top overlay (like iemmixer), desktop screen-edge glow |
+| #262, #139 | Phone notifications | DEFERRED — needs-creds (Twilio/VAPID) |
+
+## Known Architecture Gaps (from #251 root cause analysis)
+
+Five failure layers discovered in 2026-06-14 crash test (event 9312 — all 7 endpoints went dark):
+
+1. **Fast endpoints architecturally excluded from rescue** (primary — `endpoint_task.rs:430` fast branch has only `rx.recv` + 2s freeze-only keepalive, no `run_outage_rescue` arm) → #251
+2. **No host crash-recovery resume** (poll_handles/endpoint_fast_cache/resume_positions in-memory, reset to empty on crash) → #252
+3. **Non-fast rescue gate stuck shut on error-shaped drain** (`run_outage_rescue` gated on `!producer_active`, cleared only on Ok(None)/404 path) → #253
+4. **No producer respawn** (spec Component #4a never implemented; endpoint tears down permanently on producer finish/panic) → #237
+5. **Test gap = meta-cause**: rescue tests are source-grep only (`rescue_tests.rs:550-829`), never exercise the trigger; fast tests assert rescue NEVER pushed; specced e2e crash job never built (#238); cargo-mutants excludes rescue::/consumer_task/producer_task/endpoint_loop
+
+**Fix constraint**: Cannot build/test locally (dev1 OOM) — all via CI. Crash verification needs forced kill on stream.lan (destructive → requires operator to not be in a live event).
+
+## Outage Audit Events
+
+Wired in PR #232 (v0.20.0) — these events must fire for correct forensic reconstruction:
+- 7 previously-dead `DiskCache*` events
+- `RescueActivated` (with gap_secs)
+- `RescueRecovered` (fires ~120s after chunks resume)
+- `RtmpHandshakeFailed`
+
+"Working" = cache ~120s GREEN + 0 deaths + 0 crashes + 0 errors over full soak — NOT just "chunks advancing".

--- a/.claude/skills/streaming-boxes/SKILL.md
+++ b/.claude/skills/streaming-boxes/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: streaming-boxes
+description: >
+  Reference for the two Windows streaming boxes (stream.lan and streampp) —
+  IPs, MCP names, subnets, API endpoints, soak/test recipe, dashboard quirks.
+  Load when working on stream.lan or streampp deployment, CI E2E jobs, VPS
+  delivery, or any task involving the production streaming infrastructure.
+triggers:
+  - stream.lan
+  - streampp
+  - win-stream-snv
+  - win-streampp
+  - streaming box
+  - soak test
+  - fast endpoint
+---
+
+# Streaming Boxes Reference
+
+Two Windows streaming boxes (separate from dev1/dev2). Both run the single unified binary `C:\Program Files\Restreamer\Restreamer.exe` (~32 MB, Tauri+embedded service+WASM) via `RestreamerGUI` scheduled task in the interactive desktop session.
+
+- **API**: `http://127.0.0.1:8910`
+- **Config/DB**: `C:\ProgramData\Restreamer\` (contains `sqlite3.exe`)
+- **Update methods**: NSIS installer `Restreamer_<ver>_x64-setup.exe` (silent `/S`) OR `scripts/install.ps1` (self-elevates UAC)
+- **MCP runs as Admin** in the interactive session
+
+## Box Details
+
+### stream.lan — Primary CI/E2E Box
+
+| Property | Value |
+|---|---|
+| IP | `10.77.9.204:8910` |
+| User | `newlevel` |
+| MCP | `win-stream-snv` (stream.lan:8090) |
+| OBS MCP | `obs-stream-snv` (stream.lan:8091) |
+| S3 region | `fsn1` (`fsn1.your-objectstorage.com` → 88.198.120.64) |
+| Disk | ~63% full (low upload jitter, max ~2s) |
+| CI role | Self-hosted runner + E2E box — CI auto-deploys here every dev/main push |
+| OBS ingest | `rtmp://127.0.0.1:1234/live/obs-e2e-test` |
+| ffmpeg | Present (winget) |
+
+Dashboard reachable from dev1 (returns 200).
+
+### streampp — Secondary Box
+
+| Property | Value |
+|---|---|
+| IP | `10.77.8.204:8910` |
+| User | `interkom` |
+| MCP | `win-streampp` |
+| S3 region | `nbg1` |
+| Disk | ~82% full → "warn" disk_pressure (source of upload-jitter issues) |
+| Subnet | 10.77.8.x — NOT reachable from dev1 (10.77.9.x) |
+
+**Access streampp dashboard**: via `win-streampp` MCP locally OR from dev2 (10.77.8.134, same subnet).
+
+No ffmpeg, OBS installed but no headless task. As of 2026-06-07 running v0.22.6 (manually deployed via NSIS for the fast-stream fix; leave it unless explicitly asked to update).
+
+## Fast Endpoints (is_fast=1)
+
+- **stream.lan**: ids 2 (Control Stream SNV), 22 (KS-PP-TEST), 30 (Control stream)
+- **NOTE**: "e2e rtmp" (id 26) is NOT fast — CI's fast path is Control/KS endpoints
+- **streampp**: KS-PP-TEST (id 22)
+
+## Dashboard Update — NSIS Does NOT Update LAN Dashboard
+
+**Critical gotcha**: NSIS installer does NOT update the LAN dashboard (`www\` next to the exe). The browser dashboard is served from `<exe_dir>\www` (ServeDir); the NSIS installer never ships it — only CI's deploy job writes it (stream.lan only).
+
+**Full manual upgrade = NSIS install + replace `www\`**:
+```bash
+gh run download <run> --name restreamer-www
+# Then copy the www/ folder to C:\Program Files\Restreamer\www\ on the target box
+```
+No app restart needed (per-request disk reads). Also: `index.html` has no cache-control → browsers heuristic-cache it for days; hard refresh needed after `www\` swap. Proper fix tracked in **#248**.
+
+## Soak/Test Recipe
+
+```
+# Setup
+POST /api/v1/events {name}
+POST /api/v1/events/{id}/endpoints/{epId}   # attach endpoint
+ffmpeg source to the inpoint
+POST /api/v1/events/{id}/activate           # sets receiving only
+POST /api/v1/delivery/start {event_id}      # creates Hetzner VPS + sets delivering
+
+# Teardown
+POST /api/v1/delivery/stop {event_id}       # deletes VPS
+POST /api/v1/events/{id}/deactivate
+# detach all endpoints
+DELETE /api/v1/events/{id}
+```
+
+**Note**: Inducing S3-upload starvation via single-IP firewall block does NOT work — HTTPS connection-pooling keeps uploads flowing.
+
+## OBS MCP Server (stream.lan only)
+
+`sbroenne/mcp-server-obs` v1.0.4 installed at `C:\Tools\obs-mcp-server\`.
+
+- **Gateway**: supergateway wraps stdio as streamableHttp on port 8091
+- **Startup**: Scheduled task `ObsMcpGateway` runs at logon (user: newlevel)
+- **Start script**: `C:\Tools\obs-mcp-server\start-gateway.bat`
+- **MCP config**: `.mcp.json` entry `obs-stream-snv` → `http://10.77.9.204:8091/mcp`
+- **Auth**: No password needed (auth_required=false in OBS WebSocket config)
+
+**Available tools (prefix `mcp__obs-stream-snv__`):**
+
+| Tool | Purpose |
+|---|---|
+| `obs_connection` | Connect, Disconnect, GetStatus, GetStats |
+| `obs_recording` | Start, Stop, Pause, Resume, GetStatus, GetSettings, SetFormat, SetQuality, SetPath |
+| `obs_streaming` | Start, Stop, GetStatus |
+| `obs_scene` | List, GetCurrent, Set, ListSources |
+| `obs_source` | AddWindowCapture, ListWindows, SetWindowCapture, Remove, SetEnabled |
+| `obs_audio` | GetInputs, Mute, Unmute, GetMuteState, SetVolume, GetVolume, MuteAll, UnmuteAll |
+| `obs_media` | SaveScreenshot, StartVirtualCamera, StopVirtualCamera |
+
+Use these OBS MCP tools instead of python obsws_python hacks via win-stream-snv Shell.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3411,15 +3411,37 @@ jobs:
             throw "FAILED: VPS warmup did not complete within $($maxWait * 5)s"
           }
 
+          # #227: Scope the progression + overshoot checks to the CI-OWNED
+          # endpoints only. The loops below iterate $resp.endpoint_details on
+          # the shared E2E-Test event; a STRAY endpoint (a leftover soak
+          # endpoint, an operator-added production FB endpoint) attached to
+          # the event would otherwise be gated too and could hard-fail the
+          # whole run on state the CI does not own (2026-05-20: a leftover
+          # 'e2e fb' soak endpoint at 157.4s > 156s init cap hard-failed YT
+          # e2e even though the CI's own endpoints were fine). The CI attaches
+          # exactly 'e2e rtmp' + 'e2e hls' (see the seed step's $needAttach).
+          $ciOwnedAliases = @("e2e rtmp", "e2e hls")
+
           # Phase 2: Initialization-phase overshoot + jump detection.
           # The 172s->120s jump bug happens in the FIRST 60s after warmup ends.
           # Take rapid samples (every 5s for 60s) and fail on:
-          #   - overshoot: any reading > target * 1.3 (= 156s for 120s target)
+          #   - overshoot: cache > target * 1.3 (= 156s for 120s target),
+          #     SUSTAINED across consecutive samples (#227)
           #   - impossible jump: drop > 20s between 5s-apart readings
+          # #227: the overshoot check is SUSTAINED, not instantaneous. The
+          # cache legitimately spikes then settles during the first seconds of
+          # init (the VPS buffer-fill overshoots momentarily before steady
+          # real-time playback pulls it back). A single transient sample over
+          # the cap is normal warmup jitter and must NOT hard-fail; require
+          # the overshoot to persist across N consecutive samples for the SAME
+          # alias. A genuine, settled overshoot still trips (N straight
+          # readings over cap) -- this stays a real gate.
+          $sustainedOvershoot = 3
           $targetDelay = if ($targetEvent.cache_delay_secs) { $targetEvent.cache_delay_secs } else { 120 }
           $maxInitCache = [math]::Round($targetDelay * 1.3)
-          Write-Host "INIT-PHASE CHECK: 12 samples, 5s apart (max cache=${maxInitCache}s, max drop=20s)"
+          Write-Host "INIT-PHASE CHECK: 12 samples, 5s apart (max cache=${maxInitCache}s sustained ${sustainedOvershoot}x, max drop=20s, aliases=$($ciOwnedAliases -join ','))"
           $initSeries = @{}
+          $overshootStreak = @{}
           for ($s = 1; $s -le 12; $s++) {
             Start-Sleep -Seconds 5
             $resp = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/delivery/status?event_id=$eventId" -TimeoutSec 30
@@ -3427,14 +3449,26 @@ jobs:
               foreach ($ep in $resp.endpoint_details) {
                 if ($ep.is_fast) { continue }
                 $alias = $ep.alias
+                # #227: ignore endpoints the CI does not own.
+                if ($ciOwnedAliases -notcontains $alias) {
+                  Write-Host "  Init $s/12 [$alias]: SKIPPED (not a CI-owned endpoint)"
+                  continue
+                }
                 $delay = [math]::Round($ep.chunk_delay_secs, 1)
                 if (-not $initSeries.ContainsKey($alias)) { $initSeries[$alias] = @() }
+                if (-not $overshootStreak.ContainsKey($alias)) { $overshootStreak[$alias] = 0 }
                 $initSeries[$alias] += $delay
-                Write-Host "  Init $s/12 [$alias]: cache=${delay}s chunk=$($ep.current_chunk_id) mode=$($ep.delivery_mode)"
 
-                # Overshoot check
+                # Overshoot check -- SUSTAINED across consecutive samples.
                 if ($delay -gt $maxInitCache) {
-                  throw "FAILED: [$alias] cache ${delay}s exceeds init max ${maxInitCache}s (target=${targetDelay}s) -- overshoot during initialization"
+                  $overshootStreak[$alias] += 1
+                  Write-Host "  Init $s/12 [$alias]: cache=${delay}s chunk=$($ep.current_chunk_id) mode=$($ep.delivery_mode) OVERSHOOT streak=$($overshootStreak[$alias])/${sustainedOvershoot}"
+                  if ($overshootStreak[$alias] -ge $sustainedOvershoot) {
+                    throw "FAILED: [$alias] cache exceeded init max ${maxInitCache}s (target=${targetDelay}s) for ${sustainedOvershoot} consecutive samples (latest ${delay}s) -- SUSTAINED overshoot during initialization, not warmup jitter"
+                  }
+                } else {
+                  $overshootStreak[$alias] = 0
+                  Write-Host "  Init $s/12 [$alias]: cache=${delay}s chunk=$($ep.current_chunk_id) mode=$($ep.delivery_mode)"
                 }
 
                 # Impossible jump check (drop > 20s in 5s interval)
@@ -3449,10 +3483,10 @@ jobs:
               }
             }
           }
-          Write-Host "INIT-PHASE CHECK PASSED: no overshoot, no impossible jumps"
+          Write-Host "INIT-PHASE CHECK PASSED: no sustained overshoot, no impossible jumps"
 
           # Phase 3: Take 4 readings at 15s intervals to verify progression
-          Write-Host "Verifying delivery progression for ALL endpoints (4 readings, 15s apart)..."
+          Write-Host "Verifying delivery progression for CI-owned endpoints (4 readings, 15s apart)..."
 
           # Track per-endpoint chunk progression across 4 readings
           $epReadings = @{}  # alias -> array of chunk_ids
@@ -3464,6 +3498,8 @@ jobs:
               foreach ($ep in $resp.endpoint_details) {
                 if (-not $ep.is_fast) {
                   $alias = $ep.alias
+                  # #227: only assert progression on CI-owned endpoints.
+                  if ($ciOwnedAliases -notcontains $alias) { continue }
                   if (-not $epReadings.ContainsKey($alias)) {
                     $epReadings[$alias] = @()
                   }
@@ -3475,7 +3511,7 @@ jobs:
           }
 
           if ($epReadings.Count -eq 0) {
-            throw "FAILED: No non-fast endpoints found in delivery status"
+            throw "FAILED: No CI-owned non-fast endpoints (e2e rtmp / e2e hls) found in delivery status"
           }
 
           # Assert EACH endpoint advanced >= 3 chunks over 45s
@@ -5663,15 +5699,33 @@ jobs:
           if ($null -ne $lastErr) { throw "delivery_start failed after 3 attempts: $lastErr" }
           Write-Host "OBS streaming + delivery started for event $($ev.id)"
 
-      - name: "GATE: e2e fb endpoint registered in delivery/status within 180s"
-        # #222: Named-step GATE pattern (mirrors e2e-obs-youtube). delivery_start
-        # returns the moment Hetzner created the server; the actual rs-delivery
-        # process takes another 30-90s to boot, pull binary from S3, POST
-        # /api/init, and populate metrics. Wait up to 3 min for the e2e fb row
-        # to register. Failure here means the VPS never came online or never
-        # posted /api/init -- DISTINCT from "VPS up but FB push stalled" below.
+      - name: "GATE: e2e fb endpoint registers (slow-VPS-boot tolerant, dead-VPS fast-fail)"
+        # #222 named-step GATE pattern; #227 slow-vs-dead robustness.
+        # delivery_start returns the moment Hetzner CREATED the server; a
+        # background poll_and_init task then drives the instance through
+        # creating -> booting -> initializing -> delivering, and the "e2e fb"
+        # row only appears in endpoint_details once init runs. Boot+init
+        # typically takes 30-90s but Hetzner has a real tail (rare runs
+        # >180s) -- the old fixed 180s wait reported that normal infra tail
+        # as a hard gate failure (#227 / run 27931333149: polled 18x then
+        # threw with a still-booting VPS).
+        #
+        # This gate now distinguishes "VPS still progressing through boot"
+        # from "VPS genuinely dead":
+        #   - PASS   : "e2e fb" appears in endpoint_details.
+        #   - FAST-FAIL: instance_status is "failed"/"deleted", or the
+        #     instance row vanished after creation -> poll_and_init errored
+        #     (delivery_handlers.rs writes "failed" on any poll_and_init
+        #     error) -> waiting longer is pointless.
+        #   - KEEP WAITING while instance_status is creating/booting/
+        #     initializing (progress), up to an absolute 5-min cap (the
+        #     observed 30-90s typical + Hetzner boot tail; the sibling
+        #     OBS-YT readiness loop allows 15 min). Only the absolute cap
+        #     with NO endpoint and NO terminal status is a real timeout.
+        # Every poll logs instance_status + elapsed so a future failure is
+        # diagnosable from the CI log alone.
         shell: powershell
-        timeout-minutes: 4
+        timeout-minutes: 7
         run: |
           $events = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/events" -Method GET -TimeoutSec 10
           $ev = $events | Where-Object { $_.name -eq $env:EVENT_NAME }
@@ -5683,18 +5737,65 @@ jobs:
           "FB_E2E_WATCHDOG_START=$watchdogStartTs" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           $statusUri = "http://127.0.0.1:8910/api/v1/delivery/status?event_id=$($ev.id)"
-          $deadline = (Get-Date).AddMinutes(3)
-          while ((Get-Date) -lt $deadline) {
-            $status = Invoke-RestMethod -Uri $statusUri -Method GET -TimeoutSec 10
+          # Statuses that mean the background poll_and_init is still making
+          # progress (the VPS is booting / initializing, NOT dead).
+          $progressing = @("creating", "booting", "initializing", "delivering")
+          # Terminal-dead statuses: poll_and_init errored and wrote the row
+          # to "failed", or the orchestrator deleted a stale/aborted VPS.
+          $deadStatuses = @("failed", "deleted", "stopping")
+          $start = Get-Date
+          # Absolute cap: 30-90s typical boot + Hetzner tail headroom. The
+          # OBS-YT readiness sibling allows ~15 min; 5 min is generous for FB
+          # while still bounded so a genuinely dead VPS that never flips to a
+          # terminal status cannot hang the job.
+          $absoluteCap = (Get-Date).AddMinutes(5)
+          # A VPS that never even reaches a known status after this grace
+          # (with no progress) is treated as never-created.
+          $sawInstance = $false
+          $poll = 0
+          while ((Get-Date) -lt $absoluteCap) {
+            $poll += 1
+            $elapsed = [int]((Get-Date) - $start).TotalSeconds
+            $status = $null
+            try {
+              $status = Invoke-RestMethod -Uri $statusUri -Method GET -TimeoutSec 10
+            } catch {
+              Write-Host "poll ${poll} (${elapsed}s): delivery/status query failed (will retry): $_"
+              Start-Sleep -Seconds 10
+              continue
+            }
             $ep = $status.endpoint_details | Where-Object { $_.alias -eq "e2e fb" }
             if ($null -ne $ep) {
-              Write-Host "GATE PASS: e2e fb endpoint registered (alive=$($ep.alive) mode=$($ep.delivery_mode))"
+              Write-Host "GATE PASS: e2e fb endpoint registered after ${elapsed}s (alive=$($ep.alive) mode=$($ep.delivery_mode) instance_status=$($status.instance_status))"
               exit 0
             }
-            Write-Host "waiting for VPS to register e2e fb endpoint..."
+            $instStatus = $status.instance_status
+            if ($null -ne $instStatus) { $sawInstance = $true }
+            Write-Host "poll ${poll} (${elapsed}s): instance_status=$instStatus server_ready=$($status.server_ready) -- e2e fb endpoint not registered yet"
+
+            # FAST-FAIL: VPS is genuinely dead -- waiting longer cannot help.
+            if ($deadStatuses -contains $instStatus) {
+              throw "GATE FAIL: VPS is dead (instance_status='$instStatus' after ${elapsed}s). poll_and_init errored or the VPS was deleted before the e2e fb endpoint registered -- this is a real boot/init fault, NOT a slow boot. Inspect vps_creating / vps_ready / delivery_init_sent audit rows for event $($ev.id)."
+            }
+            # FAST-FAIL: the instance row vanished after it had appeared --
+            # the orchestrator deleted it (terminal), so it will never register.
+            if ($sawInstance -and ($null -eq $instStatus)) {
+              throw "GATE FAIL: delivery instance row disappeared after ${elapsed}s (instance_status is now null). The VPS was torn down before the e2e fb endpoint registered -- a real fault, not a slow boot."
+            }
+            # KEEP WAITING while progressing through boot/init phases.
+            if ($progressing -contains $instStatus) {
+              Start-Sleep -Seconds 10
+              continue
+            }
+            # Unknown/transient status (e.g. row not yet written): keep
+            # polling within the cap rather than guessing it is dead.
             Start-Sleep -Seconds 10
           }
-          throw "GATE FAIL: e2e fb endpoint never registered in delivery/status within 180s of VPS boot"
+          $capElapsed = [int]((Get-Date) - $start).TotalSeconds
+          if (-not $sawInstance) {
+            throw "GATE FAIL: no delivery instance ever appeared in delivery/status within ${capElapsed}s -- delivery_start did not create a VPS (Hetzner create_server failed?). Check the 'Start OBS stream + delivery' step output."
+          }
+          throw "GATE FAIL: e2e fb endpoint never registered within the ${capElapsed}s absolute cap while instance_status kept reporting a non-terminal boot phase -- the VPS booted but rs-delivery never reached the init step. Likely a stuck buffer-fill / init hang (see #146), NOT normal Hetzner tail-latency."
 
       - name: "STRICT: 30-min sustained soak on rust pusher (chunks+bytes advancing, no push_died after first chunk)"
         # #222: Renamed from generic "Local watchdog" so the failing step name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4239,6 +4239,141 @@ jobs:
           }
           Write-Host "=== OBS Disconnect/Reconnect Test PASSED ==="
 
+      - name: OBS republish A/V-alignment gate (av_skew_ms)
+        if: success()
+        shell: powershell
+        timeout-minutes: 8
+        run: |
+          # Issue #258: after a mid-stream OBS unpublish/republish, assert the
+          # delivered stream stays audio/video aligned (av_skew_ms ~0) and that
+          # no endpoint dies. Regression gate for the chunker shared-epoch fix
+          # (#255) and the av_skew_ms exposure (#257). Without this, the
+          # 2026-06-19 mid-stream-republish desync (av_skew ~25500ms) is
+          # untested.
+          #
+          # SKEW_LIMIT is set well below the pusher's own MAX_AV_SKEW_MS (4000)
+          # so this gate fails BEFORE the pusher's auto-recovery would mask the
+          # regression.
+          $SKEW_LIMIT = 1500
+          Write-Host "=== OBS Republish A/V-Alignment Gate (SKEW_LIMIT=${SKEW_LIMIT}ms) ==="
+
+          $appStatus = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/status"
+          $eventId = $appStatus.streaming_event.id
+          Write-Host "Active event ID: $eventId"
+
+          # Helper: open an authenticated OBS WebSocket and return the socket +
+          # a shared buffer/segment for request/response round-trips.
+          function Connect-ObsWs {
+            $ws = New-Object System.Net.WebSockets.ClientWebSocket
+            $ws.Options.KeepAliveInterval = [TimeSpan]::FromSeconds(5)
+            $cts = New-Object System.Threading.CancellationTokenSource(30000)
+            $ws.ConnectAsync("ws://$($env:OBS_WS_HOST):$($env:OBS_WS_PORT)", $cts.Token).Wait()
+            $buf = [byte[]]::new(8192)
+            $seg = [ArraySegment[byte]]$buf
+            $recv = $ws.ReceiveAsync($seg, $cts.Token).Result
+            $hello = [System.Text.Encoding]::UTF8.GetString($buf, 0, $recv.Count) | ConvertFrom-Json
+            if ($hello.d.authentication) {
+              $salt = $hello.d.authentication.salt
+              $challenge = $hello.d.authentication.challenge
+              $sha = [System.Security.Cryptography.SHA256]::Create()
+              $b64secret = [Convert]::ToBase64String($sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes("$($env:OBS_WS_PASSWORD)$salt")))
+              $auth = [Convert]::ToBase64String($sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes("$b64secret$challenge")))
+              $identify = @{ op = 1; d = @{ rpcVersion = 1; authentication = $auth } } | ConvertTo-Json -Depth 5
+              $bytes = [System.Text.Encoding]::UTF8.GetBytes($identify)
+              $ws.SendAsync([ArraySegment[byte]]$bytes, 'Text', $true, $cts.Token).Wait()
+              $recv = $ws.ReceiveAsync($seg, $cts.Token).Result
+            }
+            return @{ Ws = $ws; Cts = $cts; Seg = $seg }
+          }
+
+          function Send-ObsRequest($conn, $requestType, $requestId) {
+            $req = @{ op = 6; d = @{ requestType = $requestType; requestId = $requestId } } | ConvertTo-Json -Depth 5
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($req)
+            $conn.Ws.SendAsync([ArraySegment[byte]]$bytes, 'Text', $true, $conn.Cts.Token).Wait()
+            $null = $conn.Ws.ReceiveAsync($conn.Seg, $conn.Cts.Token).Result
+          }
+
+          # One or more republish cycles (issue asks "one or more times").
+          # Each cycle: StopStream -> dead-air gap -> StartStream, the same
+          # session churn a real OBS restart produces.
+          $cycles = 2
+          $deadAirSecs = 8
+          for ($c = 1; $c -le $cycles; $c++) {
+            Write-Host "--- Republish cycle $c of $cycles ---"
+            $conn = Connect-ObsWs
+            Write-Host "Stopping OBS stream (cycle $c)..."
+            Send-ObsRequest $conn "StopStream" "av-align-stop-$c"
+            Write-Host "Dead-air gap: ${deadAirSecs}s..."
+            Start-Sleep -Seconds $deadAirSecs
+            Write-Host "Restarting OBS stream (cycle $c)..."
+            Send-ObsRequest $conn "StartStream" "av-align-start-$c"
+            $conn.Ws.CloseAsync('NormalClosure', '', [System.Threading.CancellationToken]::None).Wait()
+
+            # Wait for RTMP to reconnect after this cycle.
+            $reconnected = $false
+            for ($i = 0; $i -lt 15; $i++) {
+              Start-Sleep -Seconds 2
+              $s = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/status"
+              if ($s.inpoint.details.rtmp_connected) {
+                Write-Host "RTMP reconnected after $($i * 2)s (cycle $c)"
+                $reconnected = $true
+                break
+              }
+            }
+            if (-not $reconnected) {
+              throw "FAILED: RTMP did not reconnect within 30s after republish cycle $c"
+            }
+          }
+
+          # Stabilize the chunk pipeline before sampling skew.
+          Write-Host "Stabilizing chunk pipeline for 30s before A/V soak..."
+          Start-Sleep -Seconds 30
+
+          # Baseline restart counts AFTER the republish + stabilize. Any
+          # increase during the soak below counts as an endpoint death.
+          $baseline = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/delivery/status?event_id=$eventId"
+          # CRITICAL: iterate endpoint_details (the field the host API
+          # serializes); $.endpoints is empty on this endpoint and would make
+          # the gate pass vacuously.
+          if (-not $baseline.endpoint_details -or $baseline.endpoint_details.Count -eq 0) {
+            throw "FAILED: no endpoint_details in delivery status after republish -- cannot assert A/V alignment (vacuous gate guard)"
+          }
+          $restartsBaseline = @{}
+          foreach ($ep in $baseline.endpoint_details) {
+            $restartsBaseline[$ep.alias] = [int]$ep.ffmpeg_restart_count
+            Write-Host "BASELINE: [$($ep.alias)] av_skew_ms=$($ep.av_skew_ms) alive=$($ep.alive) restarts=$($ep.ffmpeg_restart_count)"
+          }
+
+          # Soak: sample every 10s for ~90s, asserting on every endpoint each
+          # sample. Logs each sample so a failure is debuggable from CI alone.
+          $soakSamples = 9
+          $soakIntervalSecs = 10
+          for ($n = 1; $n -le $soakSamples; $n++) {
+            Start-Sleep -Seconds $soakIntervalSecs
+            $st = Invoke-RestMethod -Uri "http://127.0.0.1:8910/api/v1/delivery/status?event_id=$eventId"
+            if (-not $st.endpoint_details -or $st.endpoint_details.Count -eq 0) {
+              throw "FAILED: endpoint_details empty at soak sample $n -- delivery status lost all endpoints"
+            }
+            foreach ($ep in $st.endpoint_details) {
+              $skew = [int]$ep.av_skew_ms
+              $absSkew = [math]::Abs($skew)
+              $restarts = [int]$ep.ffmpeg_restart_count
+              Write-Host "SAMPLE $n/$soakSamples [$($ep.alias)] av_skew_ms=$skew alive=$($ep.alive) restarts=$restarts"
+              if (-not $ep.alive) {
+                throw "FAILED: endpoint '$($ep.alias)' is not alive at soak sample $n (endpoint death after OBS republish)"
+              }
+              if ($absSkew -ge $SKEW_LIMIT) {
+                throw "FAILED: endpoint '$($ep.alias)' av_skew_ms=$skew (|skew|=$absSkew) exceeds limit ${SKEW_LIMIT}ms after OBS republish -- A/V desync regression (chunker shared-epoch / pusher skew safety net)"
+              }
+              $base = if ($restartsBaseline.ContainsKey($ep.alias)) { $restartsBaseline[$ep.alias] } else { 0 }
+              if ($restarts -gt $base) {
+                $tail = if ($ep.ffmpeg_last_stderr) { $ep.ffmpeg_last_stderr } else { '<empty>' }
+                throw "FAILED: endpoint '$($ep.alias)' ffmpeg_restart_count rose from $base to $restarts during A/V soak (endpoint restart after OBS republish). stderr_tail:`n$tail"
+              }
+            }
+          }
+          Write-Host "=== OBS Republish A/V-Alignment Gate PASSED ==="
+
       - name: Simulated network disconnect - cache drain and recovery
         if: success()
         shell: powershell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,17 +5,29 @@
 
 You are "Claude Autonomous Windows Engineer" (CAWE) — a senior Rust developer with CI/CD expertise working on the Restreamer project — a church live-streaming infrastructure built entirely in Rust.
 
+## Playbook Router
+
+Load the relevant skill BEFORE working on these areas:
+
+- stream.lan / streampp operations, deployment, OBS, MCP → `.claude/skills/stream-lan-operations`
+- Streaming boxes reference (IPs, subnets, soak recipe, fast endpoints) → `.claude/skills/streaming-boxes`
+- Facebook Live endpoints, CI gate, Graph API credentials → `.claude/skills/facebook-streaming`
+- OBS degraded / CI runner offline / autonomous recovery → `.claude/skills/obs-recovery`
+- Outage survival, rescue clip, keepalive, notification UX → `.claude/skills/outage-rescue`
+
 ## Project Structure
 
 Pure Rust monorepo with Cargo workspace at the root.
 
 | Directory    | Purpose                                      |
 | ------------ | -------------------------------------------- |
-| `crates/`    | 11 workspace crates (see Architecture below) |
+| `crates/`    | 11 workspace crates                          |
 | `src-tauri/` | Tauri desktop app (Windows tray + WebView2)  |
 | `leptos-ui/` | Leptos CSR frontend (WASM, all-Rust)         |
 | `e2e/`       | Playwright E2E tests (frontend + YouTube)    |
 | `scripts/`   | Windows install/deploy PowerShell scripts    |
+
+**Architecture**: 10 workspace crates (`rs-core`, `rs-inpoint`, `rs-endpoint`, `rs-api`, `rs-runtime`, `rs-service`, `rs-cloud`, `rs-delivery`, `rs-ffmpeg`, `rs-youtube`) + `rs-ts-normalize`. `src-tauri` and `leptos-ui` excluded from workspace. Single unified binary `Restreamer.exe` (Tauri + embedded service + Leptos/WASM UI). SQLite via sqlx, Axum on `:8910`, RTMP in pure Rust. Rust edition 2024 (requires `unsafe` for `set_var`/`remove_var`), min Rust 1.85. Use `log` crate (not `tracing`) — xiu RTMP stack uses `log`; use `env_logger` in tests.
 
 ## Strict Rules
 
@@ -28,223 +40,81 @@ The global version-bumping rule applies. For this project, bump ALL of these fil
 - `src-tauri/tauri.conf.json`
 - `leptos-ui/Cargo.toml`
 
-Check current vs main:
-
 ```bash
 grep '^version' Cargo.toml | head -1
 git show origin/main:Cargo.toml | grep '^version' | head -1
 ```
 
-### PR Delivery — Dashboard URL
+### Completion Report — Dashboard URL
 
-When providing a completion report, always include the dashboard URL:
+Always include in the completion report:
 
 ```
-PR: <url> | CI: green | Deploy: verified | Dashboard: http://10.77.9.204:8910/
+Dashboard: http://10.77.9.204:8910/
 ```
 
-### CI Monitoring — Post-Deploy Verification
+### Post-Deploy Verification (stream.lan)
 
-After the `deploy-stream-lan` CI job completes, verify the deployment on stream.lan:
+After `deploy-stream-lan` CI job completes:
 
-- Use `mcp__win-stream-snv__ListProcesses` with filter "Restreamer" to verify the process is running.
-- Use `mcp__win-stream-snv__Shell` with command `Invoke-RestMethod -Uri http://127.0.0.1:8910/api/v1/status` to verify the API responds.
+```powershell
+mcp__win-stream-snv__ListProcesses filter="Restreamer"
+mcp__win-stream-snv__Shell command="Invoke-RestMethod -Uri http://127.0.0.1:8910/api/v1/status"
+```
 
-**NEVER CLAIM DONE** until CI is fully green AND deployment is verified working on stream.lan.
+**NEVER CLAIM DONE** until CI is fully green AND deployment verified on stream.lan.
 
 ### Tray App Deployment (CRITICAL)
 
-**The Restreamer app MUST run as a tray application in the user's desktop session, NOT as a background service or headless process.**
-
-The global `windows-desktop-session` module defines the schtasks pattern. For this project:
-
-- **App**: `Restreamer.exe`
-- **User**: `newlevel`
-- **Task name**: `RestreamerGUI`
-- **Install path**: `C:\Program Files\Restreamer\`
-- **No `--headless` flag** — ever. No fallback to headless mode.
-
-Project-specific verification after deploy:
-
-```powershell
-# Stop existing
-taskkill /F /IM "Restreamer.exe"
-
-# Register and start in user session (see windows-desktop-session module for full pattern)
-Register-ScheduledTask -TaskName "RestreamerGUI" ...
-Start-ScheduledTask -TaskName "RestreamerGUI"
-
-# Verify correct session
-$proc = Get-Process -Name "Restreamer"
-if ($proc.SessionId -eq 0) { throw "Must run in user session, not SYSTEM" }
-```
-
-stream.lan always has user "newlevel" logged in. The scheduled task runs in their interactive session. If the scheduled task fails, CI must fail — do not fall back to headless mode.
+Restreamer.exe MUST run as a tray app in the user's desktop session — NEVER as background service or headless. Task name: `RestreamerGUI`, user: `newlevel`, install path: `C:\Program Files\Restreamer\`. No `--headless` flag ever. If the scheduled task fails, CI must fail.
 
 ### Testing — PRIMARY GOAL
 
-**The main goal is complete, full E2E tests that cover ALL flows in the app and the web frontend.** Every functionality must be covered by an E2E test flow. All tests MUST be part of GitHub CI workflows.
+Full E2E test coverage is the primary goal. Every feature ships with E2E tests covering the full user flow. All tests run in GitHub CI — never skipped.
 
-The global `test-strictness` and `no-continue-on-error` modules apply. Additional project-specific rules:
+- CI `test-integrity` job scans for `#[ignore]`, `assert!(true)`, empty test bodies — MUST pass
+- `deploy-stream-lan` job MUST run on every push (use `always()` in complex `if` conditions)
+- E2E gate requires both frontend and YouTube E2E to pass — condition uses `!= 'failure'`
+- Every CSS class referenced in UI components MUST be defined in the stylesheet
 
-- **CI hardening job** — The workflow includes a dedicated `test-integrity` job that scans source code for `#[ignore]`, `assert!(true)`, empty test bodies, and verifies `cargo test` output shows zero ignored/filtered tests. This job MUST pass for the CI gate to be green.
-- **NO skipped deployment jobs** — The `deploy-stream-lan` job MUST run on every dev and main push. Always use `always()` in complex `if` conditions.
-- **E2E tests run on EVERY push to dev/main** — Never skipped. The E2E job condition uses `!= 'failure'` (not `== 'success'`). The `e2e-gate` job requires both E2E tests to succeed on every push.
+### Local Build Policy — Tier 0 (dev1 OOM)
 
-#### E2E Coverage Gate (MANDATORY)
+NO local `cargo build`, `cargo test`, `cargo check`, or `cargo clippy` on dev1 — it has 7.5 GB RAM and OOMs (target/ hit 23 GB; 2026-06-10 operator directive). **`cargo fmt --all -- --check` only** locally. Purge `target/` whenever found. All compilation, clippy, and tests run on CI.
 
-- **NO feature ships without E2E tests** — Every implemented UI feature, API endpoint, and user-facing functionality MUST have corresponding E2E tests before a PR can be considered green.
-- **E2E tests verify rendering** — Frontend E2E tests must verify that UI components actually render visible content (text, buttons, forms), not just that the page loads without errors. Check for specific text content, element visibility, and interactive behavior.
-- **CSS coverage** — Every CSS class referenced in UI components MUST be defined in the stylesheet. Missing CSS = invisible UI = broken feature = red CI.
+Never pipe a pre-push gate through `tail`/`grep` then `&& echo OK` — it swallows the real exit code; use `$?` or `${PIPESTATUS[0]}`.
 
-#### Web/Frontend E2E (Playwright)
+### Push Discipline — ONE In-Flight CI Run at a Time
 
-- Use Playwright to test every frontend functionality — dashboard, config editor, status display, WebSocket updates.
-- Each user-facing feature needs a Playwright test covering the full flow.
-- Playwright tests run in CI on every push/PR, not just locally.
+NEVER push to dev while a main run (or the release workflow) is in flight, and never stack a second dev push on a running dev E2E. All E2E shares ONE self-hosted runner, ONE stream.lan box, and ONE YouTube test stream — concurrent runs race deploys and shared state; historically BOTH fail.
 
-#### Backend/Service E2E (Rust)
+The `stream-lan-box` concurrency group (`queue: max`, `cancel-in-progress: false`) in ci.yml serializes E2E jobs platform-side (FIFO). Hold the post-merge version-bump push until main + release reach terminal state.
 
-- Write real end-to-end tests that exercise actual code paths — RTMP ingest, chunk storage, S3 upload, API endpoints, WebSocket events.
-- Not mocked, not hidden, not stubbed. Real code, real assertions.
-- Always consider current tests as not comprehensive enough and actively improve coverage, edge cases, and failure scenarios.
-
-## Rust Development
-
-### Build Commands
-
-```bash
-cargo build                          # Debug build (workspace crates)
-cargo build --release -p rs-service  # Release build (standalone service binary)
-cargo test --workspace               # Run all tests
-cargo fmt --all -- --check           # Check formatting
-cargo clippy --workspace -- -D warnings  # Lint
-
-# Leptos frontend (WASM)
-cd leptos-ui && trunk build --release  # Production WASM build
-
-# Tauri unified app
-cargo tauri build                    # Production Tauri build (NSIS installer)
-```
-
-### Code Quality Standards
-
-- `cargo fmt` — enforced in CI
-- `cargo clippy -- -D warnings` — no warnings allowed
-- `cargo audit` — no known vulnerabilities
-- Max 1000 lines per `.rs` file
-- 60% minimum test coverage target
-- `SQLX_OFFLINE=true` — CI uses offline mode (no live DB during build)
-- ffmpeg required for E2E tests — CI installs it; tests panic if missing
-- `log` crate (not `tracing`) — xiu RTMP stack uses `log`; use `env_logger` in tests
-
-### Architecture
-
-- **Workspace** with 10 crates (under `crates/`): `rs-core`, `rs-inpoint`, `rs-endpoint`, `rs-api`, `rs-runtime`, `rs-service`, `rs-cloud`, `rs-delivery`, `rs-ffmpeg`, `rs-youtube`
-- **Excluded from workspace**: `src-tauri` (needs built frontend), `leptos-ui` (WASM target)
-- **Rust edition**: 2024 — requires `unsafe` for `std::env::set_var`/`remove_var`
-- **Minimum Rust**: 1.85
-- **Single unified binary**: `Restreamer.exe` (Tauri app with embedded service + Leptos/WASM UI)
-- **rs-runtime**: Contains `ServiceCore` for reusable service orchestration
-- **Database**: SQLite via `sqlx` with compile-time checked queries
-- **RTMP server**: Pure Rust (no ffmpeg dependency)
-- **S3 uploads**: `rust-s3` crate
-- **API**: Axum on `http://127.0.0.1:8910` (embedded in Tauri app)
-- **Frontend**: Leptos CSR WASM (all-Rust, no React/npm)
-
-### Tauri Development
-
-```bash
-# No npm/package.json — Tauri builds Leptos frontend via trunk internally
-cargo tauri build                    # Production build with NSIS installer
-# Note: src-tauri and leptos-ui are excluded from workspace and built separately
-```
-
-## Versioning
-
-- **Cargo.toml** workspace version at repo root (e.g., `0.3.0`)
-- **Release tags**: `restreamer-v{X.Y.Z}` (auto-created on merge to main)
-- Always bump version before merging
+**If two runs ARE ever in flight**: cancel the lower-value run immediately (keep the release-bound main run), clean shared state (deactivate/detach the E2E event via API, delete any orphan VPS), then let the surviving run continue. One decisive cancel beats letting both race.
 
 ## CI/CD Pipelines
 
-| Workflow      | Trigger                     | Purpose                                       |
-| ------------- | --------------------------- | --------------------------------------------- |
-| `ci.yml`      | Push to `dev`, PR to `main` | Rust lint, test, audit, build, E2E, file-size |
-| `release.yml` | `restreamer-v*` tag         | Windows release (Tauri NSIS + delivery)       |
+| Workflow     | Trigger                     | Purpose                                        |
+|---|---|---|
+| `ci.yml`     | Push to `dev`, PR to `main` | Rust lint, test, audit, build, E2E, file-size  |
+| `release.yml`| `restreamer-v*` tag         | Windows release (Tauri NSIS + delivery binary) |
 
-### Auto-Release Flow
-
-```
-dev → PR to main → merge → auto-tag (restreamer-vX.Y.Z) → release.yml → GitHub Release with NSIS installer
-```
+Auto-release flow: `dev → PR to main → merge → auto-tag (restreamer-vX.Y.Z) → release.yml → GitHub Release`
 
 ## Deployment Targets
 
-### stream.lan (Local Client)
+**stream.lan**: Windows 11 IoT Enterprise LTSC, `10.77.9.204:8910`, install path `C:\Program Files\Restreamer\`, config `C:\ProgramData\Restreamer\config.json`, credentials in `~/.restreamer-secrets/stream-lan.env`. Self-hosted CI runner (runs as SYSTEM). MCP: `win-stream-snv`.
 
-- **Host**: `stream.lan` (Windows 11 IoT Enterprise LTSC)
-- **Install Path**: `C:\Program Files\Restreamer\`
-- **Config**: `C:\ProgramData\Restreamer\config.json`
-- **Credentials**: See `~/.restreamer-secrets/stream-lan.env` (not tracked by git)
-- **Install**: `irm https://raw.githubusercontent.com/zbynekdrlik/restreamer/main/scripts/install.ps1 | iex`
-- **Self-hosted runner**: GitHub Actions runner for CI deployment (runs as SYSTEM)
-- **Binary**: `Restreamer.exe` (Tauri GUI with embedded service + tray icon)
+**Hetzner VPS (Delivery)**: `rs-delivery` binary deployed to ad-hoc VPS instances. `DeliveryOrchestrator` in `rs-api` manages lifecycle (create → cloud-init → poll → init → stop → delete). E2E orchestration via local Rust API at `http://127.0.0.1:8910/api/v1/delivery/*` and `/api/v1/youtube/*`. No external manager or SSH needed.
 
-### Delivery (Hetzner VPS)
+## Code Quality
 
-- **Provider**: Hetzner Cloud
-- **Binary**: `rs-delivery` — standalone Rust binary deployed to ad-hoc VPS instances
-- **Orchestration**: `DeliveryOrchestrator` in `rs-api` manages Hetzner server lifecycle
-- **Flow**: Create Hetzner server with cloud-init → download rs-delivery from S3 → POST `/api/init` → stream via ffmpeg
+- `cargo fmt` — enforced in CI; `cargo clippy -- -D warnings` — no warnings
+- `cargo audit` — no known vulnerabilities; `SQLX_OFFLINE=true` in CI
+- Max 1000 lines per `.rs` file; 60% minimum test coverage
+- ffmpeg required for E2E tests — CI installs it; tests panic if missing
 
-#### E2E Testing API (Local Rust)
+## Versioning
 
-CI uses these local Rust API endpoints at `http://127.0.0.1:8910`:
-
-| Endpoint                     | Method | Purpose                                        |
-| ---------------------------- | ------ | ---------------------------------------------- |
-| `/api/v1/delivery/start`     | POST   | Create Hetzner VPS, deploy rs-delivery, init   |
-| `/api/v1/delivery/status`    | GET    | Check delivery server health + endpoint status |
-| `/api/v1/delivery/stop`      | POST   | Stop delivery, delete Hetzner server           |
-| `/api/v1/delivery/instances` | GET    | List active delivery instances                 |
-| `/api/v1/youtube/status`     | GET    | Query YouTube Data API for stream reception    |
-| `/api/v1/youtube/oauth/seed` | POST   | Seed YouTube OAuth tokens from CI secrets      |
-
-No external manager server or SSH needed. All E2E orchestration is local.
-
-## Developer Tools
-
-### Skills (`.claude/skills/`)
-
-Operational guides for common tasks:
-
-- `stream-lan-operations.md` — MCP tools, OBS WebSocket, client config
-
-## Local Build Policy
-
-Tier 0 (default): NO local builds or test runs — dev1 has 7.5 GB RAM and rustc
-workspace builds OOM it (operator directive 2026-06-10). Lint/fmt only locally;
-compilation, clippy, and tests run on CI. Purge `target/` whenever found.
-
-## Push Discipline — ONE in-flight CI run at a time
-
-NEVER push to dev while a main run (or the release workflow) is in flight, and
-never stack a second dev push on a running dev E2E. All E2E shares ONE
-self-hosted runner, ONE stream.lan box and ONE YouTube test stream — concurrent
-runs race deploys and shared state, and historically BOTH fail (2026-06-07,
-2026-06-11). The `stream-lan-box` concurrency group (`queue: max`,
-`cancel-in-progress: false`) in ci.yml serializes those jobs platform-side
-(FIFO queue — `queue: max` is required; the default single-pending-slot
-semantics would cancel an older run's pending E2E sibling). Queued runs still
-waste hours: hold the post-merge version-bump push until main + release reach
-terminal state.
-
-**If two runs ARE ever in flight together: STOP one immediately — never let
-both proceed.** Cancel the lower-value run (usually the version-bump/dev run;
-keep the release-bound main run), clean shared state if its E2E was mid-test
-(deactivate/detach the E2E event via the API, delete any orphan VPS), then let
-the surviving run continue. A deliberate cancel + 5-minute cleanup always
-beats letting two runs race (2026-06-11: letting both run cost ~3 h and
-failed BOTH). This is one decisive cancel — not the banned cancel-thrashing
-of stuck runs.
+- Workspace version in `Cargo.toml` at repo root
+- Release tags: `restreamer-v{X.Y.Z}` (auto-created on merge to main)
+- Always bump version before merging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["src-tauri", "leptos-ui"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/leptos-ui/Cargo.toml
+++ b/leptos-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ui"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 license = "MIT"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restreamer"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/zbynekdrlik/restreamer"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Restreamer",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "identifier": "media.newlevel.restreamer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Adds an automated **mid-stream OBS unpublish/republish A/V-alignment gate** to the `e2e-obs-youtube-test` CI job (#258).

After the existing reconnect test, the new step performs **two** republish cycles (`StopStream` -> 8s dead-air gap -> `StartStream`, the session churn a real OBS restart produces), waits for RTMP reconnect each cycle, stabilizes 30s, then **soaks ~90s** sampling `GET /api/v1/delivery/status?event_id=$eventId` every 10s. For **each endpoint** it asserts:

- `|av_skew_ms| < 1500` ms (well below the pusher's `MAX_AV_SKEW_MS=4000`, so the gate fires *before* the pusher's own auto-recovery would mask a regression)
- `alive == true` (no endpoint death)
- `ffmpeg_restart_count` does not increase from the post-republish baseline (zero restarts)

Every sample is logged (`alias av_skew_ms alive restarts`) so a failure is debuggable from CI logs alone.

### Why this gate

The 2026-06-19 production incident (A/V desync ~25500ms + endpoint deaths) reached prod because **no test exercised a mid-stream OBS republish**. This is the regression gate for:
- the chunker shared-epoch fix (#255 — re-anchors audio+video onto a shared session epoch on OBS republish)
- the `av_skew_ms` telemetry exposure on the host delivery-status API (#257)

With #255 merged, current code keeps `av_skew_ms ~0` after republish -> gate PASSES. Should the desync regress, `av_skew_ms` spikes -> gate THROWS.

### Correctness note

Iterates `$st.endpoint_details` (the field the host API actually serializes) — **not** `$st.endpoints`, which is empty on this endpoint and would make the gate pass vacuously. Guarded explicitly: an empty `endpoint_details` throws.

ASCII-only PowerShell (project rule). No Rust/source changed; CI-gate assertion only.

Closes #258

---

## Also fixes #227 — FB-push gate slow-vs-dead VPS boot + sustained overshoot

This PR's run flaked **only** on the `E2E FB Push` job (the #258 A/V gate itself PASSED). Root cause = the FB-push registration GATE blindly waited a fixed 180s then hard-failed, unable to tell a slow-but-progressing Hetzner boot from a dead VPS. That is the `#227` fragility, so it is fixed here and the PR closes both.

**CI YAML only, no Rust change, ASCII-only PowerShell:**

1. **Registration gate (ci.yml ~5666) — slow-vs-dead.** Each poll now reads `delivery/status .instance_status`:
   - **PASS** when `e2e fb` registers in `endpoint_details`.
   - **FAST-FAIL** when `instance_status` is `failed`/`deleted`/`stopping`, or the instance row vanishes after appearing (`poll_and_init` errored — the handler writes `failed`). Waiting longer cannot help.
   - **KEEP WAITING** while `creating`/`booting`/`initializing`/`delivering` (genuine progress), up to a bounded **5-min** absolute cap (typical boot 30-90s + Hetzner tail; the sibling OBS-YT readiness loop already allows ~15 min). Per-poll `instance_status`+elapsed logging so future failures are diagnosable from the CI log alone. This is robustness, not a blind timeout bump.
2. **Init-phase cache-overshoot (ci.yml ~3436) — sustained, not instantaneous.** Now requires **3 consecutive** over-cap samples for the same alias. The cache legitimately spikes then settles during warmup; a single transient over-cap reading is jitter. A settled overshoot (3 straight) still fails — it stays a real gate.
3. **#227 #1 scope.** The YT progression + overshoot loops are scoped to the CI-owned aliases (`e2e rtmp` / `e2e hls`) so a stray endpoint attached to `E2E-Test` can no longer poison the gate (the 2026-05-20 root cause).

All three gates still FAIL on real faults (dead VPS, sustained genuine overshoot, stalled push) — only infra variance is separated from regressions.

Closes #227


---

### ➕ Also in this PR — per-project playbook consolidation (config-only, commit `2d241ff5`)

This dev→main batch also carries a one-time **playbook cleanup** (airuleset's new per-project knowledge system). Config-only, no source/CI changes — reviewable as the single commit `2d241ff5`:
- `CLAUDE.md` slimmed 250 → 120 lines (now: global imports + a lean `## Playbook router` + always-rules)
- 4 new `.claude/skills/` areas (`streaming-boxes`, `facebook-streaming`, `obs-recovery`, `outage-rescue`) holding procedures previously scattered in agent-memory
- Memory trimmed 70 → 42 (procedures moved into the skills; credentials/investigations/decisions retained). Backup at `memory.bak-precleanup/`.
